### PR TITLE
HOCS-1801 : case restored to previous Triage owner when deescalated

### DIFF
--- a/src/main/resources/processes/MPAM.bpmn
+++ b/src/main/resources/processes/MPAM.bpmn
@@ -188,7 +188,6 @@
         <camunda:in source="QueueTeamUUID" target="AllocationTeamUUID" />
         <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
         <camunda:in source="QaUserUUID" target="AllocatedUserUUID" />
-        <camunda:out source="LastUpdatedByUserUUID" target="QaUserUUID" />
         <camunda:out source="QaStatus" target="QaStatus" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0gzhnr0</bpmn:incoming>
@@ -349,7 +348,6 @@
         <camunda:in source="QueueTeamUUID" target="AllocationTeamUUID" />
         <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
         <camunda:in source="DraftUserUUID" target="AllocatedUserUUID" />
-        <camunda:out source="LastUpdatedByUserUUID" target="DraftUserUUID" />
         <camunda:out source="DraftStatus" target="DraftStatus" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0kq3lhc</bpmn:incoming>
@@ -385,7 +383,6 @@
         <camunda:in source="QueueTeamUUID" target="AllocationTeamUUID" />
         <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
         <camunda:in source="TriageUserUUID" target="AllocatedUserUUID" />
-        <camunda:out source="LastUpdatedByUserUUID" target="TriageUserUUID" />
         <camunda:out source="TriageEscalateOutcome" target="TriageEscalateOutcome" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0xndnj6</bpmn:incoming>


### PR DESCRIPTION
Fix. Stop remembering the last update user when leaving any Escalated stage.