### PR TITLE
HOCS-1812 - WCS case closed with no apparent reason

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,7 @@ dependencies {
 	implementation('net.logstash.logback:logstash-logback-encoder:5.2')
 
 	implementation('org.camunda.bpm:camunda-engine-spring:7.9.0')
+	implementation('com.fasterxml.uuid:java-uuid-generator:3.1.0')
 
 	runtimeOnly('org.postgresql:postgresql')
 	compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.6'

--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 	implementation('net.logstash.logback:logstash-logback-encoder:5.2')
 
 	implementation('org.camunda.bpm:camunda-engine-spring:7.9.0')
-	implementation('com.fasterxml.uuid:java-uuid-generator:3.1.0')
+	implementation('com.fasterxml.uuid:java-uuid-generator:3.1.2')
 
 	runtimeOnly('org.postgresql:postgresql')
 	compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.6'

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/application/CamundaProcessEngineConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/application/CamundaProcessEngineConfiguration.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.hocs.workflow.application;
 
+import org.camunda.bpm.engine.impl.persistence.StrongUuidGenerator;
 import org.camunda.bpm.engine.spring.ProcessEngineFactoryBean;
 import org.camunda.bpm.engine.spring.SpringProcessEngineConfiguration;
 import org.camunda.bpm.engine.spring.SpringProcessEngineServicesConfiguration;
@@ -39,6 +40,7 @@ public class CamundaProcessEngineConfiguration {
     config.setTransactionManager(transactionManager());
 
     config.setHistory(historyLevel);
+    config.setIdGenerator(new StrongUuidGenerator());
 
     config.setJobExecutorActivate(true);
     config.setMetricsEnabled(false);


### PR DESCRIPTION
- updating default id generation (DBIdGenerator) in favor of StrongUuidGenerator
as it is the one recommended in camunda docs
- Adding java-uuid-generator dependency as it is required for StrongUuidGenerator

After investigation is has been discovered that intermittent issues are caused
by optimistic lock exception that occur when Camunda uses default DbIdGenerator on
more than 1 service (single db and multiple services)

More details here:
https://docs.camunda.org/manual/7.9/user-guide/process-engine/id-generator/#the-uuid-generator