### PR TITLE
HOCS-1945

### DIFF
--- a/src/main/resources/processes/MPAM.bpmn
+++ b/src/main/resources/processes/MPAM.bpmn
@@ -46,6 +46,7 @@
         <camunda:in source="&#34;&#34;" target="RefTypeStatus" />
         <camunda:out source="RefTypeStatus" target="RefTypeStatus" />
         <camunda:out source="RefType" target="RefType" />
+        <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_02q4ggm</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0u2xrvf</bpmn:incoming>
@@ -81,6 +82,7 @@
         <camunda:in source="&#34;&#34;" target="BusAreaStatus" />
         <camunda:in source="&#34;&#34;" target="RefTypeStatus" />
         <camunda:out source="RefTypeStatus" target="RefTypeStatus" />
+        <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1lxdhh3</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0pe8uiv</bpmn:incoming>
@@ -111,6 +113,7 @@
         <camunda:out source="QaStatus" target="QaStatus" />
         <camunda:out source="LastUpdatedByUserUUID" target="QaUserUUID" />
         <camunda:in source="QaUserUUID" target="AllocatedUserUUID" />
+        <camunda:out source="DraftUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1mtywbg</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1qyrvbe</bpmn:incoming>
@@ -346,6 +349,7 @@
         <camunda:out source="PoStatus" target="PoStatus" />
         <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
         <camunda:out source="LastUpdatedByUserUUID" target="LastUpdatedByUserUUID" />
+        <camunda:out source="DraftUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1hnwm4d</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1d7lzq0</bpmn:outgoing>
@@ -399,7 +403,7 @@
         <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
         <camunda:in source="QueueTeamUUID" target="AllocationTeamUUID" />
         <camunda:out source="LastUpdatedByUserUUID" target="LastUpdatedByUserUUID" />
-        <camunda:in source="LastUpdatedByUserUUID" target="AllocatedUserUUID" />
+        <camunda:in source="CampaignUserUUID" target="AllocatedUserUUID" />
         <camunda:out source="LastUpdatedByUserUUID" target="TriageUserUUID" />
         <camunda:out source="LastUpdatedByUserUUID" target="DraftUserUUID" />
         <camunda:out source="CampaignOutcome" target="CampaignOutcome" />
@@ -521,6 +525,7 @@
         <camunda:in source="DraftUserUUID" target="AllocatedUserUUID" />
         <camunda:out source="LastUpdatedByUserUUID" target="DraftUserUUID" />
         <camunda:out source="DraftRequestedContributionOutcome" target="DraftRequestedContributionOutcome" />
+        <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0emd0q1</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_06j8j3d</bpmn:outgoing>
@@ -543,6 +548,7 @@
         <camunda:out source="LastUpdatedByUserUUID" target="TriageUserUUID" />
         <camunda:out source="TriageRequestedContributionOutcome" target="TriageRequestedContributionOutcome" />
         <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
+        <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0rb09oq</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1q9gl8y</bpmn:outgoing>
@@ -624,6 +630,7 @@
         <camunda:out source="RefTypeStatus" target="RefTypeStatus" />
         <camunda:out source="RefType" target="RefType" />
         <camunda:out source="LastUpdatedByUserUUID" target="LastUpdatedByUserUUID" />
+        <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0fjxe8s</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0cfab7l</bpmn:incoming>
@@ -661,6 +668,7 @@
         <camunda:in source="&#34;&#34;" target="RefTypeStatus" />
         <camunda:out source="RefTypeStatus" target="RefTypeStatus" />
         <camunda:out source="RefType" target="RefType" />
+        <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1387m3c</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0ar1y4h</bpmn:incoming>
@@ -694,6 +702,7 @@
         <camunda:in source="DraftUserUUID" target="AllocatedUserUUID" />
         <camunda:out source="LastUpdatedByUserUUID" target="DraftUserUUID" />
         <camunda:out source="DraftStatus" target="DraftStatus" />
+        <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0gaps17</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1tuybfg</bpmn:outgoing>
@@ -716,6 +725,7 @@
         <camunda:in source="TriageUserUUID" target="AllocatedUserUUID" />
         <camunda:out source="TriageOnHoldOutcome" target="TriageOnHoldOutcome" />
         <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
+        <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1yjtv4p</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_097igop</bpmn:outgoing>
@@ -738,6 +748,7 @@
         <camunda:in source="QaUserUUID" target="AllocatedUserUUID" />
         <camunda:out source="LastUpdatedByUserUUID" target="QaUserUUID" />
         <camunda:out source="QaStatus" target="QaStatus" />
+        <camunda:out source="DraftUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1osy0mr</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0xfjnko</bpmn:outgoing>
@@ -759,6 +770,7 @@
         <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
         <camunda:in source="QaUserUUID" target="AllocatedUserUUID" />
         <camunda:out source="QaStatus" target="QaStatus" />
+        <camunda:out source="DraftUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0gzhnr0</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0k3rats</bpmn:outgoing>
@@ -781,6 +793,7 @@
         <camunda:out source="DispatchStatus" target="DispatchStatus" />
         <camunda:out source="LastUpdatedByUserUUID" target="LastUpdatedByUserUUID" />
         <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
+        <camunda:out source="DraftUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1pemtrq</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0i4wmw7</bpmn:outgoing>


### PR DESCRIPTION
Assign to drafter when sending to campaign from stages past draft

- added and populated new variable 'CampaignUserUUID', this now drives
what user will be assigned at Campaign stage