### PR TITLE
HOCS-1978

### DIFF
--- a/src/main/resources/processes/DCU_DTEN.bpmn
+++ b/src/main/resources/processes/DCU_DTEN.bpmn
@@ -31,7 +31,7 @@
         <camunda:in variables="all" />
         <camunda:out source="StageUUID" target="MarkupUUID" />
         <camunda:in sourceExpression="DCU_DTEN_MARKUP" target="StageType" />
-        <camunda:out sourceExpression=" ALLOCATE_TEAM" target="EmailType" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
         <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
         <camunda:out source="DraftingTeamUUID" target="DraftingTeamUUID" />
         <camunda:out source="POTeamUUID" target="POTeamUUID" />


### PR DESCRIPTION
Enum constant has a space in it, which causes an exception in the notify service.
The space has now been removed.