### PR TITLE
HOCS-2191 Don't assign team from topic if inactive

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
@@ -144,8 +144,12 @@ public class BpmnService {
 
         Map<String, String> teamsForTopic = new HashMap<>();
         TeamDto teamDto = infoClient.getTeamForTopicAndStage(caseUUID, topicUUID, stageType);
-        teamsForTopic.put(teamNameKey, teamDto.getUuid().toString());
-        teamsForTopic.put(teamUUIDKey, teamDto.getDisplayName());
+        if (teamDto.isActive()) {
+            teamsForTopic.put(teamNameKey, teamDto.getUuid().toString());
+            teamsForTopic.put(teamUUIDKey, teamDto.getDisplayName());
+        } else {
+            log.warn("Avoiding assigning orphaned team {}", teamDto.getDisplayName());
+        }
         camundaClient.updateTask(stageUUID, teamsForTopic);
         caseworkClient.updateCase(caseUUID, stageUUID, teamsForTopic);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/BpmnServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/BpmnServiceTest.java
@@ -132,6 +132,54 @@ public class BpmnServiceTest {
     }
 
     @Test
+    public void shouldNotAssignInactiveTeam() {
+        UUID caseUUID = UUID.randomUUID();
+        UUID stageUUID = UUID.randomUUID();
+        UUID topicUUID = UUID.randomUUID();
+        String stageName = "MOCK_STAGE_TYPE";
+        String teamName = "Team Name";
+        UUID teamUUID = UUID.randomUUID();
+
+        when(infoClient.getTeamForTopicAndStage(caseUUID, topicUUID, stageName)).thenReturn(new TeamDto(teamName, teamUUID, false, new HashSet<>()));
+        doNothing().when(camundaClient).updateTask(eq(stageUUID), any());
+        doNothing().when(caseworkClient).updateCase(eq(caseUUID), eq(stageUUID), any());
+
+        bpmnService.updateTeamsForPrimaryTopic(caseUUID.toString(), stageUUID.toString(), topicUUID.toString(), stageName, teamName, teamUUID.toString());
+
+        verify(camundaClient, times(1)).updateTask(eq(stageUUID), eq(new HashMap<>()));
+        verify(caseworkClient, times(1)).updateCase(eq(caseUUID), eq(stageUUID), any());
+
+        verifyZeroInteractions(caseworkClient);
+        verifyZeroInteractions(camundaClient);
+    }
+
+    @Test
+    public void shouldAssignActiveTeam() {
+        ArgumentCaptor<Map<String, String>> valueCapture = ArgumentCaptor.forClass(Map.class);
+
+        UUID caseUUID = UUID.randomUUID();
+        UUID stageUUID = UUID.randomUUID();
+        UUID topicUUID = UUID.randomUUID();
+        String stageName = "MOCK_STAGE_TYPE";
+        String teamName = "Team Name";
+        UUID teamUUID = UUID.randomUUID();
+
+        when(infoClient.getTeamForTopicAndStage(caseUUID, topicUUID, stageName)).thenReturn(new TeamDto(teamName, teamUUID, true, new HashSet<>()));
+        doNothing().when(camundaClient).updateTask(eq(stageUUID), any());
+        doNothing().when(caseworkClient).updateCase(eq(caseUUID), eq(stageUUID), any());
+
+        bpmnService.updateTeamsForPrimaryTopic(caseUUID.toString(), stageUUID.toString(), topicUUID.toString(), stageName, teamName, teamUUID.toString());
+
+        verify(camundaClient, times(1)).updateTask(eq(stageUUID), valueCapture.capture());
+        verify(caseworkClient, times(1)).updateCase(eq(caseUUID), eq(stageUUID), any());
+
+        assertThat(valueCapture.getValue().size()).isEqualTo(2);
+
+        verifyZeroInteractions(caseworkClient);
+        verifyZeroInteractions(camundaClient);
+    }
+
+    @Test
     public void shouldUpdateDataNewTeams() {
 
         UUID draftingString = UUID.randomUUID();


### PR DESCRIPTION
This commit adds a check immediately prior to assigning a team based on
a selected topic at (e.g.) markup stage. If the team is inactive, it
doesn't assign a team at all.

As far as I can tell, that means the case gets sent to the default team
(that is, DCU's central team).

This has the side-effect of meaning that in the UI on the override
("Answering") screen the missing team will show up as an empty field.
However, this is quite an edgey edge-case that should rarely surface, so
I think that's fine for now.

This commit also adds tests; previously the method had no coverage.