### PR TITLE
HOCS-2019 : correct bpmn calls to bpmn service to create case note

### DIFF
--- a/src/main/resources/processes/MPAM_DISPATCH.bpmn
+++ b/src/main/resources/processes/MPAM_DISPATCH.bpmn
@@ -206,7 +206,7 @@
       <bpmn:outgoing>Flow_13k7b3x</bpmn:outgoing>
       <bpmn:outgoing>Flow_05292wb</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="Activity_08te8ix" name="Save Close Case Notes" camunda:expression="${bpmnService.createCaseNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_CaseClose&#34;))}">
+    <bpmn:serviceTask id="Activity_08te8ix" name="Save Close Case Notes" camunda:expression="${bpmnService.createCaseNote(execution.getVariable(&#34;CaseUUID&#34;), execution.getVariable(&#34;CaseNote_CaseClose&#34;),&#34;CLOSE_CASE_TELEPHONE&#34;)}">
       <bpmn:incoming>Flow_0ic9zi8</bpmn:incoming>
       <bpmn:outgoing>Flow_01a96j1</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/src/main/resources/processes/MPAM_DRAFT.bpmn
+++ b/src/main/resources/processes/MPAM_DRAFT.bpmn
@@ -461,7 +461,7 @@
     <bpmn:sequenceFlow id="Flow_1fj82vn" name="Return To Triage" sourceRef="Gateway_1lkkdav" targetRef="ServiceTask_0orq4iy">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="Activity_0dr9jrd" name="Save Close Case Notes" camunda:expression="${bpmnService.createCaseNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_CaseClose&#34;))}">
+    <bpmn:serviceTask id="Activity_0dr9jrd" name="Save Close Case Notes" camunda:expression="${bpmnService.createCaseNote(execution.getVariable(&#34;CaseUUID&#34;), execution.getVariable(&#34;CaseNote_CaseClose&#34;),&#34;CLOSE_CASE_TELEPHONE&#34;)}">
       <bpmn:incoming>Flow_0k28sec</bpmn:incoming>
       <bpmn:outgoing>Flow_0lluryd</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/src/main/resources/processes/MPAM_QA.bpmn
+++ b/src/main/resources/processes/MPAM_QA.bpmn
@@ -309,7 +309,7 @@
       <bpmn:outgoing>Flow_0l4g4rl</bpmn:outgoing>
       <bpmn:outgoing>Flow_0bam9gx</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="Activity_0mmuzje" name="Save Close Case Notes" camunda:expression="${bpmnService.createCaseNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_CaseClose&#34;))}">
+    <bpmn:serviceTask id="Activity_0mmuzje" name="Save Close Case Notes" camunda:expression="${bpmnService.createCaseNote(execution.getVariable(&#34;CaseUUID&#34;), execution.getVariable(&#34;CaseNote_CaseClose&#34;),&#34;CLOSE_CASE_TELEPHONE&#34;)}">
       <bpmn:incoming>Flow_1j1nl0c</bpmn:incoming>
       <bpmn:outgoing>Flow_1ml757g</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/src/main/resources/processes/MPAM_TRIAGE.bpmn
+++ b/src/main/resources/processes/MPAM_TRIAGE.bpmn
@@ -494,7 +494,7 @@
       <bpmn:outgoing>Flow_1ieiwvi</bpmn:outgoing>
       <bpmn:outgoing>Flow_1gxj9d4</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="Activity_1rzz5vn" name="Save Close Case Notes" camunda:expression="${bpmnService.createCaseNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_CaseClose&#34;))}">
+    <bpmn:serviceTask id="Activity_1rzz5vn" name="Save Close Case Notes" camunda:expression="${bpmnService.createCaseNote(execution.getVariable(&#34;CaseUUID&#34;), execution.getVariable(&#34;CaseNote_CaseClose&#34;),&#34;CLOSE_CASE_TELEPHONE&#34;)}">
       <bpmn:incoming>Flow_0eb5pgl</bpmn:incoming>
       <bpmn:outgoing>Flow_19ce18n</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/BpmnServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/BpmnServiceTest.java
@@ -470,4 +470,21 @@ public class BpmnServiceTest {
         assertThat(valueCapture.getValue()).isEqualTo(expectedData);
         verifyZeroInteractions(caseworkClient, camundaClient, infoClient);
     }
+
+    @Test
+    public void shouldCreateCaseNote() {
+
+        UUID testCaseId = UUID.randomUUID();
+        String testCaseNote = "Case note for closing a case by telephone.";
+        ArgumentCaptor<String> valueCapture = ArgumentCaptor.forClass(String.class);
+
+        when(caseworkClient.createCaseNote(testCaseId, "CLOSE_CASE_TELEPHONE", testCaseNote)).thenReturn(testCaseId);
+
+        bpmnService.createCaseNote(testCaseId.toString(), testCaseNote, "CLOSE_CASE_TELEPHONE");
+
+        verify(caseworkClient, times(1)).createCaseNote(testCaseId, "CLOSE_CASE_TELEPHONE", testCaseNote);
+        verify(caseworkClient).createCaseNote(eq(testCaseId), eq("CLOSE_CASE_TELEPHONE"), valueCapture.capture());
+        assertThat(valueCapture.getValue()).isEqualTo(testCaseNote);
+        verifyNoMoreInteractions(caseworkClient, infoClient, camundaClient);
+    }
 }


### PR DESCRIPTION
Corrections made to the calls made from bpmn diagrams to the bpmn Service method to create case notes.
The call to createCaseNote from bpmn diagrams had the wrong parameters, now fixed.