### PR TITLE
Spike/hocs 2284 workflow process unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle
 /build/
+/target/
 !gradle/wrapper/gradle-wrapper.jar
 
 ### STS ###
@@ -20,7 +21,6 @@
 
 ### NetBeans ###
 /nbproject/private/
-/build/
 /nbbuild/
 /dist/
 /nbdist/

--- a/build.gradle
+++ b/build.gradle
@@ -75,16 +75,22 @@ dependencies {
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
 	testImplementation("org.apache.camel:camel-test-spring:${camelVersion}")
 	testImplementation('org.assertj:assertj-core')
+	testCompile group: 'org.camunda.bpm.extension', name: 'camunda-bpm-assert', version: '1.1'
+	testImplementation('com.h2database:h2')
 
 }
 
 sourceSets {
-	integrationTest {
-		java.srcDir 'src/integration-test/java'
-		resources.srcDir 'src/integration-test/resources'
-		compileClasspath += main.output + test.output
-		runtimeClasspath += main.output + test.output
-	}
+    test {
+        resources.srcDir 'src/main/resources'
+    }
+
+    integrationTest {
+        java.srcDir 'src/integration-test/java'
+        resources.srcDir 'src/integration-test/resources'
+        compileClasspath += main.output + test.output
+        runtimeClasspath += main.output + test.output
+    }
 }
 
 configurations {

--- a/build.gradle
+++ b/build.gradle
@@ -75,7 +75,11 @@ dependencies {
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
 	testImplementation("org.apache.camel:camel-test-spring:${camelVersion}")
 	testImplementation('org.assertj:assertj-core')
+
 	testCompile group: 'org.camunda.bpm.extension', name: 'camunda-bpm-assert', version: '1.1'
+	testCompile group: 'org.camunda.bpm.extension', name: 'camunda-bpm-assert-scenario', version: '1.0.0'
+	testCompile group: 'org.camunda.bpm.extension', name: 'camunda-bpm-process-test-coverage', version: '0.4.0'
+
 	testImplementation('com.h2database:h2')
 
 }

--- a/build.gradle
+++ b/build.gradle
@@ -77,6 +77,7 @@ dependencies {
 	testImplementation('org.assertj:assertj-core')
 
 	testCompile group: 'org.camunda.bpm.extension', name: 'camunda-bpm-assert', version: '1.1'
+	testCompile group: 'org.camunda.bpm.extension.mockito', name: 'camunda-bpm-mockito', version: '4.13.0'
 	testCompile group: 'org.camunda.bpm.extension', name: 'camunda-bpm-assert-scenario', version: '1.0.0'
 	testCompile group: 'org.camunda.bpm.extension', name: 'camunda-bpm-process-test-coverage', version: '0.4.0'
 

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAM.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAM.java
@@ -22,22 +22,10 @@ import static org.mockito.Mockito.verify;
 @Deployment(resources = {
         "processes/MPAM.bpmn",
         "processes/MPAM_CREATION.bpmn",
-        "processes/MPAM_CAMPAIGN.bpmn",
-        "processes/MPAM_CREATION.bpmn",
-        "processes/MPAM_DISPATCH.bpmn",
-        "processes/MPAM_DISPATCHED_FOLLOW_UP.bpmn",
+        "processes/MPAM_TRIAGE.bpmn",
         "processes/MPAM_DRAFT.bpmn",
-        "processes/MPAM_DRAFT_ESCALATE.bpmn",
-        "processes/MPAM_DRAFT_ONHOLD.bpmn",
-        "processes/MPAM_DRAFT_REQUESTED_CONTRIBUTION.bpmn",
         "processes/MPAM_PO.bpmn",
         "processes/MPAM_QA.bpmn",
-        "processes/MPAM_QA_ESCALATE.bpmn",
-        "processes/MPAM_QA_ONHOLD.bpmn",
-        "processes/MPAM_TRIAGE.bpmn",
-        "processes/MPAM_TRIAGE_ESCALATE.bpmn",
-        "processes/MPAM_TRIAGE_ON_HOLD.bpmn",
-        "processes/MPAM_TRIAGE_REQUESTED_CONTRIBUTION.bpmn",
         "processes/STAGE.bpmn",
         "processes/STAGE_WITH_USER.bpmn"})
 public class MPAM {

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAM.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAM.java
@@ -1,0 +1,95 @@
+package uk.gov.digital.ho.hocs.workflow.processes;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.extension.mockito.ProcessExpressions;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.camunda.bpm.scenario.ProcessScenario;
+import org.camunda.bpm.scenario.Scenario;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+@Deployment(resources = {
+        "processes/MPAM.bpmn",
+        "processes/MPAM_CREATION.bpmn",
+        "processes/MPAM_CAMPAIGN.bpmn",
+        "processes/MPAM_CREATION.bpmn",
+        "processes/MPAM_DISPATCH.bpmn",
+        "processes/MPAM_DISPATCHED_FOLLOW_UP.bpmn",
+        "processes/MPAM_DRAFT.bpmn",
+        "processes/MPAM_DRAFT_ESCALATE.bpmn",
+        "processes/MPAM_DRAFT_ONHOLD.bpmn",
+        "processes/MPAM_DRAFT_REQUESTED_CONTRIBUTION.bpmn",
+        "processes/MPAM_PO.bpmn",
+        "processes/MPAM_QA.bpmn",
+        "processes/MPAM_QA_ESCALATE.bpmn",
+        "processes/MPAM_QA_ONHOLD.bpmn",
+        "processes/MPAM_TRIAGE.bpmn",
+        "processes/MPAM_TRIAGE_ESCALATE.bpmn",
+        "processes/MPAM_TRIAGE_ON_HOLD.bpmn",
+        "processes/MPAM_TRIAGE_REQUESTED_CONTRIBUTION.bpmn",
+        "processes/STAGE.bpmn",
+        "processes/STAGE_WITH_USER.bpmn"})
+public class MPAM {
+
+    @Rule
+    @ClassRule
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
+            .build();
+
+    @Mock
+    BpmnService bpmnService;
+    @Mock
+    private ProcessScenario mpamProcess;
+
+    @Before
+    public void defaultScenario() {
+
+        Mocks.register("bpmnService", bpmnService);
+
+        ProcessExpressions.registerCallActivityMock("MPAM_CREATION")
+                .deploy(rule);
+
+        ProcessExpressions.registerCallActivityMock("MPAM_TRIAGE")
+                .deploy(rule);
+
+        ProcessExpressions.registerCallActivityMock("MPAM_DRAFT")
+                .onExecutionAddVariable("RefType", "Ministerial")
+                .deploy(rule);
+
+        ProcessExpressions.registerCallActivityMock("MPAM_QA")
+                .deploy(rule);
+
+        ProcessExpressions.registerCallActivityMock("MPAM_PO")
+                .onExecutionAddVariable("PoStatus", "Dispatched-Follow-Up")
+                .deploy(rule);
+
+        ProcessExpressions.registerCallActivityMock("MPAM_DISPATCHED_FOLLOW_UP")
+                .deploy(rule);
+    }
+
+    @Test
+    public void happyPath() {
+
+        Scenario.run(mpamProcess)
+                .startByKey("MPAM")
+                .execute();
+
+        verify(mpamProcess)
+                .hasCompleted("CallActivity_1c4zy60");
+        verify(mpamProcess)
+                .hasCompleted("ServiceTask_0rwk9ie");
+
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMCreation.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMCreation.java
@@ -1,0 +1,50 @@
+package uk.gov.digital.ho.hocs.workflow.processes;
+
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.Deployment;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@TestPropertySource(locations = {"classpath:test.properties"})
+public class MPAMCreation {
+
+    @MockBean
+    BpmnService bpmnService;
+
+    @Test
+    @Deployment(resources = "processes/MPAM_CREATION.bpmn")
+    public void happyPath() {
+
+        when(bpmnService.caseHasMember(any())).thenReturn(true);
+
+        ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("MPAM_CREATION");
+        assertThat(processInstance).isStarted();
+        assertThat(processInstance).isWaitingAt("UserTask_145n012");
+
+        complete(task(), withVariables("valid", true));
+
+        assertThat(processInstance).isWaitingAt("UserTask_0iez602");
+
+        complete(task(), withVariables("DIRECTION", "FORWARD"));
+
+        assertThat(processInstance)
+                .hasPassed("ServiceTask_1wekfef")
+                .hasPassed("ServiceTask_0wdqurs")
+                .isEnded();
+
+        verify(bpmnService, times(1)).updatePrimaryCorrespondent(any(), any(), any());
+
+        verify(bpmnService, times(1)).updateTeamByStageAndTexts(any(), any(), any(), any(), any(), any(), any());
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMCreation.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMCreation.java
@@ -27,6 +27,7 @@ public class MPAMCreation {
     @Rule
     @ClassRule
     public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
+            .assertClassCoverageAtLeast(0.88)
             .build();
 
     @Rule
@@ -41,7 +42,6 @@ public class MPAMCreation {
 
         Mocks.register("bpmnService", bpmnService);
 
-        //Happy-Path
         when(mpamCreationProcess.waitsAtUserTask("UserTask_145n012"))
                 .thenReturn(task -> task.complete(withVariables("valid", true)));
         when(mpamCreationProcess.waitsAtUserTask("UserTask_0iez602"))

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMTriageOnHold.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMTriageOnHold.java
@@ -1,0 +1,51 @@
+package uk.gov.digital.ho.hocs.workflow.processes;
+
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineAssertions.assertThat;
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@TestPropertySource(locations = {"classpath:test.properties"})
+public class MPAMTriageOnHold {
+
+    @MockBean
+    BpmnService bpmnService;
+
+    @Test
+    public void happyPath() {
+
+        ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("MPAM_TRIAGE_ON_HOLD");
+        assertThat(processInstance).isStarted();
+
+        assertThat(processInstance).isWaitingAt("UserTask_0jxw8et");
+
+        complete(task(), withVariables("valid", true, "TriageOnHoldOutcome", "PutOnCampaign", "DIRECTION", "FORWARD"));
+
+        assertThat(processInstance).isWaitingAt("UserTask_1ql7p2r");
+
+        complete(task(), withVariables("valid", true, "DIRECTION", "FORWARD"));
+
+        assertThat(processInstance)
+                .hasPassed("ServiceTask_1smdf47")
+                .hasPassed("ServiceTask_18u5rz3")
+                .hasPassed("ServiceTask_0ms9mqv")
+                .isEnded();
+
+        verify(bpmnService, times(1)).blankCaseValues(any(), any(), any());
+
+        verify(bpmnService, times(1)).updateTeamByStageAndTexts(any(), any(), any(), any(), any(), any(), any());
+
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMTriageOnHold.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMTriageOnHold.java
@@ -1,51 +1,70 @@
 package uk.gov.digital.ho.hocs.workflow.processes;
 
-import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.camunda.bpm.scenario.ProcessScenario;
+import org.camunda.bpm.scenario.Scenario;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.digital.ho.hocs.workflow.BpmnService;
 
-import static org.camunda.bpm.engine.test.assertions.ProcessEngineAssertions.assertThat;
-import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.*;
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.withVariables;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
-@RunWith(SpringRunner.class)
-@SpringBootTest
-@TestPropertySource(locations = {"classpath:test.properties"})
+@RunWith(MockitoJUnitRunner.class)
+@Deployment(resources = "processes/MPAM_TRIAGE_ON_HOLD.bpmn")
 public class MPAMTriageOnHold {
 
-    @MockBean
+    @Rule
+    @ClassRule
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
+            .build();
+    @Mock
     BpmnService bpmnService;
+    @Mock
+    private ProcessScenario mpamTriageOnHoldScenario;
+
+    @Before
+    public void defaultScenario() {
+
+        Mocks.register("bpmnService", bpmnService);
+
+        //Happy-Path
+        when(mpamTriageOnHoldScenario.waitsAtUserTask("UserTask_0jxw8et"))
+                .thenReturn(task -> task.complete(withVariables("valid", true, "TriageOnHoldOutcome", "PutOnCampaign", "DIRECTION", "FORWARD")));
+        when(mpamTriageOnHoldScenario.waitsAtUserTask("UserTask_1ql7p2r"))
+                .thenReturn(task -> task.complete(withVariables("valid", true, "DIRECTION", "FORWARD")));
+    }
 
     @Test
     public void happyPath() {
 
-        ProcessInstance processInstance = runtimeService().startProcessInstanceByKey("MPAM_TRIAGE_ON_HOLD");
-        assertThat(processInstance).isStarted();
+        Scenario.run(mpamTriageOnHoldScenario)
+                .startByKey("MPAM_TRIAGE_ON_HOLD")
+                .execute();
 
-        assertThat(processInstance).isWaitingAt("UserTask_0jxw8et");
+        verify(mpamTriageOnHoldScenario)
+                .hasCompleted("ServiceTask_1smdf47");
+        verify(mpamTriageOnHoldScenario)
+                .hasCompleted("ServiceTask_18u5rz3");
+        verify(mpamTriageOnHoldScenario)
+                .hasCompleted("ServiceTask_0ms9mqv");
+        verify(mpamTriageOnHoldScenario)
+                .hasFinished("EndEvent_1golwf2");
 
-        complete(task(), withVariables("valid", true, "TriageOnHoldOutcome", "PutOnCampaign", "DIRECTION", "FORWARD"));
+        verify(bpmnService).blankCaseValues(any(), any(), any());
 
-        assertThat(processInstance).isWaitingAt("UserTask_1ql7p2r");
-
-        complete(task(), withVariables("valid", true, "DIRECTION", "FORWARD"));
-
-        assertThat(processInstance)
-                .hasPassed("ServiceTask_1smdf47")
-                .hasPassed("ServiceTask_18u5rz3")
-                .hasPassed("ServiceTask_0ms9mqv")
-                .isEnded();
-
-        verify(bpmnService, times(1)).blankCaseValues(any(), any(), any());
-
-        verify(bpmnService, times(1)).updateTeamByStageAndTexts(any(), any(), any(), any(), any(), any(), any());
+        verify(bpmnService).updateTeamByStageAndTexts(any(), any(), any(), any(), any(), any(), any());
 
     }
+
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMTriageOnHold.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMTriageOnHold.java
@@ -27,6 +27,7 @@ public class MPAMTriageOnHold {
     @Rule
     @ClassRule
     public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
+            .assertClassCoverageAtLeast(0.83)
             .build();
     @Mock
     BpmnService bpmnService;
@@ -38,7 +39,6 @@ public class MPAMTriageOnHold {
 
         Mocks.register("bpmnService", bpmnService);
 
-        //Happy-Path
         when(mpamTriageOnHoldScenario.waitsAtUserTask("UserTask_0jxw8et"))
                 .thenReturn(task -> task.complete(withVariables("valid", true, "TriageOnHoldOutcome", "PutOnCampaign", "DIRECTION", "FORWARD")));
         when(mpamTriageOnHoldScenario.waitsAtUserTask("UserTask_1ql7p2r"))

--- a/src/test/resources/camunda.cfg.xml
+++ b/src/test/resources/camunda.cfg.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans   http://www.springframework.org/schema/beans/spring-beans.xsd">
+
+    <bean id="processEngineConfiguration" class="org.camunda.bpm.extension.process_test_coverage.junit.rules.ProcessCoverageInMemProcessEngineConfiguration">
+
+        <property name="jdbcUrl" value="jdbc:h2:mem:camunda;DB_CLOSE_DELAY=1000" />
+        <property name="jdbcDriver" value="org.h2.Driver" />
+        <property name="jdbcUsername" value="sa" />
+        <property name="jdbcPassword" value="" />
+
+        <property name="databaseSchemaUpdate" value="true" />
+
+        <property name="jobExecutorActivate" value="false" />
+
+    </bean>
+
+</beans>

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,8 +1,0 @@
-# suppress inspection "UnusedProperty" for whole file
-
-spring.datasource.url=jdbc:h2:mem:camunda;DB_CLOSE_DELAY=1000
-spring.datasource.username=SA
-spring.datasource.password=
-spring.datasource.driverClassName=org.h2.Driver
-
-camunda.bpm.history-level=full

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,0 +1,8 @@
+# suppress inspection "UnusedProperty" for whole file
+
+spring.datasource.url=jdbc:h2:mem:camunda;DB_CLOSE_DELAY=1000
+spring.datasource.username=SA
+spring.datasource.password=
+spring.datasource.driverClassName=org.h2.Driver
+
+camunda.bpm.history-level=activity

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -5,4 +5,4 @@ spring.datasource.username=SA
 spring.datasource.password=
 spring.datasource.driverClassName=org.h2.Driver
 
-camunda.bpm.history-level=activity
+camunda.bpm.history-level=full


### PR DESCRIPTION
This change adds an example of unit testing camunda process flows. It is a spike and not extensive. The 3 tests added should help as examples for more richer tests against future real stories.

The work is based on these notes : 

- https://camunda.com/best-practices/testing-process-definitions/
- https://camunda.com/blog/2020/10/testing-entire-process-paths/