### PR TITLE
HOCS-2274: Change to workflow to adapt to new Somu flow

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
@@ -238,7 +238,7 @@ public class BpmnService {
         }
 
     }
-
+    
     private Map<String, String> parseArgPairs(String... argPairs) {
         if (argPairs.length % 2 == 1) {
             throw new ApplicationExceptions.InvalidMethodArgumentException("Even number of arguments expected");
@@ -353,5 +353,11 @@ public class BpmnService {
 
     }
 
+    public void unallocateUserFromStage(String caseUUIDString, String stageUUIDString) {
+        UUID caseUUID = UUID.fromString(caseUUIDString);
+        UUID stageUUID = UUID.fromString(stageUUIDString);
+
+        caseworkClient.updateStageUser(caseUUID, stageUUID, null); 
+    }
 
 }

--- a/src/main/resources/processes/MPAM.bpmn
+++ b/src/main/resources/processes/MPAM.bpmn
@@ -553,12 +553,14 @@
         <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
         <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0241apj</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0rb09oq</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1q9gl8y</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="SequenceFlow_1q9gl8y" sourceRef="CallActivity_0gubz9s" targetRef="ExclusiveGateway_1ov5a6c" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_0i6lwxh" name="TriageEscalateOutcome?">
       <bpmn:incoming>SequenceFlow_1o62r04</bpmn:incoming>
+      <bpmn:incoming>Flow_0uw7du8</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0p09mbr</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1msf6ie</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1eflymy</bpmn:outgoing>
@@ -636,7 +638,6 @@
         <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0fjxe8s</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_0cfab7l</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0xndnj6</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1tmdgnf</bpmn:outgoing>
     </bpmn:callActivity>
@@ -644,7 +645,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_0fjxe8s" sourceRef="ExclusiveGateway_0gyznaj" targetRef="CallActivity_1dpqxto">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${BusAreaStatus == "Confirm" || BusAreaStatus == "Pending" || RefTypeStatus == "Confirm"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0cfab7l" name="Escalate" sourceRef="ExclusiveGateway_1ov5a6c" targetRef="CallActivity_1dpqxto">
+    <bpmn:sequenceFlow id="SequenceFlow_0cfab7l" name="Escalate" sourceRef="ExclusiveGateway_1ov5a6c" targetRef="Activity_12cebpj">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageRequestedContributionOutcome == "Escalate"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0xndnj6" name="SendToWorkflowManager" sourceRef="ExclusiveGateway_0pqjsx7" targetRef="CallActivity_1dpqxto">
@@ -851,9 +852,84 @@
     <bpmn:sequenceFlow id="Flow_04db6ze" name="Close Case Telephone" sourceRef="Gateway_0ne1m4t" targetRef="ServiceTask_0rwk9ie">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageOutcome == "CloseCaseTelephone"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:callActivity id="Activity_12cebpj" name="Triage Escalated" calledElement="STAGE_WITH_USER">
+      <bpmn:extensionElements>
+        <camunda:in source="TriageEscalateUUID" target="StageUUID" />
+        <camunda:in sourceExpression="MPAM_TRIAGE_ESCALATE" target="StageWorkFlow" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+        <camunda:out source="StageUUID" target="TriageEscalateUUID" />
+        <camunda:out source="DateReceived" target="DateReceived" />
+        <camunda:in sourceExpression="MPAM_TRIAGE_ESCALATE" target="StageType" />
+        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in source="QueueTeamUUID" target="AllocationTeamUUID" />
+        <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
+        <camunda:in source="TriageUserUUID" target="AllocatedUserUUID" />
+        <camunda:out source="TriageEscalateOutcome" target="TriageEscalateOutcome" />
+        <camunda:in source="&#34;&#34;" target="BusAreaStatus" />
+        <camunda:out source="BusAreaStatus" target="BusAreaStatus" />
+        <camunda:in source="&#34;&#34;" target="RefTypeStatus" />
+        <camunda:out source="RefTypeStatus" target="RefTypeStatus" />
+        <camunda:out source="RefType" target="RefType" />
+        <camunda:out source="LastUpdatedByUserUUID" target="LastUpdatedByUserUUID" />
+        <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0cfab7l</bpmn:incoming>
+      <bpmn:incoming>Flow_077ml5o</bpmn:incoming>
+      <bpmn:outgoing>Flow_1qtq31k</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_0bfsmfy">
+      <bpmn:incoming>Flow_1qtq31k</bpmn:incoming>
+      <bpmn:outgoing>Flow_077ml5o</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1t2khe9</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_077ml5o" sourceRef="Gateway_0bfsmfy" targetRef="Activity_12cebpj">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${BusAreaStatus == "Confirm" || BusAreaStatus == "Pending" || RefTypeStatus == "Confirm"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1qtq31k" sourceRef="Activity_12cebpj" targetRef="Gateway_0bfsmfy" />
+    <bpmn:exclusiveGateway id="Gateway_1apsblq">
+      <bpmn:incoming>Flow_1t2khe9</bpmn:incoming>
+      <bpmn:outgoing>Flow_0241apj</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0uw7du8</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1t2khe9" sourceRef="Gateway_0bfsmfy" targetRef="Gateway_1apsblq">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${BusAreaStatus != "Confirm" &amp;&amp; BusAreaStatus != "Pending" &amp;&amp; RefTypeStatus != "Confirm"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0241apj" sourceRef="Gateway_1apsblq" targetRef="CallActivity_0gubz9s">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageEscalateOutcome != "Close" &amp;&amp; TriageEscalateOutcome != "PutOnCampaign"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0uw7du8" sourceRef="Gateway_1apsblq" targetRef="ExclusiveGateway_0i6lwxh">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageEscalateOutcome =="Close" || TriageEscalateOutcome == "PutOnCampaign"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM">
+      <bpmndi:BPMNEdge id="Flow_0uw7du8_di" bpmnElement="Flow_0uw7du8">
+        <di:waypoint x="1505" y="693" />
+        <di:waypoint x="1640" y="693" />
+        <di:waypoint x="1640" y="725" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0241apj_di" bpmnElement="Flow_0241apj">
+        <di:waypoint x="1455" y="693" />
+        <di:waypoint x="1230" y="693" />
+        <di:waypoint x="1230" y="556" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1t2khe9_di" bpmnElement="Flow_1t2khe9">
+        <di:waypoint x="1480" y="638" />
+        <di:waypoint x="1480" y="668" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qtq31k_di" bpmnElement="Flow_1qtq31k">
+        <di:waypoint x="1480" y="556" />
+        <di:waypoint x="1480" y="588" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_077ml5o_di" bpmnElement="Flow_077ml5o">
+        <di:waypoint x="1505" y="613" />
+        <di:waypoint x="1570" y="613" />
+        <di:waypoint x="1570" y="516" />
+        <di:waypoint x="1530" y="516" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_04db6ze_di" bpmnElement="Flow_04db6ze">
         <di:waypoint x="975" y="374" />
         <di:waypoint x="975" y="80" />
@@ -952,28 +1028,28 @@
         <di:waypoint x="2849" y="609" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0xndnj6_di" bpmnElement="SequenceFlow_0xndnj6">
-        <di:waypoint x="1585" y="422" />
-        <di:waypoint x="1585" y="476" />
+        <di:waypoint x="1640" y="424" />
+        <di:waypoint x="1640" y="476" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1588" y="434" width="83" height="27" />
+          <dc:Bounds x="1568" y="437" width="83" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0cfab7l_di" bpmnElement="SequenceFlow_0cfab7l">
-        <di:waypoint x="1447" y="516" />
-        <di:waypoint x="1535" y="516" />
+        <di:waypoint x="1375" y="516" />
+        <di:waypoint x="1430" y="516" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1469" y="519" width="43" height="14" />
+          <dc:Bounds x="1381" y="519" width="43" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0fjxe8s_di" bpmnElement="SequenceFlow_0fjxe8s">
-        <di:waypoint x="1610" y="634" />
-        <di:waypoint x="1700" y="634" />
-        <di:waypoint x="1700" y="516" />
-        <di:waypoint x="1635" y="516" />
+        <di:waypoint x="1665" y="634" />
+        <di:waypoint x="1740" y="634" />
+        <di:waypoint x="1740" y="516" />
+        <di:waypoint x="1690" y="516" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1tmdgnf_di" bpmnElement="SequenceFlow_1tmdgnf">
-        <di:waypoint x="1585" y="556" />
-        <di:waypoint x="1585" y="609" />
+        <di:waypoint x="1640" y="556" />
+        <di:waypoint x="1640" y="609" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0gzhnr0_di" bpmnElement="SequenceFlow_0gzhnr0">
         <di:waypoint x="3624" y="422" />
@@ -1038,64 +1114,65 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1o62r04_di" bpmnElement="SequenceFlow_1o62r04">
-        <di:waypoint x="1585" y="659" />
-        <di:waypoint x="1585" y="699" />
+        <di:waypoint x="1640" y="659" />
+        <di:waypoint x="1640" y="725" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1eflymy_di" bpmnElement="SequenceFlow_1eflymy">
-        <di:waypoint x="1560" y="724" />
-        <di:waypoint x="577" y="724" />
-        <di:waypoint x="577" y="438" />
+        <di:waypoint x="1615" y="750" />
+        <di:waypoint x="577" y="750" />
+        <di:waypoint x="577" y="437" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1494" y="707" width="21" height="14" />
+          <dc:Bounds x="1546" y="733" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1msf6ie_di" bpmnElement="SequenceFlow_1msf6ie">
-        <di:waypoint x="1585" y="749" />
-        <di:waypoint x="1585" y="801" />
+        <di:waypoint x="1640" y="775" />
+        <di:waypoint x="1640" y="801" />
         <di:waypoint x="4728" y="801" />
         <di:waypoint x="4728" y="437" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1609" y="765" width="29" height="14" />
+          <dc:Bounds x="1663" y="765" width="29" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0p09mbr_di" bpmnElement="SequenceFlow_0p09mbr">
-        <di:waypoint x="1585" y="749" />
-        <di:waypoint x="1585" y="877" />
+        <di:waypoint x="1640" y="775" />
+        <di:waypoint x="1640" y="877" />
         <di:waypoint x="1455" y="877" />
         <di:waypoint x="1455" y="908" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1462" y="740" width="82" height="14" />
+          <dc:Bounds x="1517" y="766" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1q9gl8y_di" bpmnElement="SequenceFlow_1q9gl8y">
-        <di:waypoint x="1322" y="516" />
-        <di:waypoint x="1397" y="516" />
+        <di:waypoint x="1270" y="516" />
+        <di:waypoint x="1325" y="516" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_06j8j3d_di" bpmnElement="SequenceFlow_06j8j3d">
         <di:waypoint x="2548" y="516" />
         <di:waypoint x="2640" y="516" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0rb09oq_di" bpmnElement="SequenceFlow_0rb09oq">
-        <di:waypoint x="1272" y="422" />
-        <di:waypoint x="1272" y="476" />
+        <di:waypoint x="1220" y="424" />
+        <di:waypoint x="1220" y="476" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1279" y="435" width="86" height="27" />
+          <dc:Bounds x="1227" y="423" width="86" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_00jq2tl_di" bpmnElement="SequenceFlow_00jq2tl">
-        <di:waypoint x="1411" y="530" />
-        <di:waypoint x="1355" y="599" />
+        <di:waypoint x="1342" y="533" />
+        <di:waypoint x="1310" y="599" />
         <di:waypoint x="596" y="599" />
         <di:waypoint x="596" y="437" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1360" y="543" width="21" height="14" />
+          <dc:Bounds x="1300" y="548" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0jrup82_di" bpmnElement="SequenceFlow_0jrup82">
-        <di:waypoint x="1422" y="541" />
-        <di:waypoint x="1422" y="908" />
+        <di:waypoint x="1350" y="541" />
+        <di:waypoint x="1350" y="948" />
+        <di:waypoint x="1372" y="948" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1424" y="584" width="82" height="14" />
+          <dc:Bounds x="1352" y="589" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0emd0q1_di" bpmnElement="SequenceFlow_0emd0q1">
@@ -1352,12 +1429,14 @@
         <di:waypoint x="2615" y="399" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0vg77eq_di" bpmnElement="SequenceFlow_0vg77eq">
-        <di:waypoint x="1297" y="397" />
-        <di:waypoint x="1560" y="397" />
+        <di:waypoint x="1245" y="399" />
+        <di:waypoint x="1615" y="399" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0pe8uiv_di" bpmnElement="SequenceFlow_0pe8uiv">
-        <di:waypoint x="1610" y="397" />
-        <di:waypoint x="1755" y="397" />
+        <di:waypoint x="1665" y="399" />
+        <di:waypoint x="1711" y="399" />
+        <di:waypoint x="1711" y="397" />
+        <di:waypoint x="1757" y="397" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0e2x7lp_di" bpmnElement="SequenceFlow_0e2x7lp">
         <di:waypoint x="3003" y="422" />
@@ -1393,7 +1472,9 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0x063rr_di" bpmnElement="SequenceFlow_0x063rr">
         <di:waypoint x="1119" y="397" />
-        <di:waypoint x="1247" y="397" />
+        <di:waypoint x="1157" y="397" />
+        <di:waypoint x="1157" y="399" />
+        <di:waypoint x="1195" y="399" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="767" y="258" width="59" height="14" />
         </bpmndi:BPMNLabel>
@@ -1539,12 +1620,12 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0pqjsx7_di" bpmnElement="ExclusiveGateway_0pqjsx7" isMarkerVisible="true">
-        <dc:Bounds x="1560" y="372" width="50" height="50" />
+        <dc:Bounds x="1615" y="374" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1fbnwdh_di" bpmnElement="ExclusiveGateway_1fbnwdh" isMarkerVisible="true">
-        <dc:Bounds x="1247" y="372" width="50" height="50" />
+        <dc:Bounds x="1195" y="374" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1231" y="356" width="82" height="14" />
+          <dc:Bounds x="1179" y="358" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0q858dj_di" bpmnElement="ExclusiveGateway_0q858dj" isMarkerVisible="true">
@@ -1620,7 +1701,7 @@
         <dc:Bounds x="1372" y="908" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0gyznaj_di" bpmnElement="ExclusiveGateway_0gyznaj" isMarkerVisible="true">
-        <dc:Bounds x="1560" y="609" width="50" height="50" />
+        <dc:Bounds x="1615" y="609" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0vigruh_di" bpmnElement="ExclusiveGateway_0vigruh" isMarkerVisible="true">
         <dc:Bounds x="2824" y="609" width="50" height="50" />
@@ -1641,21 +1722,21 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1ov5a6c_di" bpmnElement="ExclusiveGateway_1ov5a6c" isMarkerVisible="true">
-        <dc:Bounds x="1397" y="491" width="50" height="50" />
+        <dc:Bounds x="1325" y="491" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1380" y="453" width="84" height="40" />
+          <dc:Bounds x="1308" y="453" width="84" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CallActivity_1068j5g_di" bpmnElement="CallActivity_1068j5g">
         <dc:Bounds x="2448" y="476" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CallActivity_0gubz9s_di" bpmnElement="CallActivity_0gubz9s">
-        <dc:Bounds x="1222" y="476" width="100" height="80" />
+        <dc:Bounds x="1170" y="476" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0i6lwxh_di" bpmnElement="ExclusiveGateway_0i6lwxh" isMarkerVisible="true">
-        <dc:Bounds x="1560" y="699" width="50" height="50" />
+        <dc:Bounds x="1615" y="725" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1616" y="710" width="82" height="27" />
+          <dc:Bounds x="1675" y="736" width="82" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1nyjaew_di" bpmnElement="ExclusiveGateway_1nyjaew" isMarkerVisible="true">
@@ -1671,7 +1752,7 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CallActivity_1dpqxto_di" bpmnElement="CallActivity_1dpqxto">
-        <dc:Bounds x="1535" y="476" width="100" height="80" />
+        <dc:Bounds x="1590" y="476" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CallActivity_0wsaktq_di" bpmnElement="CallActivity_0wsaktq">
         <dc:Bounds x="2799" y="476" width="100" height="80" />
@@ -1705,6 +1786,15 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0ne1m4t_di" bpmnElement="Gateway_0ne1m4t" isMarkerVisible="true">
         <dc:Bounds x="950" y="374" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12cebpj_di" bpmnElement="Activity_12cebpj">
+        <dc:Bounds x="1430" y="476" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0bfsmfy_di" bpmnElement="Gateway_0bfsmfy" isMarkerVisible="true">
+        <dc:Bounds x="1455" y="588" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1apsblq_di" bpmnElement="Gateway_1apsblq" isMarkerVisible="true">
+        <dc:Bounds x="1455" y="668" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/MPAM_TRIAGE.bpmn
+++ b/src/main/resources/processes/MPAM_TRIAGE.bpmn
@@ -31,11 +31,11 @@
     <bpmn:endEvent id="EndEvent_1golwf2" name="End Stage">
       <bpmn:incoming>SequenceFlow_0kcq8md</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1vaolyx</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_10u8lqt</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_108azcx</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_09iq9he</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0ksl1cg</bpmn:incoming>
       <bpmn:incoming>Flow_19ce18n</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_15la2x5</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="SequenceFlow_06v8hsn" name="false" sourceRef="ExclusiveGateway_13qjvzx" targetRef="ServiceTask_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
@@ -189,12 +189,7 @@
       <bpmn:outgoing>SequenceFlow_0rbinee</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:sequenceFlow id="SequenceFlow_15q2bxb" sourceRef="ServiceTask_1w1h0tl" targetRef="UserTask_0bqjeeg" />
-    <bpmn:serviceTask id="ServiceTask_0702omj" name="Save Request Contribution Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_TriageRequestContribution&#34;), &#34;REQUEST_CONTRIBUTION&#34;)}">
-      <bpmn:incoming>SequenceFlow_15la2x5</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_10u8lqt</bpmn:outgoing>
-    </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_0rbinee" sourceRef="UserTask_0bqjeeg" targetRef="ExclusiveGateway_05idho6" />
-    <bpmn:sequenceFlow id="SequenceFlow_10u8lqt" sourceRef="ServiceTask_0702omj" targetRef="EndEvent_1golwf2" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_05idho6" name="Direction Check">
       <bpmn:incoming>SequenceFlow_0rbinee</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0cjqztr</bpmn:outgoing>
@@ -211,7 +206,7 @@
       <bpmn:outgoing>SequenceFlow_15la2x5</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1lphuf4</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_15la2x5" sourceRef="ExclusiveGateway_08miue5" targetRef="ServiceTask_0702omj">
+    <bpmn:sequenceFlow id="SequenceFlow_15la2x5" sourceRef="ExclusiveGateway_08miue5" targetRef="EndEvent_1golwf2">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1lphuf4" sourceRef="ExclusiveGateway_08miue5" targetRef="ServiceTask_1w1h0tl">
@@ -530,9 +525,8 @@
       <bpmndi:BPMNEdge id="Flow_19ce18n_di" bpmnElement="Flow_19ce18n">
         <di:waypoint x="810" y="193" />
         <di:waypoint x="810" y="40" />
-        <di:waypoint x="2370" y="40" />
-        <di:waypoint x="2370" y="370" />
-        <di:waypoint x="2350" y="621" />
+        <di:waypoint x="2349" y="40" />
+        <di:waypoint x="2349" y="621" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1gxj9d4_di" bpmnElement="Flow_1gxj9d4">
         <di:waypoint x="570" y="368" />
@@ -549,8 +543,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0eb5pgl_di" bpmnElement="Flow_0eb5pgl">
         <di:waypoint x="490" y="318" />
-        <di:waypoint x="490" y="163" />
-        <di:waypoint x="720" y="216" />
+        <di:waypoint x="490" y="228" />
+        <di:waypoint x="720" y="228" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1lrv0lg_di" bpmnElement="Flow_1lrv0lg">
         <di:waypoint x="490" y="368" />
@@ -838,7 +832,10 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_15la2x5_di" bpmnElement="SequenceFlow_15la2x5">
         <di:waypoint x="1173" y="179" />
-        <di:waypoint x="1224" y="179" />
+        <di:waypoint x="1274" y="179" />
+        <di:waypoint x="1274" y="110" />
+        <di:waypoint x="2349" y="110" />
+        <di:waypoint x="2349" y="621" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1bypsoj_di" bpmnElement="SequenceFlow_1bypsoj">
         <di:waypoint x="1058" y="154" />
@@ -849,12 +846,6 @@
       <bpmndi:BPMNEdge id="SequenceFlow_0cjqztr_di" bpmnElement="SequenceFlow_0cjqztr">
         <di:waypoint x="1083" y="179" />
         <di:waypoint x="1123" y="179" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_10u8lqt_di" bpmnElement="SequenceFlow_10u8lqt">
-        <di:waypoint x="1274" y="139" />
-        <di:waypoint x="1274" y="110" />
-        <di:waypoint x="2349" y="110" />
-        <di:waypoint x="2349" y="621" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0rbinee_di" bpmnElement="SequenceFlow_0rbinee">
         <di:waypoint x="995" y="179" />
@@ -1130,9 +1121,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0bqjeeg_di" bpmnElement="UserTask_0bqjeeg">
         <dc:Bounds x="895" y="139" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0702omj_di" bpmnElement="ServiceTask_0702omj">
-        <dc:Bounds x="1224" y="139" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_05idho6_di" bpmnElement="ExclusiveGateway_05idho6" isMarkerVisible="true">
         <dc:Bounds x="1033" y="154" width="50" height="50" />

--- a/src/main/resources/processes/MPAM_TRIAGE_REQUESTED_CONTRIBUTION.bpmn
+++ b/src/main/resources/processes/MPAM_TRIAGE_REQUESTED_CONTRIBUTION.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ixf2kb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.2">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ixf2kb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
   <bpmn:process id="MPAM_TRIAGE_REQUESTED_CONTRIBUTION" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_0x8dpmn</bpmn:outgoing>
@@ -7,8 +7,8 @@
     <bpmn:serviceTask id="ServiceTask_05nlmnl" name="User Input" camunda:expression="MPAM_TRIAGE_REQUESTED_CONTRIBUTION" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_06v8hsn</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1m917qi</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_0x8dpmn</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_17wwsjo</bpmn:incoming>
+      <bpmn:incoming>Flow_19ef0w2</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_16wwh9z</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:userTask id="UserTask_0jxw8et" name="Validate User Input">
@@ -28,7 +28,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_1co3k2r" sourceRef="ExclusiveGateway_13qjvzx" targetRef="ExclusiveGateway_0p3mwpr">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0x8dpmn" sourceRef="StartEvent_1" targetRef="ServiceTask_05nlmnl" />
+    <bpmn:sequenceFlow id="SequenceFlow_0x8dpmn" sourceRef="StartEvent_1" targetRef="Activity_18ccgnf" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_0p3mwpr" name="TriageRequestedContributionOutcome?">
       <bpmn:incoming>SequenceFlow_1co3k2r</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_10l93df</bpmn:outgoing>
@@ -103,157 +103,169 @@
     <bpmn:sequenceFlow id="SequenceFlow_17wwsjo" sourceRef="ExclusiveGateway_0dlbolw" targetRef="ServiceTask_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="Activity_18ccgnf" name="Unallocate Stage From User" camunda:expression="${bpmnService.unallocateUserFromStage(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey)}">
+      <bpmn:incoming>SequenceFlow_0x8dpmn</bpmn:incoming>
+      <bpmn:outgoing>Flow_19ef0w2</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_19ef0w2" sourceRef="Activity_18ccgnf" targetRef="ServiceTask_05nlmnl" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_TRIAGE_REQUESTED_CONTRIBUTION">
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="119" y="514" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_05nlmnl_di" bpmnElement="ServiceTask_05nlmnl">
-        <dc:Bounds x="385" y="492" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_0jxw8et_di" bpmnElement="UserTask_0jxw8et">
-        <dc:Bounds x="385" y="655" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_13qjvzx_di" bpmnElement="ExclusiveGateway_13qjvzx" isMarkerVisible="true">
-        <dc:Bounds x="590" y="590" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_06v8hsn_di" bpmnElement="SequenceFlow_06v8hsn">
-        <di:waypoint x="615" y="590" />
-        <di:waypoint x="615" y="532" />
-        <di:waypoint x="485" y="532" />
+      <bpmndi:BPMNEdge id="SequenceFlow_17wwsjo_di" bpmnElement="SequenceFlow_17wwsjo">
+        <di:waypoint x="1378" y="198" />
+        <di:waypoint x="1378" y="81" />
+        <di:waypoint x="535" y="81" />
+        <di:waypoint x="535" y="492" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1gdsbt3_di" bpmnElement="SequenceFlow_1gdsbt3">
+        <di:waypoint x="1058" y="615" />
+        <di:waypoint x="1240" y="615" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0t1dhfb_di" bpmnElement="SequenceFlow_0t1dhfb">
+        <di:waypoint x="1493" y="223" />
+        <di:waypoint x="1616" y="223" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0jj0974_di" bpmnElement="SequenceFlow_0jj0974">
+        <di:waypoint x="1403" y="223" />
+        <di:waypoint x="1443" y="223" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1pscwkf_di" bpmnElement="SequenceFlow_1pscwkf">
+        <di:waypoint x="1315" y="223" />
+        <di:waypoint x="1353" y="223" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1a5ltb2_di" bpmnElement="SequenceFlow_1a5ltb2">
+        <di:waypoint x="1265" y="590" />
+        <di:waypoint x="1265" y="538" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="603" y="511" width="24" height="14" />
+          <dc:Bounds x="1272" y="566" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_16wwh9z_di" bpmnElement="SequenceFlow_16wwh9z">
-        <di:waypoint x="435" y="572" />
-        <di:waypoint x="435" y="655" />
+      <bpmndi:BPMNEdge id="SequenceFlow_1dmmweu_di" bpmnElement="SequenceFlow_1dmmweu">
+        <di:waypoint x="1265" y="347" />
+        <di:waypoint x="1265" y="263" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1da9mhc_di" bpmnElement="SequenceFlow_1da9mhc">
-        <di:waypoint x="485" y="695" />
-        <di:waypoint x="615" y="695" />
-        <di:waypoint x="615" y="640" />
+      <bpmndi:BPMNEdge id="SequenceFlow_1jj24t0_di" bpmnElement="SequenceFlow_1jj24t0">
+        <di:waypoint x="1265" y="458" />
+        <di:waypoint x="1265" y="427" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1co3k2r_di" bpmnElement="SequenceFlow_1co3k2r">
-        <di:waypoint x="640" y="615" />
-        <di:waypoint x="742" y="615" />
+      <bpmndi:BPMNEdge id="SequenceFlow_1n6ai9h_di" bpmnElement="SequenceFlow_1n6ai9h">
+        <di:waypoint x="1468" y="248" />
+        <di:waypoint x="1468" y="387" />
+        <di:waypoint x="1315" y="387" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0x8dpmn_di" bpmnElement="SequenceFlow_0x8dpmn">
-        <di:waypoint x="155" y="532" />
-        <di:waypoint x="385" y="532" />
+      <bpmndi:BPMNEdge id="SequenceFlow_0ssgyv1_di" bpmnElement="SequenceFlow_0ssgyv1">
+        <di:waypoint x="1666" y="263" />
+        <di:waypoint x="1666" y="597" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="ExclusiveGateway_0p3mwpr_di" bpmnElement="ExclusiveGateway_0p3mwpr" isMarkerVisible="true">
-        <dc:Bounds x="742" y="590" width="50" height="50" />
+      <bpmndi:BPMNEdge id="SequenceFlow_1eba3c1_di" bpmnElement="SequenceFlow_1eba3c1">
+        <di:waypoint x="1290" y="615" />
+        <di:waypoint x="1648" y="615" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="677" y="634" width="84" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_10l93df_di" bpmnElement="SequenceFlow_10l93df">
-        <di:waypoint x="792" y="615" />
-        <di:waypoint x="858" y="615" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="815" y="597" width="21" height="14" />
+          <dc:Bounds x="1301" y="596" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1m917qi_di" bpmnElement="SequenceFlow_1m917qi">
-        <di:waypoint x="767" y="590" />
-        <di:waypoint x="767" y="423" />
-        <di:waypoint x="435" y="423" />
-        <di:waypoint x="435" y="492" />
+        <di:waypoint x="867" y="590" />
+        <di:waypoint x="867" y="423" />
+        <di:waypoint x="535" y="423" />
+        <di:waypoint x="535" y="492" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="716" y="550" width="40" height="14" />
+          <dc:Bounds x="816" y="550" width="40" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_10l93df_di" bpmnElement="SequenceFlow_10l93df">
+        <di:waypoint x="892" y="615" />
+        <di:waypoint x="958" y="615" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="915" y="597" width="21" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0x8dpmn_di" bpmnElement="SequenceFlow_0x8dpmn">
+        <di:waypoint x="188" y="532" />
+        <di:waypoint x="290" y="532" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1co3k2r_di" bpmnElement="SequenceFlow_1co3k2r">
+        <di:waypoint x="740" y="615" />
+        <di:waypoint x="842" y="615" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1da9mhc_di" bpmnElement="SequenceFlow_1da9mhc">
+        <di:waypoint x="585" y="695" />
+        <di:waypoint x="715" y="695" />
+        <di:waypoint x="715" y="640" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_16wwh9z_di" bpmnElement="SequenceFlow_16wwh9z">
+        <di:waypoint x="535" y="572" />
+        <di:waypoint x="535" y="655" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_06v8hsn_di" bpmnElement="SequenceFlow_06v8hsn">
+        <di:waypoint x="715" y="590" />
+        <di:waypoint x="715" y="532" />
+        <di:waypoint x="585" y="532" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="703" y="511" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19ef0w2_di" bpmnElement="Flow_19ef0w2">
+        <di:waypoint x="390" y="532" />
+        <di:waypoint x="485" y="532" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_05nlmnl_di" bpmnElement="ServiceTask_05nlmnl">
+        <dc:Bounds x="485" y="492" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_0jxw8et_di" bpmnElement="UserTask_0jxw8et">
+        <dc:Bounds x="485" y="655" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_13qjvzx_di" bpmnElement="ExclusiveGateway_13qjvzx" isMarkerVisible="true">
+        <dc:Bounds x="690" y="590" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_0p3mwpr_di" bpmnElement="ExclusiveGateway_0p3mwpr" isMarkerVisible="true">
+        <dc:Bounds x="842" y="590" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="777" y="634" width="84" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0u7de46_di" bpmnElement="ServiceTask_0u7de46">
-        <dc:Bounds x="858" y="575" width="100" height="80" />
+        <dc:Bounds x="958" y="575" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_155qjcq_di" bpmnElement="EndEvent_155qjcq">
-        <dc:Bounds x="1548" y="597" width="36" height="36" />
+        <dc:Bounds x="1648" y="597" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1540" y="643" width="52" height="14" />
+          <dc:Bounds x="1640" y="643" width="52" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0n42bj5_di" bpmnElement="ServiceTask_0n42bj5">
-        <dc:Bounds x="1115" y="347" width="100" height="80" />
+        <dc:Bounds x="1215" y="347" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1aiye3g_di" bpmnElement="ExclusiveGateway_1aiye3g" isMarkerVisible="true">
-        <dc:Bounds x="1140" y="590" width="50" height="50" />
+        <dc:Bounds x="1240" y="590" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1124" y="642" width="84" height="40" />
+          <dc:Bounds x="1224" y="642" width="84" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0wfgq51_di" bpmnElement="UserTask_0wfgq51">
-        <dc:Bounds x="1115" y="183" width="100" height="80" />
+        <dc:Bounds x="1215" y="183" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0dlbolw_di" bpmnElement="ExclusiveGateway_0dlbolw" isMarkerVisible="true">
-        <dc:Bounds x="1253" y="198" width="50" height="50" />
+        <dc:Bounds x="1353" y="198" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1239" y="258" width="78" height="14" />
+          <dc:Bounds x="1339" y="258" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1vuskiu_di" bpmnElement="ExclusiveGateway_1vuskiu" isMarkerVisible="true">
-        <dc:Bounds x="1343" y="198" width="50" height="50" />
+        <dc:Bounds x="1443" y="198" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0d0na5b_di" bpmnElement="ServiceTask_0d0na5b">
-        <dc:Bounds x="1516" y="183" width="100" height="80" />
+        <dc:Bounds x="1616" y="183" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0e3golq_di" bpmnElement="ServiceTask_0e3golq">
-        <dc:Bounds x="1115" y="458" width="100" height="80" />
+        <dc:Bounds x="1215" y="458" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1eba3c1_di" bpmnElement="SequenceFlow_1eba3c1">
-        <di:waypoint x="1190" y="615" />
-        <di:waypoint x="1548" y="615" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1201" y="596" width="21" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0ssgyv1_di" bpmnElement="SequenceFlow_0ssgyv1">
-        <di:waypoint x="1566" y="263" />
-        <di:waypoint x="1566" y="597" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1n6ai9h_di" bpmnElement="SequenceFlow_1n6ai9h">
-        <di:waypoint x="1368" y="248" />
-        <di:waypoint x="1368" y="387" />
-        <di:waypoint x="1215" y="387" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1jj24t0_di" bpmnElement="SequenceFlow_1jj24t0">
-        <di:waypoint x="1165" y="458" />
-        <di:waypoint x="1165" y="427" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1dmmweu_di" bpmnElement="SequenceFlow_1dmmweu">
-        <di:waypoint x="1165" y="347" />
-        <di:waypoint x="1165" y="263" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1a5ltb2_di" bpmnElement="SequenceFlow_1a5ltb2">
-        <di:waypoint x="1165" y="590" />
-        <di:waypoint x="1165" y="538" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1172" y="565.5" width="82" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1pscwkf_di" bpmnElement="SequenceFlow_1pscwkf">
-        <di:waypoint x="1215" y="223" />
-        <di:waypoint x="1253" y="223" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0jj0974_di" bpmnElement="SequenceFlow_0jj0974">
-        <di:waypoint x="1303" y="223" />
-        <di:waypoint x="1343" y="223" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0t1dhfb_di" bpmnElement="SequenceFlow_0t1dhfb">
-        <di:waypoint x="1393" y="223" />
-        <di:waypoint x="1516" y="223" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1gdsbt3_di" bpmnElement="SequenceFlow_1gdsbt3">
-        <di:waypoint x="958" y="615" />
-        <di:waypoint x="1140" y="615" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_17wwsjo_di" bpmnElement="SequenceFlow_17wwsjo">
-        <di:waypoint x="1278" y="198" />
-        <di:waypoint x="1278" y="81" />
-        <di:waypoint x="435" y="81" />
-        <di:waypoint x="435" y="492" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="514" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18ccgnf_di" bpmnElement="Activity_18ccgnf">
+        <dc:Bounds x="290" y="492" width="100" height="80" />
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>


### PR DESCRIPTION
Remove the saving of a contribution note as that needs to be moved within the hocs-casework on contribution note addition. 
Fix to MPAM_TRIAGE bpmn to go back to contribution requested if escalated at that stage.
Unallocate case when going into contribution requested stage in MPAM Triage.