### PR TITLE
HOCS-2296 : change to Official clears Ministerial data, fix

### DIFF
--- a/src/main/resources/processes/MPAM_DRAFT.bpmn
+++ b/src/main/resources/processes/MPAM_DRAFT.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_07mbj45" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_07mbj45" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.2">
   <bpmn:process id="MPAM_DRAFT" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_1ivlngt</bpmn:outgoing>
@@ -257,8 +257,8 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_0324wwr">
-      <bpmn:incoming>SequenceFlow_11x8a2s</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_171hy6u</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1lhbixe</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1pu5xef</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1pkybrv</bpmn:outgoing>
     </bpmn:exclusiveGateway>
@@ -283,7 +283,7 @@
       <bpmn:incoming>SequenceFlow_1ggfwm6</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_171hy6u</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_11x8a2s" sourceRef="ServiceTask_0lic0m6" targetRef="ExclusiveGateway_0324wwr" />
+    <bpmn:sequenceFlow id="SequenceFlow_11x8a2s" sourceRef="ServiceTask_0lic0m6" targetRef="ServiceTask_0xqy6p5" />
     <bpmn:sequenceFlow id="SequenceFlow_171hy6u" sourceRef="ServiceTask_0urk37h" targetRef="ExclusiveGateway_0324wwr" />
     <bpmn:sequenceFlow id="SequenceFlow_0jenwmy" sourceRef="ServiceTask_1trdh33" targetRef="Activity_1yc1ce2" />
     <bpmn:serviceTask id="ServiceTask_1blck00" name="Request Campaign" camunda:expression="MPAM_CAMPAIGN_REQUEST" camunda:resultVariable="screen">
@@ -474,6 +474,11 @@
     <bpmn:sequenceFlow id="Flow_06gx7kj" sourceRef="Gateway_0b9xe9y" targetRef="ExclusiveGateway_0vqlqgx">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus != "CloseCaseTelephone"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="ServiceTask_0xqy6p5" name="Clear Ministerial values" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;MinSignOffTeam&#34;, &#34;Addressee&#34;)}">
+      <bpmn:incoming>SequenceFlow_11x8a2s</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1lhbixe</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1lhbixe" sourceRef="ServiceTask_0xqy6p5" targetRef="ExclusiveGateway_0324wwr" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_DRAFT">
@@ -482,8 +487,10 @@
         <di:waypoint x="986" y="1660" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0lluryd_di" bpmnElement="Flow_0lluryd">
-        <di:waypoint x="750" y="1295" />
-        <di:waypoint x="1970" y="1655" />
+        <di:waypoint x="700" y="1240" />
+        <di:waypoint x="700" y="1182" />
+        <di:waypoint x="1987" y="1182" />
+        <di:waypoint x="1987" y="1642" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1fj82vn_di" bpmnElement="Flow_1fj82vn">
         <di:waypoint x="580" y="1415" />
@@ -502,8 +509,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0k28sec_di" bpmnElement="Flow_0k28sec">
         <di:waypoint x="490" y="1365" />
-        <di:waypoint x="490" y="1210" />
-        <di:waypoint x="650" y="1263" />
+        <di:waypoint x="490" y="1280" />
+        <di:waypoint x="650" y="1280" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_14ic9i2_di" bpmnElement="Flow_14ic9i2">
         <di:waypoint x="490" y="1415" />
@@ -551,7 +558,7 @@
         <di:waypoint x="1011" y="320" />
         <di:waypoint x="1201" y="320" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1005" y="975" width="43" height="14" />
+          <dc:Bounds x="1090" y="304" width="43" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1e18l7v_di" bpmnElement="SequenceFlow_1e18l7v">
@@ -590,7 +597,7 @@
         <di:waypoint x="1011" y="745" />
         <di:waypoint x="1201" y="745" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="989" y="1187" width="76" height="14" />
+          <dc:Bounds x="1074" y="730" width="76" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1fa0o3g_di" bpmnElement="SequenceFlow_1fa0o3g">
@@ -616,8 +623,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_103d2ja_di" bpmnElement="SequenceFlow_103d2ja">
         <di:waypoint x="1364" y="1220" />
-        <di:waypoint x="1364" y="1185" />
-        <di:waypoint x="413" y="1185" />
+        <di:waypoint x="1364" y="1196" />
+        <di:waypoint x="413" y="1196" />
         <di:waypoint x="413" y="1537" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0gqz21i_di" bpmnElement="SequenceFlow_0gqz21i">
@@ -664,22 +671,22 @@
         <di:waypoint x="1404" y="2297" />
         <di:waypoint x="1404" y="2210" />
         <di:waypoint x="1260" y="2210" />
-        <di:waypoint x="1260" y="2170" />
+        <di:waypoint x="1260" y="2160" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_171hy6u_di" bpmnElement="SequenceFlow_171hy6u">
-        <di:waypoint x="1162" y="2665" />
-        <di:waypoint x="1260" y="2665" />
-        <di:waypoint x="1260" y="2362" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_11x8a2s_di" bpmnElement="SequenceFlow_11x8a2s">
         <di:waypoint x="1162" y="2337" />
         <di:waypoint x="1235" y="2337" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_11x8a2s_di" bpmnElement="SequenceFlow_11x8a2s">
+        <di:waypoint x="1162" y="2660" />
+        <di:waypoint x="1260" y="2660" />
+        <di:waypoint x="1260" y="2617" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1pkybrv_di" bpmnElement="SequenceFlow_1pkybrv">
         <di:waypoint x="1260" y="2312" />
         <di:waypoint x="1260" y="2160" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1228" y="2193" width="51" height="14" />
+          <dc:Bounds x="1234" y="2247" width="51" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1pu5xef_di" bpmnElement="SequenceFlow_1pu5xef">
@@ -687,51 +694,51 @@
         <di:waypoint x="1354" y="2337" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1ggfwm6_di" bpmnElement="SequenceFlow_1ggfwm6">
-        <di:waypoint x="965" y="2665" />
-        <di:waypoint x="1062" y="2665" />
+        <di:waypoint x="965" y="2337" />
+        <di:waypoint x="1062" y="2337" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1y4lk7l_di" bpmnElement="SequenceFlow_1y4lk7l">
-        <di:waypoint x="940" y="2770" />
-        <di:waypoint x="940" y="2840" />
-        <di:waypoint x="293" y="2840" />
+        <di:waypoint x="940" y="2442" />
+        <di:waypoint x="940" y="2497" />
+        <di:waypoint x="293" y="2497" />
         <di:waypoint x="293" y="1577" />
         <di:waypoint x="363" y="1577" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1uojgpn_di" bpmnElement="SequenceFlow_1uojgpn">
-        <di:waypoint x="673" y="2279" />
-        <di:waypoint x="673" y="2582" />
-        <di:waypoint x="741" y="2582" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1m5233h_di" bpmnElement="SequenceFlow_1m5233h">
         <di:waypoint x="698" y="2254" />
         <di:waypoint x="741" y="2254" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1m5233h_di" bpmnElement="SequenceFlow_1m5233h">
+        <di:waypoint x="673" y="2279" />
+        <di:waypoint x="673" y="2577" />
+        <di:waypoint x="741" y="2577" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1tc6caf_di" bpmnElement="SequenceFlow_1tc6caf">
-        <di:waypoint x="940" y="2720" />
-        <di:waypoint x="940" y="2690" />
+        <di:waypoint x="940" y="2392" />
+        <di:waypoint x="940" y="2362" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="944" y="2705" width="57" height="14" />
+          <dc:Bounds x="944" y="2377" width="57" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1cz4xuc_di" bpmnElement="SequenceFlow_1cz4xuc">
-        <di:waypoint x="841" y="2745" />
-        <di:waypoint x="915" y="2745" />
+        <di:waypoint x="841" y="2417" />
+        <di:waypoint x="915" y="2417" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0hgy197_di" bpmnElement="SequenceFlow_0hgy197">
-        <di:waypoint x="791" y="2622" />
-        <di:waypoint x="791" y="2705" />
+        <di:waypoint x="791" y="2294" />
+        <di:waypoint x="791" y="2377" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1yz68yy_di" bpmnElement="SequenceFlow_1yz68yy">
-        <di:waypoint x="940" y="2640" />
-        <di:waypoint x="940" y="2582" />
-        <di:waypoint x="841" y="2582" />
+        <di:waypoint x="940" y="2312" />
+        <di:waypoint x="940" y="2254" />
+        <di:waypoint x="841" y="2254" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="928" y="2564" width="24" height="14" />
+          <dc:Bounds x="928" y="2236" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_14azxs6_di" bpmnElement="SequenceFlow_14azxs6">
-        <di:waypoint x="965" y="2337" />
-        <di:waypoint x="1062" y="2337" />
+        <di:waypoint x="965" y="2660" />
+        <di:waypoint x="1062" y="2660" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0654hf2_di" bpmnElement="SequenceFlow_0654hf2">
         <di:waypoint x="593" y="1765" />
@@ -739,33 +746,33 @@
         <di:waypoint x="648" y="2254" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0mdieu9_di" bpmnElement="SequenceFlow_0mdieu9">
-        <di:waypoint x="940" y="2442" />
-        <di:waypoint x="940" y="2504" />
-        <di:waypoint x="293" y="2504" />
+        <di:waypoint x="940" y="2765" />
+        <di:waypoint x="940" y="2826" />
+        <di:waypoint x="293" y="2826" />
         <di:waypoint x="293" y="1577" />
         <di:waypoint x="363" y="1577" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0a5rk4w_di" bpmnElement="SequenceFlow_0a5rk4w">
-        <di:waypoint x="940" y="2392" />
-        <di:waypoint x="940" y="2362" />
+        <di:waypoint x="940" y="2715" />
+        <di:waypoint x="940" y="2685" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="944" y="2377" width="57" height="14" />
+          <dc:Bounds x="944" y="2700" width="57" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0xbeybw_di" bpmnElement="SequenceFlow_0xbeybw">
-        <di:waypoint x="841" y="2417" />
-        <di:waypoint x="915" y="2417" />
+        <di:waypoint x="841" y="2740" />
+        <di:waypoint x="915" y="2740" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_03u9yfs_di" bpmnElement="SequenceFlow_03u9yfs">
-        <di:waypoint x="791" y="2294" />
-        <di:waypoint x="791" y="2377" />
+        <di:waypoint x="791" y="2617" />
+        <di:waypoint x="791" y="2700" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0r2r56q_di" bpmnElement="SequenceFlow_0r2r56q">
-        <di:waypoint x="940" y="2312" />
-        <di:waypoint x="940" y="2254" />
-        <di:waypoint x="841" y="2254" />
+        <di:waypoint x="940" y="2635" />
+        <di:waypoint x="940" y="2577" />
+        <di:waypoint x="841" y="2577" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="928" y="2236" width="24" height="14" />
+          <dc:Bounds x="928" y="2559" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_15tk81s_di" bpmnElement="SequenceFlow_15tk81s">
@@ -839,7 +846,7 @@
         <di:waypoint x="1011" y="1122" />
         <di:waypoint x="1201" y="1122" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="917" y="1563" width="86" height="27" />
+          <dc:Bounds x="1069" y="1093" width="86" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0yg3lht_di" bpmnElement="SequenceFlow_0yg3lht">
@@ -1007,33 +1014,33 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0ia1i5c_di" bpmnElement="ServiceTask_0ia1i5c">
-        <dc:Bounds x="741" y="2214" width="100" height="80" />
+        <dc:Bounds x="741" y="2537" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_08l10xy_di" bpmnElement="UserTask_08l10xy">
-        <dc:Bounds x="741" y="2377" width="100" height="80" />
+        <dc:Bounds x="741" y="2700" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1fuk0q6_di" bpmnElement="ExclusiveGateway_1fuk0q6" isMarkerVisible="true">
-        <dc:Bounds x="915" y="2312" width="50" height="50" />
+        <dc:Bounds x="915" y="2635" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1v05dfs_di" bpmnElement="ExclusiveGateway_1v05dfs" isMarkerVisible="true">
-        <dc:Bounds x="915" y="2392" width="50" height="50" />
+        <dc:Bounds x="915" y="2715" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="950" y="2433" width="78" height="14" />
+          <dc:Bounds x="950" y="2756" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1unkg32_di" bpmnElement="ServiceTask_1unkg32">
-        <dc:Bounds x="741" y="2542" width="100" height="80" />
+        <dc:Bounds x="741" y="2214" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0zaqr6s_di" bpmnElement="UserTask_0zaqr6s">
-        <dc:Bounds x="741" y="2705" width="100" height="80" />
+        <dc:Bounds x="741" y="2377" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0m7zmvc_di" bpmnElement="ExclusiveGateway_0m7zmvc" isMarkerVisible="true">
-        <dc:Bounds x="915" y="2640" width="50" height="50" />
+        <dc:Bounds x="915" y="2312" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0ofzr32_di" bpmnElement="ExclusiveGateway_0ofzr32" isMarkerVisible="true">
-        <dc:Bounds x="915" y="2720" width="50" height="50" />
+        <dc:Bounds x="915" y="2392" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="952" y="2760" width="78" height="14" />
+          <dc:Bounds x="952" y="2432" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_10wtbjv_di" bpmnElement="ExclusiveGateway_10wtbjv" isMarkerVisible="true">
@@ -1046,10 +1053,10 @@
         <dc:Bounds x="1354" y="2297" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0lic0m6_di" bpmnElement="ServiceTask_0lic0m6">
-        <dc:Bounds x="1062" y="2297" width="100" height="80" />
+        <dc:Bounds x="1062" y="2620" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0urk37h_di" bpmnElement="ServiceTask_0urk37h">
-        <dc:Bounds x="1062" y="2625" width="100" height="80" />
+        <dc:Bounds x="1062" y="2297" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1blck00_di" bpmnElement="ServiceTask_1blck00">
         <dc:Bounds x="1201" y="1369" width="100" height="80" />
@@ -1132,6 +1139,13 @@
       <bpmndi:BPMNShape id="Gateway_0b9xe9y_di" bpmnElement="Gateway_0b9xe9y" isMarkerVisible="true">
         <dc:Bounds x="875" y="1635" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0xqy6p5_di" bpmnElement="ServiceTask_0xqy6p5">
+        <dc:Bounds x="1210" y="2537" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1lhbixe_di" bpmnElement="SequenceFlow_1lhbixe">
+        <di:waypoint x="1260" y="2537" />
+        <di:waypoint x="1260" y="2362" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/processes/MPAM_DRAFT.bpmn
+++ b/src/main/resources/processes/MPAM_DRAFT.bpmn
@@ -18,7 +18,7 @@
       <bpmn:incoming>Flow_1fj82vn</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1u7cdfq</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_00s8k9f" name="Validate User Input">
+    <bpmn:userTask id="Validate_UserInput_00s8k9f" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_1u7cdfq</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0sfu5f2</bpmn:outgoing>
     </bpmn:userTask>
@@ -41,8 +41,8 @@
     <bpmn:sequenceFlow id="SequenceFlow_0jno6nt" name="false" sourceRef="ExclusiveGateway_0urib3x" targetRef="ServiceTask_0orq4iy">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1u7cdfq" sourceRef="ServiceTask_0orq4iy" targetRef="UserTask_00s8k9f" />
-    <bpmn:sequenceFlow id="SequenceFlow_0sfu5f2" sourceRef="UserTask_00s8k9f" targetRef="ExclusiveGateway_0ytznox" />
+    <bpmn:sequenceFlow id="SequenceFlow_1u7cdfq" sourceRef="ServiceTask_0orq4iy" targetRef="Validate_UserInput_00s8k9f" />
+    <bpmn:sequenceFlow id="SequenceFlow_0sfu5f2" sourceRef="Validate_UserInput_00s8k9f" targetRef="ExclusiveGateway_0ytznox" />
     <bpmn:sequenceFlow id="SequenceFlow_00pezmh" sourceRef="ExclusiveGateway_0urib3x" targetRef="ExclusiveGateway_0i7ko22">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -179,12 +179,12 @@
     <bpmn:sequenceFlow id="SequenceFlow_15tk81s" name="BACKWARD" sourceRef="ExclusiveGateway_0244uy2" targetRef="ServiceTask_0orq4iy">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_0ia1i5c" name="Reference Type To Offical" camunda:expression="MPAM_REFTYPE_TO_OFFICIAL" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="Screen_RefTypeToOfficial_0ia1i5c" name="Reference Type To Offical" camunda:expression="MPAM_REFTYPE_TO_OFFICIAL" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_0r2r56q</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1m5233h</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_03u9yfs</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_08l10xy" name="Validate User Input">
+    <bpmn:userTask id="Validate_RefTypeToOfficial_08l10xy" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_03u9yfs</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0xbeybw</bpmn:outgoing>
     </bpmn:userTask>
@@ -198,11 +198,11 @@
       <bpmn:outgoing>SequenceFlow_0a5rk4w</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0mdieu9</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_0r2r56q" name="false" sourceRef="ExclusiveGateway_1fuk0q6" targetRef="ServiceTask_0ia1i5c">
+    <bpmn:sequenceFlow id="SequenceFlow_0r2r56q" name="false" sourceRef="ExclusiveGateway_1fuk0q6" targetRef="Screen_RefTypeToOfficial_0ia1i5c">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_03u9yfs" sourceRef="ServiceTask_0ia1i5c" targetRef="UserTask_08l10xy" />
-    <bpmn:sequenceFlow id="SequenceFlow_0xbeybw" sourceRef="UserTask_08l10xy" targetRef="ExclusiveGateway_1v05dfs" />
+    <bpmn:sequenceFlow id="SequenceFlow_03u9yfs" sourceRef="Screen_RefTypeToOfficial_0ia1i5c" targetRef="Validate_RefTypeToOfficial_08l10xy" />
+    <bpmn:sequenceFlow id="SequenceFlow_0xbeybw" sourceRef="Validate_RefTypeToOfficial_08l10xy" targetRef="ExclusiveGateway_1v05dfs" />
     <bpmn:sequenceFlow id="SequenceFlow_0a5rk4w" name="FORWARD" sourceRef="ExclusiveGateway_1v05dfs" targetRef="ExclusiveGateway_1fuk0q6">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -212,15 +212,15 @@
     <bpmn:sequenceFlow id="SequenceFlow_0654hf2" sourceRef="ExclusiveGateway_0ytznox" targetRef="ExclusiveGateway_10wtbjv">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "UpdateRefType"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_14azxs6" sourceRef="ExclusiveGateway_1fuk0q6" targetRef="ServiceTask_0lic0m6">
+    <bpmn:sequenceFlow id="SequenceFlow_14azxs6" sourceRef="ExclusiveGateway_1fuk0q6" targetRef="Service_UpdateRefTypeToOfficial_0lic0m6">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_1unkg32" name="Reference Type To Ministerial" camunda:expression="MPAM_REFTYPE_TO_MINISTERIAL" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="Screen_ReferenceTypeToMinisterial_1unkg32" name="Reference Type To Ministerial" camunda:expression="MPAM_REFTYPE_TO_MINISTERIAL" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_1yz68yy</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1uojgpn</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0hgy197</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_0zaqr6s" name="Validate User Input">
+    <bpmn:userTask id="Validate_ReferenceTypeToMinisterial_0zaqr6s" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_0hgy197</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1cz4xuc</bpmn:outgoing>
     </bpmn:userTask>
@@ -234,11 +234,11 @@
       <bpmn:outgoing>SequenceFlow_1tc6caf</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1y4lk7l</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1yz68yy" name="false" sourceRef="ExclusiveGateway_0m7zmvc" targetRef="ServiceTask_1unkg32">
+    <bpmn:sequenceFlow id="SequenceFlow_1yz68yy" name="false" sourceRef="ExclusiveGateway_0m7zmvc" targetRef="Screen_ReferenceTypeToMinisterial_1unkg32">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0hgy197" sourceRef="ServiceTask_1unkg32" targetRef="UserTask_0zaqr6s" />
-    <bpmn:sequenceFlow id="SequenceFlow_1cz4xuc" sourceRef="UserTask_0zaqr6s" targetRef="ExclusiveGateway_0ofzr32" />
+    <bpmn:sequenceFlow id="SequenceFlow_0hgy197" sourceRef="Screen_ReferenceTypeToMinisterial_1unkg32" targetRef="Validate_ReferenceTypeToMinisterial_0zaqr6s" />
+    <bpmn:sequenceFlow id="SequenceFlow_1cz4xuc" sourceRef="Validate_ReferenceTypeToMinisterial_0zaqr6s" targetRef="ExclusiveGateway_0ofzr32" />
     <bpmn:sequenceFlow id="SequenceFlow_1tc6caf" name="FORWARD" sourceRef="ExclusiveGateway_0ofzr32" targetRef="ExclusiveGateway_0m7zmvc">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -247,10 +247,10 @@
       <bpmn:outgoing>SequenceFlow_1m5233h</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1uojgpn</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1m5233h" sourceRef="ExclusiveGateway_10wtbjv" targetRef="ServiceTask_0ia1i5c">
+    <bpmn:sequenceFlow id="SequenceFlow_1m5233h" sourceRef="ExclusiveGateway_10wtbjv" targetRef="Screen_RefTypeToOfficial_0ia1i5c">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${RefType == "Ministerial"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1uojgpn" sourceRef="ExclusiveGateway_10wtbjv" targetRef="ServiceTask_1unkg32">
+    <bpmn:sequenceFlow id="SequenceFlow_1uojgpn" sourceRef="ExclusiveGateway_10wtbjv" targetRef="Screen_ReferenceTypeToMinisterial_1unkg32">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${RefType == "Official"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1y4lk7l" sourceRef="ExclusiveGateway_0ofzr32" targetRef="ServiceTask_0orq4iy">
@@ -262,7 +262,7 @@
       <bpmn:outgoing>SequenceFlow_1pu5xef</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1pkybrv</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1ggfwm6" sourceRef="ExclusiveGateway_0m7zmvc" targetRef="ServiceTask_0urk37h">
+    <bpmn:sequenceFlow id="SequenceFlow_1ggfwm6" sourceRef="ExclusiveGateway_0m7zmvc" targetRef="Service_UpdateRefTypeToMinisterial_0urk37h">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="ServiceTask_1trdh33" name="Increment RefType Update Count" camunda:expression="${bpmnService.updateCount(execution.getVariable(&#34;CaseUUID&#34;),&#34;RefTypeUpdateCount&#34;,1)}">
@@ -272,20 +272,20 @@
     <bpmn:sequenceFlow id="SequenceFlow_1pu5xef" sourceRef="ExclusiveGateway_0324wwr" targetRef="ServiceTask_1trdh33">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${RefTypeCorrection != "Correction"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1pkybrv" name="Correction" sourceRef="ExclusiveGateway_0324wwr" targetRef="Activity_1yc1ce2">
+    <bpmn:sequenceFlow id="SequenceFlow_1pkybrv" name="Correction" sourceRef="ExclusiveGateway_0324wwr" targetRef="Service_SaveRefTypeChangeCaseNote_1yc1ce2">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${RefTypeCorrection == "Correction"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_0lic0m6" name="Update RefType To Official" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;RefType&#34;, &#34;Official&#34;, &#34;RefTypeStatus&#34;, &#34;Confirm&#34;)}">
+    <bpmn:serviceTask id="Service_UpdateRefTypeToOfficial_0lic0m6" name="Update RefType To Official" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;RefType&#34;, &#34;Official&#34;, &#34;RefTypeStatus&#34;, &#34;Confirm&#34;)}">
       <bpmn:incoming>SequenceFlow_14azxs6</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_11x8a2s</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="ServiceTask_0urk37h" name="Update RefType To Ministerial" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;RefType&#34;, &#34;Ministerial&#34;, &#34;RefTypeStatus&#34;, &#34;Confirm&#34;)}">
+    <bpmn:serviceTask id="Service_UpdateRefTypeToMinisterial_0urk37h" name="Update RefType To Ministerial" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;RefType&#34;, &#34;Ministerial&#34;, &#34;RefTypeStatus&#34;, &#34;Confirm&#34;)}">
       <bpmn:incoming>SequenceFlow_1ggfwm6</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_171hy6u</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_11x8a2s" sourceRef="ServiceTask_0lic0m6" targetRef="ServiceTask_0xqy6p5" />
-    <bpmn:sequenceFlow id="SequenceFlow_171hy6u" sourceRef="ServiceTask_0urk37h" targetRef="ExclusiveGateway_0324wwr" />
-    <bpmn:sequenceFlow id="SequenceFlow_0jenwmy" sourceRef="ServiceTask_1trdh33" targetRef="Activity_1yc1ce2" />
+    <bpmn:sequenceFlow id="SequenceFlow_11x8a2s" sourceRef="Service_UpdateRefTypeToOfficial_0lic0m6" targetRef="Service_ClearMinisterialValues_0xqy6p5" />
+    <bpmn:sequenceFlow id="SequenceFlow_171hy6u" sourceRef="Service_UpdateRefTypeToMinisterial_0urk37h" targetRef="ExclusiveGateway_0324wwr" />
+    <bpmn:sequenceFlow id="SequenceFlow_0jenwmy" sourceRef="ServiceTask_1trdh33" targetRef="Service_SaveRefTypeChangeCaseNote_1yc1ce2" />
     <bpmn:serviceTask id="ServiceTask_1blck00" name="Request Campaign" camunda:expression="MPAM_CAMPAIGN_REQUEST" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_0a5r7ra</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0zrzm62</bpmn:incoming>
@@ -419,12 +419,12 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION != "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1cv2gqf" sourceRef="ServiceTask_10701e0" targetRef="EndEvent_168jcnt" />
-    <bpmn:serviceTask id="Activity_1yc1ce2" name="Save Ref Type Change Case Note" camunda:expression="${bpmnService.createCaseConversionNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_TriageChangeCaseType&#34;))}">
+    <bpmn:serviceTask id="Service_SaveRefTypeChangeCaseNote_1yc1ce2" name="Save Ref Type Change Case Note" camunda:expression="${bpmnService.createCaseConversionNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_TriageChangeCaseType&#34;))}">
       <bpmn:incoming>SequenceFlow_1pkybrv</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0jenwmy</bpmn:incoming>
       <bpmn:outgoing>Flow_0d0qvpw</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0d0qvpw" sourceRef="Activity_1yc1ce2" targetRef="ServiceTask_02f5ipq" />
+    <bpmn:sequenceFlow id="Flow_0d0qvpw" sourceRef="Service_SaveRefTypeChangeCaseNote_1yc1ce2" targetRef="ServiceTask_02f5ipq" />
     <bpmn:sequenceFlow id="Flow_08196yy" name="Close Case (Telephone)" sourceRef="Gateway_0b9xe9y" targetRef="Activity_0pt85ju">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus == "CloseCaseTelephone"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -474,11 +474,11 @@
     <bpmn:sequenceFlow id="Flow_06gx7kj" sourceRef="Gateway_0b9xe9y" targetRef="ExclusiveGateway_0vqlqgx">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus != "CloseCaseTelephone"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_0xqy6p5" name="Clear Ministerial values" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;MinSignOffTeam&#34;, &#34;Addressee&#34;)}">
+    <bpmn:serviceTask id="Service_ClearMinisterialValues_0xqy6p5" name="Clear Ministerial values" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;MinSignOffTeam&#34;, &#34;Addressee&#34;)}">
       <bpmn:incoming>SequenceFlow_11x8a2s</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1lhbixe</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_1lhbixe" sourceRef="ServiceTask_0xqy6p5" targetRef="ExclusiveGateway_0324wwr" />
+    <bpmn:sequenceFlow id="SequenceFlow_1lhbixe" sourceRef="Service_ClearMinisterialValues_0xqy6p5" targetRef="ExclusiveGateway_0324wwr" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_DRAFT">
@@ -941,7 +941,7 @@
       <bpmndi:BPMNShape id="ServiceTask_0orq4iy_di" bpmnElement="ServiceTask_0orq4iy">
         <dc:Bounds x="363" y="1537" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_00s8k9f_di" bpmnElement="UserTask_00s8k9f">
+      <bpmndi:BPMNShape id="UserTask_00s8k9f_di" bpmnElement="Validate_UserInput_00s8k9f">
         <dc:Bounds x="363" y="1700" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0urib3x_di" bpmnElement="ExclusiveGateway_0urib3x" isMarkerVisible="true">
@@ -1013,10 +1013,10 @@
           <dc:Bounds x="625" y="1733" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0ia1i5c_di" bpmnElement="ServiceTask_0ia1i5c">
+      <bpmndi:BPMNShape id="ServiceTask_0ia1i5c_di" bpmnElement="Screen_RefTypeToOfficial_0ia1i5c">
         <dc:Bounds x="741" y="2537" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_08l10xy_di" bpmnElement="UserTask_08l10xy">
+      <bpmndi:BPMNShape id="UserTask_08l10xy_di" bpmnElement="Validate_RefTypeToOfficial_08l10xy">
         <dc:Bounds x="741" y="2700" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1fuk0q6_di" bpmnElement="ExclusiveGateway_1fuk0q6" isMarkerVisible="true">
@@ -1028,10 +1028,10 @@
           <dc:Bounds x="950" y="2756" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1unkg32_di" bpmnElement="ServiceTask_1unkg32">
+      <bpmndi:BPMNShape id="ServiceTask_1unkg32_di" bpmnElement="Screen_ReferenceTypeToMinisterial_1unkg32">
         <dc:Bounds x="741" y="2214" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_0zaqr6s_di" bpmnElement="UserTask_0zaqr6s">
+      <bpmndi:BPMNShape id="UserTask_0zaqr6s_di" bpmnElement="Validate_ReferenceTypeToMinisterial_0zaqr6s">
         <dc:Bounds x="741" y="2377" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0m7zmvc_di" bpmnElement="ExclusiveGateway_0m7zmvc" isMarkerVisible="true">
@@ -1052,10 +1052,10 @@
       <bpmndi:BPMNShape id="ServiceTask_1trdh33_di" bpmnElement="ServiceTask_1trdh33">
         <dc:Bounds x="1354" y="2297" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0lic0m6_di" bpmnElement="ServiceTask_0lic0m6">
+      <bpmndi:BPMNShape id="ServiceTask_0lic0m6_di" bpmnElement="Service_UpdateRefTypeToOfficial_0lic0m6">
         <dc:Bounds x="1062" y="2620" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0urk37h_di" bpmnElement="ServiceTask_0urk37h">
+      <bpmndi:BPMNShape id="ServiceTask_0urk37h_di" bpmnElement="Service_UpdateRefTypeToMinisterial_0urk37h">
         <dc:Bounds x="1062" y="2297" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1blck00_di" bpmnElement="ServiceTask_1blck00">
@@ -1118,7 +1118,7 @@
       <bpmndi:BPMNShape id="Activity_1kt4ox6_di" bpmnElement="ServiceTask_1kt4ox6">
         <dc:Bounds x="1201" y="280" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1yc1ce2_di" bpmnElement="Activity_1yc1ce2">
+      <bpmndi:BPMNShape id="Activity_1yc1ce2_di" bpmnElement="Service_SaveRefTypeChangeCaseNote_1yc1ce2">
         <dc:Bounds x="1210" y="2080" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1hczk36_di" bpmnElement="Activity_1hczk36">
@@ -1139,7 +1139,7 @@
       <bpmndi:BPMNShape id="Gateway_0b9xe9y_di" bpmnElement="Gateway_0b9xe9y" isMarkerVisible="true">
         <dc:Bounds x="875" y="1635" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0xqy6p5_di" bpmnElement="ServiceTask_0xqy6p5">
+      <bpmndi:BPMNShape id="ServiceTask_0xqy6p5_di" bpmnElement="Service_ClearMinisterialValues_0xqy6p5">
         <dc:Bounds x="1210" y="2537" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_1lhbixe_di" bpmnElement="SequenceFlow_1lhbixe">

--- a/src/main/resources/processes/MPAM_TRIAGE.bpmn
+++ b/src/main/resources/processes/MPAM_TRIAGE.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ixf2kb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ixf2kb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.2">
   <bpmn:process id="MPAM_TRIAGE" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_0x8dpmn</bpmn:outgoing>
@@ -341,7 +341,7 @@
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_0d3wc9s">
       <bpmn:incoming>SequenceFlow_18rq3r1</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_10jivty</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_00sgdbb</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_17gv9sk</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0pqrbfz</bpmn:outgoing>
     </bpmn:exclusiveGateway>
@@ -358,7 +358,7 @@
       <bpmn:outgoing>SequenceFlow_10jivty</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_18rq3r1" sourceRef="ServiceTask_0ai6870" targetRef="ExclusiveGateway_0d3wc9s" />
-    <bpmn:sequenceFlow id="SequenceFlow_10jivty" sourceRef="ServiceTask_07vhlhy" targetRef="ExclusiveGateway_0d3wc9s" />
+    <bpmn:sequenceFlow id="SequenceFlow_10jivty" sourceRef="ServiceTask_07vhlhy" targetRef="ServiceTask_05l3eed" />
     <bpmn:sequenceFlow id="SequenceFlow_17gv9sk" name="Correction" sourceRef="ExclusiveGateway_0d3wc9s" targetRef="Activity_1sobox0">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${RefTypeCorrection == "Correction"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -524,15 +524,19 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_19ce18n" sourceRef="Activity_1rzz5vn" targetRef="EndEvent_1golwf2" />
+    <bpmn:serviceTask id="ServiceTask_05l3eed" name="Clear Ministerial values" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;MinSignOffTeam&#34;, &#34;Addressee&#34;)}">
+      <bpmn:incoming>SequenceFlow_10jivty</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_00sgdbb</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_00sgdbb" sourceRef="ServiceTask_05l3eed" targetRef="ExclusiveGateway_0d3wc9s" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_TRIAGE">
       <bpmndi:BPMNEdge id="Flow_19ce18n_di" bpmnElement="Flow_19ce18n">
-        <di:waypoint x="810" y="193" />
-        <di:waypoint x="810" y="40" />
-        <di:waypoint x="2370" y="40" />
-        <di:waypoint x="2370" y="370" />
-        <di:waypoint x="2350" y="621" />
+        <di:waypoint x="759" y="139" />
+        <di:waypoint x="759" y="40" />
+        <di:waypoint x="2349" y="40" />
+        <di:waypoint x="2349" y="621" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1gxj9d4_di" bpmnElement="Flow_1gxj9d4">
         <di:waypoint x="570" y="368" />
@@ -549,8 +553,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0eb5pgl_di" bpmnElement="Flow_0eb5pgl">
         <di:waypoint x="490" y="318" />
-        <di:waypoint x="490" y="163" />
-        <di:waypoint x="720" y="216" />
+        <di:waypoint x="490" y="174" />
+        <di:waypoint x="709" y="174" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1lrv0lg_di" bpmnElement="Flow_1lrv0lg">
         <di:waypoint x="490" y="368" />
@@ -576,8 +580,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ksl1cg_di" bpmnElement="SequenceFlow_0ksl1cg">
         <di:waypoint x="1520" y="150" />
-        <di:waypoint x="1520" y="110" />
-        <di:waypoint x="2349" y="110" />
+        <di:waypoint x="1520" y="40" />
+        <di:waypoint x="2349" y="40" />
         <di:waypoint x="2349" y="621" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0sk755u_di" bpmnElement="SequenceFlow_0sk755u">
@@ -675,7 +679,7 @@
         <di:waypoint x="1744" y="1167" />
         <di:waypoint x="1744" y="1110" />
         <di:waypoint x="1598" y="1110" />
-        <di:waypoint x="1598" y="1060" />
+        <di:waypoint x="1598" y="1050" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0pqrbfz_di" bpmnElement="SequenceFlow_0pqrbfz">
         <di:waypoint x="1623" y="1207" />
@@ -689,61 +693,61 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_10jivty_di" bpmnElement="SequenceFlow_10jivty">
+        <di:waypoint x="1502" y="1548" />
+        <di:waypoint x="1598" y="1548" />
+        <di:waypoint x="1598" y="1505" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_18rq3r1_di" bpmnElement="SequenceFlow_18rq3r1">
         <di:waypoint x="1502" y="1207" />
         <di:waypoint x="1573" y="1207" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_18rq3r1_di" bpmnElement="SequenceFlow_18rq3r1">
-        <di:waypoint x="1502" y="1546" />
-        <di:waypoint x="1598" y="1546" />
-        <di:waypoint x="1598" y="1232" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1xbbggi_di" bpmnElement="SequenceFlow_1xbbggi">
-        <di:waypoint x="1338" y="1546" />
-        <di:waypoint x="1402" y="1546" />
+        <di:waypoint x="1338" y="1207" />
+        <di:waypoint x="1402" y="1207" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_03cktte_di" bpmnElement="SequenceFlow_03cktte">
-        <di:waypoint x="1313" y="1651" />
-        <di:waypoint x="1313" y="1721" />
-        <di:waypoint x="318" y="1721" />
+        <di:waypoint x="1313" y="1312" />
+        <di:waypoint x="1313" y="1373" />
+        <di:waypoint x="318" y="1373" />
         <di:waypoint x="318" y="556" />
         <di:waypoint x="380" y="556" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0475c6m_di" bpmnElement="SequenceFlow_0475c6m">
-        <di:waypoint x="920" y="1149" />
-        <di:waypoint x="920" y="1463" />
-        <di:waypoint x="1114" y="1463" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1wx2cqk_di" bpmnElement="SequenceFlow_1wx2cqk">
         <di:waypoint x="945" y="1124" />
         <di:waypoint x="1114" y="1124" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1wx2cqk_di" bpmnElement="SequenceFlow_1wx2cqk">
+        <di:waypoint x="920" y="1149" />
+        <di:waypoint x="920" y="1465" />
+        <di:waypoint x="1114" y="1465" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1ixqf2u_di" bpmnElement="SequenceFlow_1ixqf2u">
-        <di:waypoint x="1313" y="1601" />
-        <di:waypoint x="1313" y="1571" />
+        <di:waypoint x="1313" y="1262" />
+        <di:waypoint x="1313" y="1232" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1317" y="1585" width="57" height="14" />
+          <dc:Bounds x="1317" y="1246" width="57" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0ql7g2b_di" bpmnElement="SequenceFlow_0ql7g2b">
-        <di:waypoint x="1214" y="1626" />
-        <di:waypoint x="1288" y="1626" />
+        <di:waypoint x="1214" y="1287" />
+        <di:waypoint x="1288" y="1287" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0tmi8ht_di" bpmnElement="SequenceFlow_0tmi8ht">
-        <di:waypoint x="1164" y="1503" />
-        <di:waypoint x="1164" y="1586" />
+        <di:waypoint x="1164" y="1164" />
+        <di:waypoint x="1164" y="1247" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_02pvi73_di" bpmnElement="SequenceFlow_02pvi73">
-        <di:waypoint x="1313" y="1521" />
-        <di:waypoint x="1313" y="1463" />
-        <di:waypoint x="1214" y="1463" />
+        <di:waypoint x="1313" y="1182" />
+        <di:waypoint x="1313" y="1124" />
+        <di:waypoint x="1214" y="1124" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1301" y="1445" width="24" height="14" />
+          <dc:Bounds x="1301" y="1106" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0roihnf_di" bpmnElement="SequenceFlow_0roihnf">
-        <di:waypoint x="1313" y="1312" />
-        <di:waypoint x="1313" y="1370" />
-        <di:waypoint x="318" y="1370" />
+        <di:waypoint x="1313" y="1653" />
+        <di:waypoint x="1313" y="1732" />
+        <di:waypoint x="318" y="1732" />
         <di:waypoint x="318" y="556" />
         <di:waypoint x="380" y="556" />
       </bpmndi:BPMNEdge>
@@ -756,30 +760,30 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1jh4a7z_di" bpmnElement="SequenceFlow_1jh4a7z">
-        <di:waypoint x="1338" y="1207" />
-        <di:waypoint x="1402" y="1207" />
+        <di:waypoint x="1338" y="1548" />
+        <di:waypoint x="1402" y="1548" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_04q8hta_di" bpmnElement="SequenceFlow_04q8hta">
-        <di:waypoint x="1313" y="1262" />
-        <di:waypoint x="1313" y="1232" />
+        <di:waypoint x="1313" y="1603" />
+        <di:waypoint x="1313" y="1573" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1317" y="1246" width="57" height="14" />
+          <dc:Bounds x="1317" y="1587" width="57" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1uld9m0_di" bpmnElement="SequenceFlow_1uld9m0">
-        <di:waypoint x="1214" y="1287" />
-        <di:waypoint x="1288" y="1287" />
+        <di:waypoint x="1214" y="1628" />
+        <di:waypoint x="1288" y="1628" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1bn197j_di" bpmnElement="SequenceFlow_1bn197j">
-        <di:waypoint x="1164" y="1164" />
-        <di:waypoint x="1164" y="1247" />
+        <di:waypoint x="1164" y="1505" />
+        <di:waypoint x="1164" y="1588" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1eauv06_di" bpmnElement="SequenceFlow_1eauv06">
-        <di:waypoint x="1313" y="1182" />
-        <di:waypoint x="1313" y="1124" />
-        <di:waypoint x="1214" y="1124" />
+        <di:waypoint x="1313" y="1523" />
+        <di:waypoint x="1313" y="1465" />
+        <di:waypoint x="1214" y="1465" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1301" y="1106" width="24" height="14" />
+          <dc:Bounds x="1301" y="1447" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1mlhuzu_di" bpmnElement="SequenceFlow_1mlhuzu">
@@ -842,8 +846,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1bypsoj_di" bpmnElement="SequenceFlow_1bypsoj">
         <di:waypoint x="1058" y="154" />
-        <di:waypoint x="1058" y="81" />
-        <di:waypoint x="430" y="81" />
+        <di:waypoint x="1058" y="80" />
+        <di:waypoint x="430" y="80" />
         <di:waypoint x="430" y="516" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0cjqztr_di" bpmnElement="SequenceFlow_0cjqztr">
@@ -852,8 +856,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_10u8lqt_di" bpmnElement="SequenceFlow_10u8lqt">
         <di:waypoint x="1274" y="139" />
-        <di:waypoint x="1274" y="110" />
-        <di:waypoint x="2349" y="110" />
+        <di:waypoint x="1274" y="40" />
+        <di:waypoint x="2349" y="40" />
         <di:waypoint x="2349" y="621" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0rbinee_di" bpmnElement="SequenceFlow_0rbinee">
@@ -1162,33 +1166,33 @@
         <dc:Bounds x="1548" y="841" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0pxyggg_di" bpmnElement="ServiceTask_0pxyggg">
-        <dc:Bounds x="1114" y="1084" width="100" height="80" />
+        <dc:Bounds x="1114" y="1425" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0ai1ek7_di" bpmnElement="UserTask_0ai1ek7">
-        <dc:Bounds x="1114" y="1247" width="100" height="80" />
+        <dc:Bounds x="1114" y="1588" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_04rfedk_di" bpmnElement="ExclusiveGateway_04rfedk" isMarkerVisible="true">
-        <dc:Bounds x="1288" y="1182" width="50" height="50" />
+        <dc:Bounds x="1288" y="1523" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0lgtxxn_di" bpmnElement="ExclusiveGateway_0lgtxxn" isMarkerVisible="true">
-        <dc:Bounds x="1288" y="1262" width="50" height="50" />
+        <dc:Bounds x="1288" y="1603" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1348" y="1280" width="78" height="14" />
+          <dc:Bounds x="1348" y="1621" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1c5qr22_di" bpmnElement="ServiceTask_1c5qr22">
-        <dc:Bounds x="1114" y="1423" width="100" height="80" />
+        <dc:Bounds x="1114" y="1084" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0k42bt1_di" bpmnElement="UserTask_0k42bt1">
-        <dc:Bounds x="1114" y="1586" width="100" height="80" />
+        <dc:Bounds x="1114" y="1247" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0z4gzdc_di" bpmnElement="ExclusiveGateway_0z4gzdc" isMarkerVisible="true">
-        <dc:Bounds x="1288" y="1521" width="50" height="50" />
+        <dc:Bounds x="1288" y="1182" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0tzco2c_di" bpmnElement="ExclusiveGateway_0tzco2c" isMarkerVisible="true">
-        <dc:Bounds x="1288" y="1601" width="50" height="50" />
+        <dc:Bounds x="1288" y="1262" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1348" y="1619" width="78" height="14" />
+          <dc:Bounds x="1348" y="1280" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_02jphpz_di" bpmnElement="ExclusiveGateway_02jphpz" isMarkerVisible="true">
@@ -1201,10 +1205,10 @@
         <dc:Bounds x="1694" y="1167" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0ai6870_di" bpmnElement="ServiceTask_0ai6870">
-        <dc:Bounds x="1402" y="1506" width="100" height="80" />
+        <dc:Bounds x="1402" y="1167" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_07vhlhy_di" bpmnElement="ServiceTask_07vhlhy">
-        <dc:Bounds x="1402" y="1167" width="100" height="80" />
+        <dc:Bounds x="1402" y="1508" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0011raj_di" bpmnElement="ServiceTask_0011raj">
         <dc:Bounds x="1707" y="376" width="100" height="80" />
@@ -1273,11 +1277,18 @@
         <dc:Bounds x="545" y="318" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1rzz5vn_di" bpmnElement="Activity_1rzz5vn">
-        <dc:Bounds x="720" y="193" width="100" height="80" />
+        <dc:Bounds x="709" y="139" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1g01f59_di" bpmnElement="Gateway_1g01f59" isMarkerVisible="true">
         <dc:Bounds x="835" y="614" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_05l3eed_di" bpmnElement="ServiceTask_05l3eed">
+        <dc:Bounds x="1548" y="1425" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_00sgdbb_di" bpmnElement="SequenceFlow_00sgdbb">
+        <di:waypoint x="1598" y="1425" />
+        <di:waypoint x="1598" y="1232" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/processes/MPAM_TRIAGE.bpmn
+++ b/src/main/resources/processes/MPAM_TRIAGE.bpmn
@@ -4,7 +4,7 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_0x8dpmn</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:serviceTask id="ServiceTask_05nlmnl" name="User Input" camunda:expression="MPAM_TRIAGE_INPUT" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="Screen_UserInput_05nlmnl" name="User Input" camunda:expression="MPAM_TRIAGE_INPUT" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_06v8hsn</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1m917qi</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0x8dpmn</bpmn:incoming>
@@ -19,7 +19,7 @@
       <bpmn:incoming>Flow_1gxj9d4</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_16wwh9z</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_0jxw8et" name="Validate User Input">
+    <bpmn:userTask id="Validate_UserInput_0jxw8et" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_16wwh9z</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1da9mhc</bpmn:outgoing>
     </bpmn:userTask>
@@ -37,15 +37,15 @@
       <bpmn:incoming>SequenceFlow_0ksl1cg</bpmn:incoming>
       <bpmn:incoming>Flow_19ce18n</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_06v8hsn" name="false" sourceRef="ExclusiveGateway_13qjvzx" targetRef="ServiceTask_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_06v8hsn" name="false" sourceRef="ExclusiveGateway_13qjvzx" targetRef="Screen_UserInput_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_16wwh9z" sourceRef="ServiceTask_05nlmnl" targetRef="UserTask_0jxw8et" />
-    <bpmn:sequenceFlow id="SequenceFlow_1da9mhc" sourceRef="UserTask_0jxw8et" targetRef="ExclusiveGateway_08l5d8b" />
+    <bpmn:sequenceFlow id="SequenceFlow_16wwh9z" sourceRef="Screen_UserInput_05nlmnl" targetRef="Validate_UserInput_0jxw8et" />
+    <bpmn:sequenceFlow id="SequenceFlow_1da9mhc" sourceRef="Validate_UserInput_0jxw8et" targetRef="ExclusiveGateway_08l5d8b" />
     <bpmn:sequenceFlow id="SequenceFlow_1co3k2r" sourceRef="ExclusiveGateway_13qjvzx" targetRef="ExclusiveGateway_0p3mwpr">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0x8dpmn" sourceRef="StartEvent_1" targetRef="ServiceTask_05nlmnl" />
+    <bpmn:sequenceFlow id="SequenceFlow_0x8dpmn" sourceRef="StartEvent_1" targetRef="Screen_UserInput_05nlmnl" />
     <bpmn:serviceTask id="ServiceTask_1ds9yik" name="Update Team for Draft" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_DRAFT&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
       <bpmn:incoming>SequenceFlow_102vcza</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0kcq8md</bpmn:outgoing>
@@ -59,7 +59,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_10l93df" name="else" sourceRef="ExclusiveGateway_0p3mwpr" targetRef="Gateway_1g01f59">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageOutcome != "Pending"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1m917qi" name="pending" sourceRef="ExclusiveGateway_0p3mwpr" targetRef="ServiceTask_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_1m917qi" name="pending" sourceRef="ExclusiveGateway_0p3mwpr" targetRef="Screen_UserInput_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageOutcome == "Pending"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_1ivf0n0" name="TriageOutcome?">
@@ -156,12 +156,12 @@
       <bpmn:incoming>SequenceFlow_1enm75p</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1sq5itz</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_1sq5itz" sourceRef="ServiceTask_060ccpx" targetRef="ServiceTask_05nlmnl" />
+    <bpmn:sequenceFlow id="SequenceFlow_1sq5itz" sourceRef="ServiceTask_060ccpx" targetRef="Screen_UserInput_05nlmnl" />
     <bpmn:serviceTask id="ServiceTask_0hpe5ym" name="Clear Temp Enquiry Subject" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;tempEnquirySubject&#34;)}">
       <bpmn:incoming>SequenceFlow_0enh4xh</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1101m5b</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_1101m5b" sourceRef="ServiceTask_0hpe5ym" targetRef="ServiceTask_05nlmnl" />
+    <bpmn:sequenceFlow id="SequenceFlow_1101m5b" sourceRef="ServiceTask_0hpe5ym" targetRef="Screen_UserInput_05nlmnl" />
     <bpmn:sequenceFlow id="SequenceFlow_1enm75p" name="BACKWARD" sourceRef="ExclusiveGateway_1iftjr8" targetRef="ServiceTask_060ccpx">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -203,7 +203,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_0cjqztr" sourceRef="ExclusiveGateway_05idho6" targetRef="ExclusiveGateway_08miue5">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1bypsoj" sourceRef="ExclusiveGateway_05idho6" targetRef="ServiceTask_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_1bypsoj" sourceRef="ExclusiveGateway_05idho6" targetRef="Screen_UserInput_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_08miue5">
@@ -253,18 +253,18 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_108azcx" sourceRef="ServiceTask_04cd41z" targetRef="EndEvent_1golwf2" />
-    <bpmn:sequenceFlow id="SequenceFlow_0j5xv9g" name="BACKWARD" sourceRef="ExclusiveGateway_03cn7o8" targetRef="ServiceTask_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_0j5xv9g" name="BACKWARD" sourceRef="ExclusiveGateway_03cn7o8" targetRef="Screen_UserInput_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1mlhuzu" name="UpdateBusinessArea" sourceRef="ExclusiveGateway_08l5d8b" targetRef="ServiceTask_06e7e59">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "UpdateBusinessArea"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_0pxyggg" name="Reference Type To Official" camunda:expression="MPAM_REFTYPE_TO_OFFICIAL" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="Screen_ReferenceTypeToOfficial_0pxyggg" name="Reference Type To Official" camunda:expression="MPAM_REFTYPE_TO_OFFICIAL" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_1eauv06</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1wx2cqk</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1bn197j</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_0ai1ek7" name="Validate User Input">
+    <bpmn:userTask id="Validate_ReferenceTypeToOfficial_0ai1ek7" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_1bn197j</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1uld9m0</bpmn:outgoing>
     </bpmn:userTask>
@@ -278,29 +278,29 @@
       <bpmn:outgoing>SequenceFlow_04q8hta</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0roihnf</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1eauv06" name="false" sourceRef="ExclusiveGateway_04rfedk" targetRef="ServiceTask_0pxyggg">
+    <bpmn:sequenceFlow id="SequenceFlow_1eauv06" name="false" sourceRef="ExclusiveGateway_04rfedk" targetRef="Screen_ReferenceTypeToOfficial_0pxyggg">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1bn197j" sourceRef="ServiceTask_0pxyggg" targetRef="UserTask_0ai1ek7" />
-    <bpmn:sequenceFlow id="SequenceFlow_1uld9m0" sourceRef="UserTask_0ai1ek7" targetRef="ExclusiveGateway_0lgtxxn" />
+    <bpmn:sequenceFlow id="SequenceFlow_1bn197j" sourceRef="Screen_ReferenceTypeToOfficial_0pxyggg" targetRef="Validate_ReferenceTypeToOfficial_0ai1ek7" />
+    <bpmn:sequenceFlow id="SequenceFlow_1uld9m0" sourceRef="Validate_ReferenceTypeToOfficial_0ai1ek7" targetRef="ExclusiveGateway_0lgtxxn" />
     <bpmn:sequenceFlow id="SequenceFlow_04q8hta" name="FORWARD" sourceRef="ExclusiveGateway_0lgtxxn" targetRef="ExclusiveGateway_04rfedk">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1jh4a7z" sourceRef="ExclusiveGateway_04rfedk" targetRef="ServiceTask_07vhlhy">
+    <bpmn:sequenceFlow id="SequenceFlow_1jh4a7z" sourceRef="ExclusiveGateway_04rfedk" targetRef="Service_UpdateRefTypeToOfficial_07vhlhy">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0nrrrl7" name="UpdateRefType" sourceRef="ExclusiveGateway_08l5d8b" targetRef="ExclusiveGateway_02jphpz">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "UpdateRefType"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0roihnf" sourceRef="ExclusiveGateway_0lgtxxn" targetRef="ServiceTask_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_0roihnf" sourceRef="ExclusiveGateway_0lgtxxn" targetRef="Screen_UserInput_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_1c5qr22" name="Reference Type To Ministerial" camunda:expression="MPAM_REFTYPE_TO_MINISTERIAL" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="Screen_ReferenceTypeToMinisterial_1c5qr22" name="Reference Type To Ministerial" camunda:expression="MPAM_REFTYPE_TO_MINISTERIAL" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_02pvi73</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0475c6m</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0tmi8ht</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_0k42bt1" name="Validate User Input">
+    <bpmn:userTask id="Validate_ReferenceTypeToMinisterial_0k42bt1" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_0tmi8ht</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0ql7g2b</bpmn:outgoing>
     </bpmn:userTask>
@@ -314,11 +314,11 @@
       <bpmn:outgoing>SequenceFlow_1ixqf2u</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_03cktte</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_02pvi73" name="false" sourceRef="ExclusiveGateway_0z4gzdc" targetRef="ServiceTask_1c5qr22">
+    <bpmn:sequenceFlow id="SequenceFlow_02pvi73" name="false" sourceRef="ExclusiveGateway_0z4gzdc" targetRef="Screen_ReferenceTypeToMinisterial_1c5qr22">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0tmi8ht" sourceRef="ServiceTask_1c5qr22" targetRef="UserTask_0k42bt1" />
-    <bpmn:sequenceFlow id="SequenceFlow_0ql7g2b" sourceRef="UserTask_0k42bt1" targetRef="ExclusiveGateway_0tzco2c" />
+    <bpmn:sequenceFlow id="SequenceFlow_0tmi8ht" sourceRef="Screen_ReferenceTypeToMinisterial_1c5qr22" targetRef="Validate_ReferenceTypeToMinisterial_0k42bt1" />
+    <bpmn:sequenceFlow id="SequenceFlow_0ql7g2b" sourceRef="Validate_ReferenceTypeToMinisterial_0k42bt1" targetRef="ExclusiveGateway_0tzco2c" />
     <bpmn:sequenceFlow id="SequenceFlow_1ixqf2u" name="FORWARD" sourceRef="ExclusiveGateway_0tzco2c" targetRef="ExclusiveGateway_0z4gzdc">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -327,16 +327,16 @@
       <bpmn:outgoing>SequenceFlow_1wx2cqk</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0475c6m</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1wx2cqk" sourceRef="ExclusiveGateway_02jphpz" targetRef="ServiceTask_0pxyggg">
+    <bpmn:sequenceFlow id="SequenceFlow_1wx2cqk" sourceRef="ExclusiveGateway_02jphpz" targetRef="Screen_ReferenceTypeToOfficial_0pxyggg">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${RefType == "Ministerial"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0475c6m" sourceRef="ExclusiveGateway_02jphpz" targetRef="ServiceTask_1c5qr22">
+    <bpmn:sequenceFlow id="SequenceFlow_0475c6m" sourceRef="ExclusiveGateway_02jphpz" targetRef="Screen_ReferenceTypeToMinisterial_1c5qr22">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${RefType == "Official"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_03cktte" sourceRef="ExclusiveGateway_0tzco2c" targetRef="ServiceTask_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_03cktte" sourceRef="ExclusiveGateway_0tzco2c" targetRef="Screen_UserInput_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1xbbggi" sourceRef="ExclusiveGateway_0z4gzdc" targetRef="ServiceTask_0ai6870">
+    <bpmn:sequenceFlow id="SequenceFlow_1xbbggi" sourceRef="ExclusiveGateway_0z4gzdc" targetRef="Service_UpdateRefTypeToMinisterial_0ai6870">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_0d3wc9s">
@@ -349,23 +349,23 @@
       <bpmn:incoming>SequenceFlow_0pqrbfz</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0cz2azb</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="ServiceTask_0ai6870" name="Update RefType To Ministerial" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;RefType&#34;, &#34;Ministerial&#34;, &#34;RefTypeStatus&#34;, &#34;Confirm&#34;)}">
+    <bpmn:serviceTask id="Service_UpdateRefTypeToMinisterial_0ai6870" name="Update RefType To Ministerial" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;RefType&#34;, &#34;Ministerial&#34;, &#34;RefTypeStatus&#34;, &#34;Confirm&#34;)}">
       <bpmn:incoming>SequenceFlow_1xbbggi</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_18rq3r1</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="ServiceTask_07vhlhy" name="Update RefType To Official" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;RefType&#34;, &#34;Official&#34;, &#34;RefTypeStatus&#34;, &#34;Confirm&#34;)}">
+    <bpmn:serviceTask id="Service_UpdateRefTypeToOfficial_07vhlhy" name="Update RefType To Official" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;RefType&#34;, &#34;Official&#34;, &#34;RefTypeStatus&#34;, &#34;Confirm&#34;)}">
       <bpmn:incoming>SequenceFlow_1jh4a7z</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_10jivty</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_18rq3r1" sourceRef="ServiceTask_0ai6870" targetRef="ExclusiveGateway_0d3wc9s" />
-    <bpmn:sequenceFlow id="SequenceFlow_10jivty" sourceRef="ServiceTask_07vhlhy" targetRef="ServiceTask_05l3eed" />
-    <bpmn:sequenceFlow id="SequenceFlow_17gv9sk" name="Correction" sourceRef="ExclusiveGateway_0d3wc9s" targetRef="Activity_1sobox0">
+    <bpmn:sequenceFlow id="SequenceFlow_18rq3r1" sourceRef="Service_UpdateRefTypeToMinisterial_0ai6870" targetRef="ExclusiveGateway_0d3wc9s" />
+    <bpmn:sequenceFlow id="SequenceFlow_10jivty" sourceRef="Service_UpdateRefTypeToOfficial_07vhlhy" targetRef="Service_ClearMinisterialValues_05l3eed" />
+    <bpmn:sequenceFlow id="SequenceFlow_17gv9sk" name="Correction" sourceRef="ExclusiveGateway_0d3wc9s" targetRef="Service_SaveRefTypeChangeCaseNote_1sobox0">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${RefTypeCorrection == "Correction"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0pqrbfz" sourceRef="ExclusiveGateway_0d3wc9s" targetRef="ServiceTask_0j4b6pe">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${RefTypeCorrection != "Correction"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0cz2azb" sourceRef="ServiceTask_0j4b6pe" targetRef="Activity_1sobox0" />
+    <bpmn:sequenceFlow id="SequenceFlow_0cz2azb" sourceRef="ServiceTask_0j4b6pe" targetRef="Service_SaveRefTypeChangeCaseNote_1sobox0" />
     <bpmn:serviceTask id="ServiceTask_0011raj" name="Request Campaign" camunda:expression="MPAM_CAMPAIGN_REQUEST" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_1d5y4cw</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0cc989h</bpmn:incoming>
@@ -404,7 +404,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_094r7km" name="PutOnCampaign" sourceRef="ExclusiveGateway_0mmxl4e" targetRef="ServiceTask_1uwrjca">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageOutcome == "PutOnCampaign"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_09fnnt9" sourceRef="ExclusiveGateway_0sd09rb" targetRef="ServiceTask_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_09fnnt9" sourceRef="ExclusiveGateway_0sd09rb" targetRef="Screen_UserInput_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1legare" sourceRef="ExclusiveGateway_13i24qr" targetRef="ServiceTask_1t6qiuf">
@@ -465,16 +465,16 @@
     <bpmn:sequenceFlow id="SequenceFlow_11xj7za" sourceRef="ExclusiveGateway_0rfbi5i" targetRef="ServiceTask_0b7jhew">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0sk755u" sourceRef="ExclusiveGateway_0o1sjlo" targetRef="ServiceTask_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_0sk755u" sourceRef="ExclusiveGateway_0o1sjlo" targetRef="Screen_UserInput_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0ksl1cg" sourceRef="ServiceTask_1bkf5fp" targetRef="EndEvent_1golwf2" />
-    <bpmn:serviceTask id="Activity_1sobox0" name="Save Ref Type Change Case Note" camunda:expression="${bpmnService.createCaseConversionNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_TriageChangeCaseType&#34;))}">
+    <bpmn:serviceTask id="Service_SaveRefTypeChangeCaseNote_1sobox0" name="Save Ref Type Change Case Note" camunda:expression="${bpmnService.createCaseConversionNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_TriageChangeCaseType&#34;))}">
       <bpmn:incoming>SequenceFlow_0cz2azb</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_17gv9sk</bpmn:incoming>
       <bpmn:outgoing>Flow_0k2oguw</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0k2oguw" sourceRef="Activity_1sobox0" targetRef="ServiceTask_04cd41z" />
+    <bpmn:sequenceFlow id="Flow_0k2oguw" sourceRef="Service_SaveRefTypeChangeCaseNote_1sobox0" targetRef="ServiceTask_04cd41z" />
     <bpmn:userTask id="Activity_00g1vuo" name="Validate User Input">
       <bpmn:incoming>Flow_1akausd</bpmn:incoming>
       <bpmn:outgoing>Flow_0j36g5q</bpmn:outgoing>
@@ -520,15 +520,15 @@
     <bpmn:sequenceFlow id="Flow_1slp2aw" sourceRef="Gateway_1g01f59" targetRef="Activity_06vopxz">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageOutcome == "CloseCaseTelephone"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1gxj9d4" sourceRef="Gateway_15nvntw" targetRef="ServiceTask_05nlmnl">
+    <bpmn:sequenceFlow id="Flow_1gxj9d4" sourceRef="Gateway_15nvntw" targetRef="Screen_UserInput_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_19ce18n" sourceRef="Activity_1rzz5vn" targetRef="EndEvent_1golwf2" />
-    <bpmn:serviceTask id="ServiceTask_05l3eed" name="Clear Ministerial values" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;MinSignOffTeam&#34;, &#34;Addressee&#34;)}">
+    <bpmn:serviceTask id="Service_ClearMinisterialValues_05l3eed" name="Clear Ministerial values" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;MinSignOffTeam&#34;, &#34;Addressee&#34;)}">
       <bpmn:incoming>SequenceFlow_10jivty</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_00sgdbb</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_00sgdbb" sourceRef="ServiceTask_05l3eed" targetRef="ExclusiveGateway_0d3wc9s" />
+    <bpmn:sequenceFlow id="SequenceFlow_00sgdbb" sourceRef="Service_ClearMinisterialValues_05l3eed" targetRef="ExclusiveGateway_0d3wc9s" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_TRIAGE">
@@ -575,8 +575,8 @@
         <di:waypoint x="730" y="343" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0k2oguw_di" bpmnElement="Flow_0k2oguw">
-        <di:waypoint x="1598" y="970" />
-        <di:waypoint x="1598" y="921" />
+        <di:waypoint x="1522" y="970" />
+        <di:waypoint x="1522" y="921" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ksl1cg_di" bpmnElement="SequenceFlow_0ksl1cg">
         <di:waypoint x="1520" y="150" />
@@ -676,163 +676,163 @@
         <di:waypoint x="1807" y="416" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0cz2azb_di" bpmnElement="SequenceFlow_0cz2azb">
-        <di:waypoint x="1744" y="1167" />
-        <di:waypoint x="1744" y="1110" />
-        <di:waypoint x="1598" y="1110" />
-        <di:waypoint x="1598" y="1050" />
+        <di:waypoint x="1668" y="1167" />
+        <di:waypoint x="1668" y="1110" />
+        <di:waypoint x="1522" y="1110" />
+        <di:waypoint x="1522" y="1050" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0pqrbfz_di" bpmnElement="SequenceFlow_0pqrbfz">
-        <di:waypoint x="1623" y="1207" />
-        <di:waypoint x="1694" y="1207" />
+        <di:waypoint x="1547" y="1207" />
+        <di:waypoint x="1618" y="1207" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_17gv9sk_di" bpmnElement="SequenceFlow_17gv9sk">
-        <di:waypoint x="1598" y="1182" />
-        <di:waypoint x="1598" y="1050" />
+        <di:waypoint x="1522" y="1182" />
+        <di:waypoint x="1522" y="1050" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1573" y="1157" width="51" height="14" />
+          <dc:Bounds x="1497" y="1157" width="51" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_10jivty_di" bpmnElement="SequenceFlow_10jivty">
-        <di:waypoint x="1502" y="1548" />
-        <di:waypoint x="1598" y="1548" />
-        <di:waypoint x="1598" y="1505" />
+        <di:waypoint x="1426" y="1548" />
+        <di:waypoint x="1522" y="1548" />
+        <di:waypoint x="1522" y="1505" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_18rq3r1_di" bpmnElement="SequenceFlow_18rq3r1">
-        <di:waypoint x="1502" y="1207" />
-        <di:waypoint x="1573" y="1207" />
+        <di:waypoint x="1426" y="1207" />
+        <di:waypoint x="1497" y="1207" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1xbbggi_di" bpmnElement="SequenceFlow_1xbbggi">
-        <di:waypoint x="1338" y="1207" />
-        <di:waypoint x="1402" y="1207" />
+        <di:waypoint x="1262" y="1207" />
+        <di:waypoint x="1326" y="1207" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_03cktte_di" bpmnElement="SequenceFlow_03cktte">
-        <di:waypoint x="1313" y="1312" />
-        <di:waypoint x="1313" y="1373" />
+        <di:waypoint x="1237" y="1312" />
+        <di:waypoint x="1237" y="1373" />
         <di:waypoint x="318" y="1373" />
         <di:waypoint x="318" y="556" />
         <di:waypoint x="380" y="556" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0475c6m_di" bpmnElement="SequenceFlow_0475c6m">
-        <di:waypoint x="945" y="1124" />
-        <di:waypoint x="1114" y="1124" />
+        <di:waypoint x="869" y="1124" />
+        <di:waypoint x="1038" y="1124" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1wx2cqk_di" bpmnElement="SequenceFlow_1wx2cqk">
-        <di:waypoint x="920" y="1149" />
-        <di:waypoint x="920" y="1465" />
-        <di:waypoint x="1114" y="1465" />
+        <di:waypoint x="844" y="1149" />
+        <di:waypoint x="844" y="1465" />
+        <di:waypoint x="1038" y="1465" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1ixqf2u_di" bpmnElement="SequenceFlow_1ixqf2u">
-        <di:waypoint x="1313" y="1262" />
-        <di:waypoint x="1313" y="1232" />
+        <di:waypoint x="1237" y="1262" />
+        <di:waypoint x="1237" y="1232" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1317" y="1246" width="57" height="14" />
+          <dc:Bounds x="1241" y="1246" width="57" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0ql7g2b_di" bpmnElement="SequenceFlow_0ql7g2b">
-        <di:waypoint x="1214" y="1287" />
-        <di:waypoint x="1288" y="1287" />
+        <di:waypoint x="1138" y="1287" />
+        <di:waypoint x="1212" y="1287" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0tmi8ht_di" bpmnElement="SequenceFlow_0tmi8ht">
-        <di:waypoint x="1164" y="1164" />
-        <di:waypoint x="1164" y="1247" />
+        <di:waypoint x="1088" y="1164" />
+        <di:waypoint x="1088" y="1247" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_02pvi73_di" bpmnElement="SequenceFlow_02pvi73">
-        <di:waypoint x="1313" y="1182" />
-        <di:waypoint x="1313" y="1124" />
-        <di:waypoint x="1214" y="1124" />
+        <di:waypoint x="1237" y="1182" />
+        <di:waypoint x="1237" y="1124" />
+        <di:waypoint x="1138" y="1124" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1301" y="1106" width="24" height="14" />
+          <dc:Bounds x="1225" y="1106" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0roihnf_di" bpmnElement="SequenceFlow_0roihnf">
-        <di:waypoint x="1313" y="1653" />
-        <di:waypoint x="1313" y="1732" />
+        <di:waypoint x="1237" y="1653" />
+        <di:waypoint x="1237" y="1732" />
         <di:waypoint x="318" y="1732" />
         <di:waypoint x="318" y="556" />
         <di:waypoint x="380" y="556" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0nrrrl7_di" bpmnElement="SequenceFlow_0nrrrl7">
-        <di:waypoint x="686" y="823" />
-        <di:waypoint x="686" y="1124" />
-        <di:waypoint x="895" y="1124" />
+        <di:waypoint x="610" y="823" />
+        <di:waypoint x="610" y="1124" />
+        <di:waypoint x="819" y="1124" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="763" y="1127" width="77" height="14" />
+          <dc:Bounds x="687" y="1127" width="77" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1jh4a7z_di" bpmnElement="SequenceFlow_1jh4a7z">
-        <di:waypoint x="1338" y="1548" />
-        <di:waypoint x="1402" y="1548" />
+        <di:waypoint x="1262" y="1548" />
+        <di:waypoint x="1326" y="1548" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_04q8hta_di" bpmnElement="SequenceFlow_04q8hta">
-        <di:waypoint x="1313" y="1603" />
-        <di:waypoint x="1313" y="1573" />
+        <di:waypoint x="1237" y="1603" />
+        <di:waypoint x="1237" y="1573" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1317" y="1587" width="57" height="14" />
+          <dc:Bounds x="1241" y="1587" width="57" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1uld9m0_di" bpmnElement="SequenceFlow_1uld9m0">
-        <di:waypoint x="1214" y="1628" />
-        <di:waypoint x="1288" y="1628" />
+        <di:waypoint x="1138" y="1628" />
+        <di:waypoint x="1212" y="1628" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1bn197j_di" bpmnElement="SequenceFlow_1bn197j">
-        <di:waypoint x="1164" y="1505" />
-        <di:waypoint x="1164" y="1588" />
+        <di:waypoint x="1088" y="1505" />
+        <di:waypoint x="1088" y="1588" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1eauv06_di" bpmnElement="SequenceFlow_1eauv06">
-        <di:waypoint x="1313" y="1523" />
-        <di:waypoint x="1313" y="1465" />
-        <di:waypoint x="1214" y="1465" />
+        <di:waypoint x="1237" y="1523" />
+        <di:waypoint x="1237" y="1465" />
+        <di:waypoint x="1138" y="1465" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1301" y="1447" width="24" height="14" />
+          <dc:Bounds x="1225" y="1447" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1mlhuzu_di" bpmnElement="SequenceFlow_1mlhuzu">
-        <di:waypoint x="711" y="798" />
-        <di:waypoint x="1114" y="798" />
+        <di:waypoint x="635" y="798" />
+        <di:waypoint x="1038" y="798" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="754" y="784" width="88" height="27" />
+          <dc:Bounds x="678" y="784" width="88" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0j5xv9g_di" bpmnElement="SequenceFlow_0j5xv9g">
-        <di:waypoint x="1313" y="986" />
-        <di:waypoint x="1313" y="1038" />
+        <di:waypoint x="1237" y="986" />
+        <di:waypoint x="1237" y="1038" />
         <di:waypoint x="318" y="1038" />
         <di:waypoint x="318" y="556" />
         <di:waypoint x="380" y="556" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1316" y="995" width="64" height="14" />
+          <dc:Bounds x="1167" y="995" width="64" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_108azcx_di" bpmnElement="SequenceFlow_108azcx">
-        <di:waypoint x="1648" y="881" />
+        <di:waypoint x="1572" y="881" />
         <di:waypoint x="2349" y="881" />
         <di:waypoint x="2349" y="657" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1tf4edx_di" bpmnElement="SequenceFlow_1tf4edx">
-        <di:waypoint x="1338" y="881" />
-        <di:waypoint x="1548" y="881" />
+        <di:waypoint x="1262" y="881" />
+        <di:waypoint x="1472" y="881" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0yp3s8d_di" bpmnElement="SequenceFlow_0yp3s8d">
-        <di:waypoint x="1313" y="936" />
-        <di:waypoint x="1313" y="906" />
+        <di:waypoint x="1237" y="936" />
+        <di:waypoint x="1237" y="906" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1317" y="920" width="57" height="14" />
+          <dc:Bounds x="1241" y="920" width="57" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_03hubue_di" bpmnElement="SequenceFlow_03hubue">
-        <di:waypoint x="1214" y="961" />
-        <di:waypoint x="1288" y="961" />
+        <di:waypoint x="1138" y="961" />
+        <di:waypoint x="1212" y="961" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0li6nao_di" bpmnElement="SequenceFlow_0li6nao">
-        <di:waypoint x="1164" y="838" />
-        <di:waypoint x="1164" y="921" />
+        <di:waypoint x="1088" y="838" />
+        <di:waypoint x="1088" y="921" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_071fvv4_di" bpmnElement="SequenceFlow_071fvv4">
-        <di:waypoint x="1313" y="856" />
-        <di:waypoint x="1313" y="798" />
-        <di:waypoint x="1214" y="798" />
+        <di:waypoint x="1237" y="856" />
+        <di:waypoint x="1237" y="798" />
+        <di:waypoint x="1138" y="798" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1301" y="780" width="24" height="14" />
+          <dc:Bounds x="1225" y="780" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1lphuf4_di" bpmnElement="SequenceFlow_1lphuf4">
@@ -883,105 +883,105 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0enh4xh_di" bpmnElement="SequenceFlow_0enh4xh">
-        <di:waypoint x="864" y="2024" />
-        <di:waypoint x="556" y="2024" />
+        <di:waypoint x="788" y="2024" />
+        <di:waypoint x="480" y="2024" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="808" y="2003" width="64" height="14" />
+          <dc:Bounds x="732" y="2003" width="64" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1enm75p_di" bpmnElement="SequenceFlow_1enm75p">
-        <di:waypoint x="1067" y="2418" />
-        <di:waypoint x="556" y="2418" />
+        <di:waypoint x="991" y="2418" />
+        <di:waypoint x="480" y="2418" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1001" y="2401" width="64" height="14" />
+          <dc:Bounds x="925" y="2401" width="64" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1101m5b_di" bpmnElement="SequenceFlow_1101m5b">
-        <di:waypoint x="456" y="2024" />
+        <di:waypoint x="380" y="2024" />
         <di:waypoint x="318" y="2024" />
         <di:waypoint x="318" y="556" />
         <di:waypoint x="380" y="556" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1sq5itz_di" bpmnElement="SequenceFlow_1sq5itz">
-        <di:waypoint x="456" y="2418" />
+        <di:waypoint x="380" y="2418" />
         <di:waypoint x="318" y="2418" />
         <di:waypoint x="318" y="556" />
         <di:waypoint x="380" y="556" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0jpt0ej_di" bpmnElement="SequenceFlow_0jpt0ej">
-        <di:waypoint x="506" y="2492" />
-        <di:waypoint x="506" y="2458" />
+        <di:waypoint x="430" y="2492" />
+        <di:waypoint x="430" y="2458" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_11zk0mc_di" bpmnElement="SequenceFlow_11zk0mc">
-        <di:waypoint x="1067" y="2532" />
-        <di:waypoint x="556" y="2532" />
+        <di:waypoint x="991" y="2532" />
+        <di:waypoint x="480" y="2532" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_08xepts_di" bpmnElement="SequenceFlow_08xepts">
-        <di:waypoint x="1092" y="2443" />
-        <di:waypoint x="1092" y="2507" />
+        <di:waypoint x="1016" y="2443" />
+        <di:waypoint x="1016" y="2507" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1024" y="2458" width="57" height="14" />
+          <dc:Bounds x="948" y="2458" width="57" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_00xav5j_di" bpmnElement="SequenceFlow_00xav5j">
-        <di:waypoint x="1092" y="2329" />
-        <di:waypoint x="1092" y="2393" />
+        <di:waypoint x="1016" y="2329" />
+        <di:waypoint x="1016" y="2393" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0a2kz4o_di" bpmnElement="SequenceFlow_0a2kz4o">
-        <di:waypoint x="939" y="2289" />
-        <di:waypoint x="1042" y="2289" />
+        <di:waypoint x="863" y="2289" />
+        <di:waypoint x="966" y="2289" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0z80bhn_di" bpmnElement="SequenceFlow_0z80bhn">
-        <di:waypoint x="1117" y="2532" />
-        <di:waypoint x="1231" y="2532" />
-        <di:waypoint x="1231" y="2217" />
-        <di:waypoint x="889" y="2217" />
-        <di:waypoint x="889" y="2249" />
+        <di:waypoint x="1041" y="2532" />
+        <di:waypoint x="1155" y="2532" />
+        <di:waypoint x="1155" y="2217" />
+        <di:waypoint x="813" y="2217" />
+        <di:waypoint x="813" y="2249" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1162" y="2515" width="24" height="14" />
+          <dc:Bounds x="1086" y="2515" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_11990z3_di" bpmnElement="SequenceFlow_11990z3">
-        <di:waypoint x="889" y="2049" />
-        <di:waypoint x="889" y="2113" />
+        <di:waypoint x="813" y="2049" />
+        <di:waypoint x="813" y="2113" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="821" y="2064" width="57" height="14" />
+          <dc:Bounds x="745" y="2064" width="57" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0wvio0a_di" bpmnElement="SequenceFlow_0wvio0a">
-        <di:waypoint x="889" y="2163" />
-        <di:waypoint x="889" y="2249" />
+        <di:waypoint x="813" y="2163" />
+        <di:waypoint x="813" y="2249" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1ijxxtj_di" bpmnElement="SequenceFlow_1ijxxtj">
-        <di:waypoint x="914" y="2138" />
-        <di:waypoint x="1043" y="2138" />
-        <di:waypoint x="1043" y="1823" />
-        <di:waypoint x="686" y="1823" />
-        <di:waypoint x="686" y="1855" />
+        <di:waypoint x="838" y="2138" />
+        <di:waypoint x="967" y="2138" />
+        <di:waypoint x="967" y="1823" />
+        <di:waypoint x="610" y="1823" />
+        <di:waypoint x="610" y="1855" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="966" y="2120" width="24" height="14" />
+          <dc:Bounds x="890" y="2120" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_068rpjw_di" bpmnElement="SequenceFlow_068rpjw">
-        <di:waypoint x="889" y="1935" />
-        <di:waypoint x="889" y="1999" />
+        <di:waypoint x="813" y="1935" />
+        <di:waypoint x="813" y="1999" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1nf0zpm_di" bpmnElement="SequenceFlow_1nf0zpm">
-        <di:waypoint x="736" y="1895" />
-        <di:waypoint x="839" y="1895" />
+        <di:waypoint x="660" y="1895" />
+        <di:waypoint x="763" y="1895" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1stb0k6_di" bpmnElement="SequenceFlow_1stb0k6">
-        <di:waypoint x="686" y="823" />
-        <di:waypoint x="686" y="1855" />
+        <di:waypoint x="610" y="823" />
+        <di:waypoint x="610" y="1855" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="642" y="1782" width="87" height="27" />
+          <dc:Bounds x="566" y="1782" width="87" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_080dqh7_di" bpmnElement="SequenceFlow_080dqh7">
-        <di:waypoint x="686" y="773" />
-        <di:waypoint x="686" y="664" />
+        <di:waypoint x="610" y="773" />
+        <di:waypoint x="610" y="664" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="694" y="741" width="57" height="14" />
+          <dc:Bounds x="542" y="735" width="57" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1vaolyx_di" bpmnElement="SequenceFlow_1vaolyx">
@@ -1024,38 +1024,36 @@
         <di:waypoint x="380" y="556" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1co3k2r_di" bpmnElement="SequenceFlow_1co3k2r">
-        <di:waypoint x="711" y="639" />
+        <di:waypoint x="635" y="639" />
         <di:waypoint x="755" y="639" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1da9mhc_di" bpmnElement="SequenceFlow_1da9mhc">
-        <di:waypoint x="556" y="798" />
-        <di:waypoint x="661" y="798" />
+        <di:waypoint x="480" y="798" />
+        <di:waypoint x="585" y="798" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_16wwh9z_di" bpmnElement="SequenceFlow_16wwh9z">
         <di:waypoint x="430" y="596" />
-        <di:waypoint x="430" y="677" />
-        <di:waypoint x="506" y="677" />
-        <di:waypoint x="506" y="758" />
+        <di:waypoint x="430" y="758" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_06v8hsn_di" bpmnElement="SequenceFlow_06v8hsn">
-        <di:waypoint x="686" y="614" />
-        <di:waypoint x="686" y="556" />
+        <di:waypoint x="610" y="614" />
+        <di:waypoint x="610" y="556" />
         <di:waypoint x="480" y="556" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="674" y="535" width="24" height="14" />
+          <dc:Bounds x="598" y="535" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="156" y="538" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_05nlmnl_di" bpmnElement="ServiceTask_05nlmnl">
+      <bpmndi:BPMNShape id="ServiceTask_05nlmnl_di" bpmnElement="Screen_UserInput_05nlmnl">
         <dc:Bounds x="380" y="516" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_0jxw8et_di" bpmnElement="UserTask_0jxw8et">
-        <dc:Bounds x="456" y="758" width="100" height="80" />
+      <bpmndi:BPMNShape id="UserTask_0jxw8et_di" bpmnElement="Validate_UserInput_0jxw8et">
+        <dc:Bounds x="380" y="758" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_13qjvzx_di" bpmnElement="ExclusiveGateway_13qjvzx" isMarkerVisible="true">
-        <dc:Bounds x="661" y="614" width="50" height="50" />
+        <dc:Bounds x="585" y="614" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_1golwf2_di" bpmnElement="EndEvent_1golwf2">
         <dc:Bounds x="2331" y="621" width="36" height="36" />
@@ -1079,49 +1077,49 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_08l5d8b_di" bpmnElement="ExclusiveGateway_08l5d8b" isMarkerVisible="true">
-        <dc:Bounds x="661" y="773" width="50" height="50" />
+        <dc:Bounds x="585" y="773" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="593" y="769" width="78" height="14" />
+          <dc:Bounds x="517" y="769" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_14o40c8_di" bpmnElement="ServiceTask_14o40c8">
-        <dc:Bounds x="636" y="1855" width="100" height="80" />
+        <dc:Bounds x="560" y="1855" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_1r69osa_di" bpmnElement="UserTask_1r69osa">
-        <dc:Bounds x="839" y="1855" width="100" height="80" />
+        <dc:Bounds x="763" y="1855" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_00ge51l_di" bpmnElement="ExclusiveGateway_00ge51l" isMarkerVisible="true">
-        <dc:Bounds x="864" y="2113" width="50" height="50" />
+        <dc:Bounds x="788" y="2113" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_049krff_di" bpmnElement="ExclusiveGateway_049krff" isMarkerVisible="true">
-        <dc:Bounds x="864" y="1999" width="50" height="50" />
+        <dc:Bounds x="788" y="1999" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="924" y="2017" width="78" height="14" />
+          <dc:Bounds x="848" y="2017" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1wl4mgd_di" bpmnElement="ServiceTask_1wl4mgd">
-        <dc:Bounds x="839" y="2249" width="100" height="80" />
+        <dc:Bounds x="763" y="2249" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0kelzuk_di" bpmnElement="UserTask_0kelzuk">
-        <dc:Bounds x="1042" y="2249" width="100" height="80" />
+        <dc:Bounds x="966" y="2249" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_17q8hsm_di" bpmnElement="ExclusiveGateway_17q8hsm" isMarkerVisible="true">
-        <dc:Bounds x="1067" y="2507" width="50" height="50" />
+        <dc:Bounds x="991" y="2507" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1iftjr8_di" bpmnElement="ExclusiveGateway_1iftjr8" isMarkerVisible="true">
-        <dc:Bounds x="1067" y="2393" width="50" height="50" />
+        <dc:Bounds x="991" y="2393" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1127" y="2411" width="78" height="14" />
+          <dc:Bounds x="1051" y="2411" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_12eh3q4_di" bpmnElement="ServiceTask_12eh3q4">
-        <dc:Bounds x="456" y="2492" width="100" height="80" />
+        <dc:Bounds x="380" y="2492" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_060ccpx_di" bpmnElement="ServiceTask_060ccpx">
-        <dc:Bounds x="456" y="2378" width="100" height="80" />
+        <dc:Bounds x="380" y="2378" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0hpe5ym_di" bpmnElement="ServiceTask_0hpe5ym">
-        <dc:Bounds x="456" y="1984" width="100" height="80" />
+        <dc:Bounds x="380" y="1984" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1w1h0tl_di" bpmnElement="ServiceTask_1w1h0tl">
         <dc:Bounds x="895" y="303" width="100" height="80" />
@@ -1148,67 +1146,67 @@
         <dc:Bounds x="1123" y="154" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_06e7e59_di" bpmnElement="ServiceTask_06e7e59">
-        <dc:Bounds x="1114" y="758" width="100" height="80" />
+        <dc:Bounds x="1038" y="758" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_1fc2lp7_di" bpmnElement="UserTask_1fc2lp7">
-        <dc:Bounds x="1114" y="921" width="100" height="80" />
+        <dc:Bounds x="1038" y="921" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1jzkkkl_di" bpmnElement="ExclusiveGateway_1jzkkkl" isMarkerVisible="true">
-        <dc:Bounds x="1288" y="856" width="50" height="50" />
+        <dc:Bounds x="1212" y="856" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_03cn7o8_di" bpmnElement="ExclusiveGateway_03cn7o8" isMarkerVisible="true">
-        <dc:Bounds x="1288" y="936" width="50" height="50" />
+        <dc:Bounds x="1212" y="936" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1348" y="954" width="78" height="14" />
+          <dc:Bounds x="1272" y="954" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_04cd41z_di" bpmnElement="ServiceTask_04cd41z">
-        <dc:Bounds x="1548" y="841" width="100" height="80" />
+        <dc:Bounds x="1472" y="841" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0pxyggg_di" bpmnElement="ServiceTask_0pxyggg">
-        <dc:Bounds x="1114" y="1425" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_0pxyggg_di" bpmnElement="Screen_ReferenceTypeToOfficial_0pxyggg">
+        <dc:Bounds x="1038" y="1425" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_0ai1ek7_di" bpmnElement="UserTask_0ai1ek7">
-        <dc:Bounds x="1114" y="1588" width="100" height="80" />
+      <bpmndi:BPMNShape id="UserTask_0ai1ek7_di" bpmnElement="Validate_ReferenceTypeToOfficial_0ai1ek7">
+        <dc:Bounds x="1038" y="1588" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_04rfedk_di" bpmnElement="ExclusiveGateway_04rfedk" isMarkerVisible="true">
-        <dc:Bounds x="1288" y="1523" width="50" height="50" />
+        <dc:Bounds x="1212" y="1523" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0lgtxxn_di" bpmnElement="ExclusiveGateway_0lgtxxn" isMarkerVisible="true">
-        <dc:Bounds x="1288" y="1603" width="50" height="50" />
+        <dc:Bounds x="1212" y="1603" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1348" y="1621" width="78" height="14" />
+          <dc:Bounds x="1272" y="1621" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1c5qr22_di" bpmnElement="ServiceTask_1c5qr22">
-        <dc:Bounds x="1114" y="1084" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_1c5qr22_di" bpmnElement="Screen_ReferenceTypeToMinisterial_1c5qr22">
+        <dc:Bounds x="1038" y="1084" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_0k42bt1_di" bpmnElement="UserTask_0k42bt1">
-        <dc:Bounds x="1114" y="1247" width="100" height="80" />
+      <bpmndi:BPMNShape id="UserTask_0k42bt1_di" bpmnElement="Validate_ReferenceTypeToMinisterial_0k42bt1">
+        <dc:Bounds x="1038" y="1247" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0z4gzdc_di" bpmnElement="ExclusiveGateway_0z4gzdc" isMarkerVisible="true">
-        <dc:Bounds x="1288" y="1182" width="50" height="50" />
+        <dc:Bounds x="1212" y="1182" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0tzco2c_di" bpmnElement="ExclusiveGateway_0tzco2c" isMarkerVisible="true">
-        <dc:Bounds x="1288" y="1262" width="50" height="50" />
+        <dc:Bounds x="1212" y="1262" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1348" y="1280" width="78" height="14" />
+          <dc:Bounds x="1272" y="1280" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_02jphpz_di" bpmnElement="ExclusiveGateway_02jphpz" isMarkerVisible="true">
-        <dc:Bounds x="895" y="1099" width="50" height="50" />
+        <dc:Bounds x="819" y="1099" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0d3wc9s_di" bpmnElement="ExclusiveGateway_0d3wc9s" isMarkerVisible="true">
-        <dc:Bounds x="1573" y="1182" width="50" height="50" />
+        <dc:Bounds x="1497" y="1182" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0j4b6pe_di" bpmnElement="ServiceTask_0j4b6pe">
-        <dc:Bounds x="1694" y="1167" width="100" height="80" />
+        <dc:Bounds x="1618" y="1167" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0ai6870_di" bpmnElement="ServiceTask_0ai6870">
-        <dc:Bounds x="1402" y="1167" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_0ai6870_di" bpmnElement="Service_UpdateRefTypeToMinisterial_0ai6870">
+        <dc:Bounds x="1326" y="1167" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_07vhlhy_di" bpmnElement="ServiceTask_07vhlhy">
-        <dc:Bounds x="1402" y="1508" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_07vhlhy_di" bpmnElement="Service_UpdateRefTypeToOfficial_07vhlhy">
+        <dc:Bounds x="1326" y="1508" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0011raj_di" bpmnElement="ServiceTask_0011raj">
         <dc:Bounds x="1707" y="376" width="100" height="80" />
@@ -1261,8 +1259,8 @@
       <bpmndi:BPMNShape id="Activity_1bkf5fp_di" bpmnElement="ServiceTask_1bkf5fp">
         <dc:Bounds x="1470" y="150" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1sobox0_di" bpmnElement="Activity_1sobox0">
-        <dc:Bounds x="1548" y="970" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_1sobox0_di" bpmnElement="Service_SaveRefTypeChangeCaseNote_1sobox0">
+        <dc:Bounds x="1472" y="970" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_00g1vuo_di" bpmnElement="Activity_00g1vuo">
         <dc:Bounds x="630" y="303" width="100" height="80" />
@@ -1282,12 +1280,12 @@
       <bpmndi:BPMNShape id="Gateway_1g01f59_di" bpmnElement="Gateway_1g01f59" isMarkerVisible="true">
         <dc:Bounds x="835" y="614" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_05l3eed_di" bpmnElement="ServiceTask_05l3eed">
-        <dc:Bounds x="1548" y="1425" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_05l3eed_di" bpmnElement="Service_ClearMinisterialValues_05l3eed">
+        <dc:Bounds x="1472" y="1425" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_00sgdbb_di" bpmnElement="SequenceFlow_00sgdbb">
-        <di:waypoint x="1598" y="1425" />
-        <di:waypoint x="1598" y="1232" />
+        <di:waypoint x="1522" y="1425" />
+        <di:waypoint x="1522" y="1232" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMDraft.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMDraft.java
@@ -1,0 +1,98 @@
+package uk.gov.digital.ho.hocs.workflow.processes;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.camunda.bpm.scenario.ProcessScenario;
+import org.camunda.bpm.scenario.Scenario;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.withVariables;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+@Deployment(resources = "processes/MPAM_DRAFT.bpmn")
+public class MPAMDraft {
+
+    @Rule
+    @ClassRule
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
+            .assertClassCoverageAtLeast(0.2)
+            .build();
+
+    @Rule
+    public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+    @Mock
+    BpmnService bpmnService;
+    @Mock
+    private ProcessScenario processScenario;
+
+    @Before
+    public void setup() {
+        Mocks.register("bpmnService", bpmnService);
+    }
+
+    @Test
+    public void whenMinisterialChangedToOfficial_thenMinisterialValuesAreNotCleared() {
+
+        when(processScenario.waitsAtUserTask("UserTask_00s8k9f"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "UpdateRefType",
+                        "RefType", "Official",
+                        "RefTypeCorrection", "Correction")));
+        when(processScenario.waitsAtUserTask("UserTask_0zaqr6s"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "FORWARD")));
+
+        Scenario.run(processScenario)
+                .startByKey("MPAM_DRAFT")
+                .execute();
+
+        verify(processScenario).hasCompleted("ServiceTask_1unkg32");
+        verify(processScenario).hasCompleted("ServiceTask_0urk37h");
+        verify(processScenario).hasCompleted("Activity_1yc1ce2");
+        verify(processScenario).hasFinished("EndEvent_168jcnt");
+        verify(bpmnService).updateValue(any(), any(), eq("RefType"), eq("Ministerial"), eq("RefTypeStatus"), eq("Confirm"));
+        verify(bpmnService, never()).blankCaseValues(any(), any(), eq("MinSignOffTeam"), eq("Addressee"));
+    }
+
+    @Test
+    public void whenOfficialChangedToMinisterial_thenMinisterialValuesAreCleared() {
+
+        when(processScenario.waitsAtUserTask("UserTask_00s8k9f"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "UpdateRefType",
+                        "RefType", "Ministerial",
+                        "RefTypeCorrection", "Correction")));
+        when(processScenario.waitsAtUserTask("UserTask_08l10xy"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "FORWARD")));
+
+        Scenario.run(processScenario)
+                .startByKey("MPAM_DRAFT")
+                .execute();
+
+        verify(processScenario).hasCompleted("ServiceTask_0ia1i5c");
+        verify(processScenario).hasCompleted("ServiceTask_0lic0m6");
+        verify(processScenario).hasCompleted("ServiceTask_0xqy6p5");
+        verify(processScenario).hasCompleted("Activity_1yc1ce2");
+        verify(processScenario).hasFinished("EndEvent_168jcnt");
+        verify(bpmnService).updateValue(any(), any(), eq("RefType"), eq("Official"), eq("RefTypeStatus"), eq("Confirm"));
+        verify(bpmnService).blankCaseValues(any(), any(), eq("MinSignOffTeam"), eq("Addressee"));
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMTriage.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMTriage.java
@@ -20,10 +20,11 @@ import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.withVari
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
-@Deployment(resources = "processes/MPAM_DRAFT.bpmn")
-public class MPAMDraft {
+@Deployment(resources = "processes/MPAM_TRIAGE.bpmn")
+public class MPAMTriage {
 
     @Rule
     @ClassRule
@@ -44,55 +45,55 @@ public class MPAMDraft {
     }
 
     @Test
-    public void whenOfficialChangedToMinisterial_thenMinisterialValuesAreNotCleared() {
-
-        when(processScenario.waitsAtUserTask("Validate_UserInput_00s8k9f"))
-                .thenReturn(task -> task.complete(withVariables(
-                        "valid", true,
-                        "DIRECTION", "UpdateRefType",
-                        "RefType", "Official",
-                        "RefTypeCorrection", "Correction")));
-        when(processScenario.waitsAtUserTask("Validate_ReferenceTypeToMinisterial_0zaqr6s"))
-                .thenReturn(task -> task.complete(withVariables(
-                        "valid", true,
-                        "DIRECTION", "FORWARD")));
-
-        Scenario.run(processScenario)
-                .startByKey("MPAM_DRAFT")
-                .execute();
-
-        verify(processScenario).hasCompleted("Screen_ReferenceTypeToMinisterial_1unkg32");
-        verify(processScenario).hasCompleted("Service_UpdateRefTypeToMinisterial_0urk37h");
-        verify(processScenario).hasCompleted("Service_SaveRefTypeChangeCaseNote_1yc1ce2");
-        verify(processScenario).hasFinished("EndEvent_168jcnt");
-        verify(bpmnService).updateValue(any(), any(), eq("RefType"), eq("Ministerial"), eq("RefTypeStatus"), eq("Confirm"));
-        verify(bpmnService, never()).blankCaseValues(any(), any(), eq("MinSignOffTeam"), eq("Addressee"));
-    }
-
-    @Test
     public void whenMinisterialChangedToOfficial_thenMinisterialValuesAreCleared() {
 
-        when(processScenario.waitsAtUserTask("Validate_UserInput_00s8k9f"))
+        when(processScenario.waitsAtUserTask("Validate_UserInput_0jxw8et"))
                 .thenReturn(task -> task.complete(withVariables(
                         "valid", true,
                         "DIRECTION", "UpdateRefType",
                         "RefType", "Ministerial",
                         "RefTypeCorrection", "Correction")));
-        when(processScenario.waitsAtUserTask("Validate_RefTypeToOfficial_08l10xy"))
+        when(processScenario.waitsAtUserTask("Validate_ReferenceTypeToOfficial_0ai1ek7"))
                 .thenReturn(task -> task.complete(withVariables(
                         "valid", true,
                         "DIRECTION", "FORWARD")));
 
         Scenario.run(processScenario)
-                .startByKey("MPAM_DRAFT")
+                .startByKey("MPAM_TRIAGE")
                 .execute();
 
-        verify(processScenario).hasCompleted("Screen_RefTypeToOfficial_0ia1i5c");
-        verify(processScenario).hasCompleted("Service_UpdateRefTypeToOfficial_0lic0m6");
-        verify(processScenario).hasCompleted("Service_ClearMinisterialValues_0xqy6p5");
-        verify(processScenario).hasCompleted("Service_SaveRefTypeChangeCaseNote_1yc1ce2");
-        verify(processScenario).hasFinished("EndEvent_168jcnt");
+        verify(processScenario).hasCompleted("Screen_ReferenceTypeToOfficial_0pxyggg");
+        verify(processScenario).hasCompleted("Service_UpdateRefTypeToOfficial_07vhlhy");
+        verify(processScenario).hasCompleted("Service_ClearMinisterialValues_05l3eed");
+        verify(processScenario).hasCompleted("Service_SaveRefTypeChangeCaseNote_1sobox0");
+        verify(processScenario).hasFinished("EndEvent_1golwf2");
         verify(bpmnService).updateValue(any(), any(), eq("RefType"), eq("Official"), eq("RefTypeStatus"), eq("Confirm"));
         verify(bpmnService).blankCaseValues(any(), any(), eq("MinSignOffTeam"), eq("Addressee"));
+    }
+
+    @Test
+    public void whenOfficialChangedToMinisterial_thenMinisterialValuesAreNotCleared() {
+
+        when(processScenario.waitsAtUserTask("Validate_UserInput_0jxw8et"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "UpdateRefType",
+                        "RefType", "Official",
+                        "RefTypeCorrection", "Correction")));
+        when(processScenario.waitsAtUserTask("Validate_ReferenceTypeToMinisterial_0k42bt1"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "FORWARD")));
+
+        Scenario.run(processScenario)
+                .startByKey("MPAM_TRIAGE")
+                .execute();
+
+        verify(processScenario).hasCompleted("Screen_ReferenceTypeToMinisterial_1c5qr22");
+        verify(processScenario).hasCompleted("Service_UpdateRefTypeToMinisterial_0ai6870");
+        verify(processScenario).hasCompleted("Service_SaveRefTypeChangeCaseNote_1sobox0");
+        verify(processScenario).hasFinished("EndEvent_1golwf2");
+        verify(bpmnService).updateValue(any(), any(), eq("RefType"), eq("Ministerial"), eq("RefTypeStatus"), eq("Confirm"));
+        verify(bpmnService, never()).blankCaseValues(any(), any(), eq("MinSignOffTeam"), eq("Addressee"));
     }
 }


### PR DESCRIPTION
Changing a case from reftype "Ministerial" to "Official" clears ministerial only data values: MinSignOffTeam, Addressee
At both Triage and Draft.
Now with Camunda unit tests!