### PR TITLE
HOCS-2274: Update MPAM Draft to allow for MC 

### DIFF
--- a/src/main/resources/processes/MPAM.bpmn
+++ b/src/main/resources/processes/MPAM.bpmn
@@ -531,6 +531,7 @@
         <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0emd0q1</bpmn:incoming>
+      <bpmn:incoming>Flow_06ntgge</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_06j8j3d</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="SequenceFlow_06j8j3d" sourceRef="CallActivity_1068j5g" targetRef="ExclusiveGateway_1hlhu8m" />
@@ -579,6 +580,7 @@
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_1nyjaew" name="DraftStatus?">
       <bpmn:incoming>SequenceFlow_1c9mhr6</bpmn:incoming>
+      <bpmn:incoming>Flow_0w190hn</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0tz3m2g</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0q9rldb</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0linen9</bpmn:outgoing>
@@ -675,7 +677,6 @@
         <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1387m3c</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_0ar1y4h</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0kq3lhc</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1d3n6u9</bpmn:outgoing>
     </bpmn:callActivity>
@@ -683,7 +684,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_1387m3c" sourceRef="ExclusiveGateway_0vigruh" targetRef="CallActivity_0wsaktq">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${BusAreaStatus == "Confirm" || BusAreaStatus == "Pending" || RefTypeStatus == "Confirm"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0ar1y4h" name="Escalate" sourceRef="ExclusiveGateway_1hlhu8m" targetRef="CallActivity_0wsaktq">
+    <bpmn:sequenceFlow id="SequenceFlow_0ar1y4h" name="Escalate" sourceRef="ExclusiveGateway_1hlhu8m" targetRef="Activity_134af50">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftRequestedContributionOutcome == "Escalate"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0kq3lhc" name="Escalate" sourceRef="ExclusiveGateway_1p73xkw" targetRef="CallActivity_0wsaktq">
@@ -903,6 +904,54 @@
     <bpmn:sequenceFlow id="Flow_0uw7du8" sourceRef="Gateway_1apsblq" targetRef="ExclusiveGateway_0i6lwxh">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageEscalateOutcome =="Close" || TriageEscalateOutcome == "PutOnCampaign"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:callActivity id="Activity_134af50" name="Draft Escalated" calledElement="STAGE_WITH_USER">
+      <bpmn:extensionElements>
+        <camunda:in source="DraftEscalateUUID" target="StageUUID" />
+        <camunda:in sourceExpression="MPAM_DRAFT_ESCALATE" target="StageWorkFlow" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+        <camunda:out source="StageUUID" target="DraftEscalateUUID" />
+        <camunda:out source="DateReceived" target="DateReceived" />
+        <camunda:in sourceExpression="MPAM_DRAFT_ESCALATE" target="StageType" />
+        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in source="QueueTeamUUID" target="AllocationTeamUUID" />
+        <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
+        <camunda:in source="DraftUserUUID" target="AllocatedUserUUID" />
+        <camunda:out source="DraftStatus" target="DraftStatus" />
+        <camunda:in source="&#34;&#34;" target="BusAreaStatus" />
+        <camunda:out source="BusAreaStatus" target="BusAreaStatus" />
+        <camunda:in source="&#34;&#34;" target="RefTypeStatus" />
+        <camunda:out source="RefTypeStatus" target="RefTypeStatus" />
+        <camunda:out source="RefType" target="RefType" />
+        <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_0ar1y4h</bpmn:incoming>
+      <bpmn:incoming>Flow_0m3x81j</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ec9mbj</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_04ovq4w">
+      <bpmn:incoming>Flow_1ec9mbj</bpmn:incoming>
+      <bpmn:outgoing>Flow_0m3x81j</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0fxuqph</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0m3x81j" sourceRef="Gateway_04ovq4w" targetRef="Activity_134af50">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${BusAreaStatus == "Confirm" || BusAreaStatus == "Pending" || RefTypeStatus == "Confirm"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1ec9mbj" sourceRef="Activity_134af50" targetRef="Gateway_04ovq4w" />
+    <bpmn:exclusiveGateway id="Gateway_0kabhfi">
+      <bpmn:incoming>Flow_0fxuqph</bpmn:incoming>
+      <bpmn:outgoing>Flow_06ntgge</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0w190hn</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_06ntgge" sourceRef="Gateway_0kabhfi" targetRef="CallActivity_1068j5g">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus != "Close" &amp;&amp; DraftStatus != "PutOnCampaign"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0fxuqph" sourceRef="Gateway_04ovq4w" targetRef="Gateway_0kabhfi" />
+    <bpmn:sequenceFlow id="Flow_0w190hn" sourceRef="Gateway_0kabhfi" targetRef="ExclusiveGateway_1nyjaew">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus == "Close" &amp;&amp; DraftStatus == "PutOnCampaign"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM">
@@ -1011,21 +1060,21 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0ar1y4h_di" bpmnElement="SequenceFlow_0ar1y4h">
-        <di:waypoint x="2690" y="516" />
-        <di:waypoint x="2799" y="516" />
+        <di:waypoint x="2595" y="516" />
+        <di:waypoint x="2640" y="516" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2723" y="498" width="43" height="14" />
+          <dc:Bounds x="2596" y="498" width="43" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1387m3c_di" bpmnElement="SequenceFlow_1387m3c">
-        <di:waypoint x="2874" y="634" />
-        <di:waypoint x="2949" y="634" />
+        <di:waypoint x="2874" y="613" />
+        <di:waypoint x="2949" y="613" />
         <di:waypoint x="2949" y="516" />
         <di:waypoint x="2899" y="516" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1d3n6u9_di" bpmnElement="SequenceFlow_1d3n6u9">
         <di:waypoint x="2849" y="556" />
-        <di:waypoint x="2849" y="609" />
+        <di:waypoint x="2849" y="588" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0xndnj6_di" bpmnElement="SequenceFlow_0xndnj6">
         <di:waypoint x="1640" y="424" />
@@ -1083,19 +1132,19 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1c9mhr6_di" bpmnElement="SequenceFlow_1c9mhr6">
-        <di:waypoint x="2849" y="659" />
-        <di:waypoint x="2849" y="699" />
+        <di:waypoint x="2849" y="638" />
+        <di:waypoint x="2849" y="715" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0linen9_di" bpmnElement="SequenceFlow_0linen9">
-        <di:waypoint x="2824" y="724" />
-        <di:waypoint x="1807" y="724" />
+        <di:waypoint x="2824" y="740" />
+        <di:waypoint x="1807" y="740" />
         <di:waypoint x="1807" y="437" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2807" y="705" width="21" height="14" />
+          <dc:Bounds x="2807" y="721" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0q9rldb_di" bpmnElement="SequenceFlow_0q9rldb">
-        <di:waypoint x="2849" y="724" />
+        <di:waypoint x="2849" y="765" />
         <di:waypoint x="2849" y="801" />
         <di:waypoint x="4728" y="801" />
         <di:waypoint x="4728" y="437" />
@@ -1104,13 +1153,13 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0tz3m2g_di" bpmnElement="SequenceFlow_0tz3m2g">
-        <di:waypoint x="2830" y="730" />
+        <di:waypoint x="2828" y="744" />
         <di:waypoint x="2733" y="762" />
         <di:waypoint x="2733" y="878" />
         <di:waypoint x="1453" y="878" />
         <di:waypoint x="1453" y="908" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2706" y="763" width="82" height="14" />
+          <dc:Bounds x="2704" y="765" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1o62r04_di" bpmnElement="SequenceFlow_1o62r04">
@@ -1148,8 +1197,8 @@
         <di:waypoint x="1325" y="516" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_06j8j3d_di" bpmnElement="SequenceFlow_06j8j3d">
-        <di:waypoint x="2548" y="516" />
-        <di:waypoint x="2640" y="516" />
+        <di:waypoint x="2510" y="516" />
+        <di:waypoint x="2545" y="516" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0rb09oq_di" bpmnElement="SequenceFlow_0rb09oq">
         <di:waypoint x="1220" y="424" />
@@ -1176,14 +1225,14 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0emd0q1_di" bpmnElement="SequenceFlow_0emd0q1">
-        <di:waypoint x="2498" y="422" />
-        <di:waypoint x="2498" y="476" />
+        <di:waypoint x="2460" y="422" />
+        <di:waypoint x="2460" y="476" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2403" y="427" width="86" height="27" />
+          <dc:Bounds x="2365" y="445" width="86" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_14hq49d_di" bpmnElement="SequenceFlow_14hq49d">
-        <di:waypoint x="2648" y="524" />
+        <di:waypoint x="2561" y="532" />
         <di:waypoint x="2537" y="580" />
         <di:waypoint x="1826" y="580" />
         <di:waypoint x="1826" y="437" />
@@ -1192,12 +1241,12 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1d19x26_di" bpmnElement="SequenceFlow_1d19x26">
-        <di:waypoint x="2665" y="541" />
-        <di:waypoint x="2665" y="878" />
+        <di:waypoint x="2570" y="541" />
+        <di:waypoint x="2570" y="878" />
         <di:waypoint x="1455" y="878" />
         <di:waypoint x="1455" y="908" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2625" y="557" width="82" height="14" />
+          <dc:Bounds x="2530" y="557" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1pemtrq_di" bpmnElement="SequenceFlow_1pemtrq">
@@ -1425,7 +1474,9 @@
         <di:waypoint x="841" y="397" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0znlvgd_di" bpmnElement="SequenceFlow_0znlvgd">
-        <di:waypoint x="2522" y="398" />
+        <di:waypoint x="2484" y="398" />
+        <di:waypoint x="2550" y="398" />
+        <di:waypoint x="2550" y="399" />
         <di:waypoint x="2615" y="399" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0vg77eq_di" bpmnElement="SequenceFlow_0vg77eq">
@@ -1456,12 +1507,12 @@
         <di:waypoint x="2319" y="422" />
         <di:waypoint x="2319" y="476" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2330" y="438" width="41" height="14" />
+          <dc:Bounds x="2269" y="454" width="41" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0of5s4m_di" bpmnElement="SequenceFlow_0of5s4m">
         <di:waypoint x="2344" y="397" />
-        <di:waypoint x="2473" y="397" />
+        <di:waypoint x="2435" y="397" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1yjtv4p_di" bpmnElement="SequenceFlow_1yjtv4p">
         <di:waypoint x="1094" y="422" />
@@ -1537,6 +1588,30 @@
       <bpmndi:BPMNEdge id="SequenceFlow_14toxc6_di" bpmnElement="SequenceFlow_14toxc6">
         <di:waypoint x="199" y="397" />
         <di:waypoint x="294" y="397" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m3x81j_di" bpmnElement="Flow_0m3x81j">
+        <di:waypoint x="2715" y="613" />
+        <di:waypoint x="2770" y="613" />
+        <di:waypoint x="2770" y="516" />
+        <di:waypoint x="2740" y="516" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ec9mbj_di" bpmnElement="Flow_1ec9mbj">
+        <di:waypoint x="2690" y="556" />
+        <di:waypoint x="2690" y="588" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06ntgge_di" bpmnElement="Flow_06ntgge">
+        <di:waypoint x="2665" y="685" />
+        <di:waypoint x="2460" y="685" />
+        <di:waypoint x="2460" y="556" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fxuqph_di" bpmnElement="Flow_0fxuqph">
+        <di:waypoint x="2690" y="638" />
+        <di:waypoint x="2690" y="660" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0w190hn_di" bpmnElement="Flow_0w190hn">
+        <di:waypoint x="2715" y="685" />
+        <di:waypoint x="2849" y="685" />
+        <di:waypoint x="2849" y="715" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="163" y="379" width="36" height="36" />
@@ -1628,12 +1703,6 @@
           <dc:Bounds x="1179" y="358" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_0q858dj_di" bpmnElement="ExclusiveGateway_0q858dj" isMarkerVisible="true">
-        <dc:Bounds x="2473" y="372" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1593" y="222" width="56" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_02dd3sx_di" bpmnElement="ExclusiveGateway_02dd3sx" isMarkerVisible="true">
         <dc:Bounds x="696" y="372" width="50" height="50" />
         <bpmndi:BPMNLabel>
@@ -1703,22 +1772,10 @@
       <bpmndi:BPMNShape id="ExclusiveGateway_0gyznaj_di" bpmnElement="ExclusiveGateway_0gyznaj" isMarkerVisible="true">
         <dc:Bounds x="1615" y="609" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_0vigruh_di" bpmnElement="ExclusiveGateway_0vigruh" isMarkerVisible="true">
-        <dc:Bounds x="2824" y="609" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2781" y="627" width="38" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1gth2bz_di" bpmnElement="ExclusiveGateway_1gth2bz" isMarkerVisible="true">
         <dc:Bounds x="4332" y="491" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="4375" y="490" width="78" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1hlhu8m_di" bpmnElement="ExclusiveGateway_1hlhu8m" isMarkerVisible="true">
-        <dc:Bounds x="2640" y="491" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2622" y="441" width="85" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1ov5a6c_di" bpmnElement="ExclusiveGateway_1ov5a6c" isMarkerVisible="true">
@@ -1727,9 +1784,6 @@
           <dc:Bounds x="1308" y="453" width="84" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="CallActivity_1068j5g_di" bpmnElement="CallActivity_1068j5g">
-        <dc:Bounds x="2448" y="476" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CallActivity_0gubz9s_di" bpmnElement="CallActivity_0gubz9s">
         <dc:Bounds x="1170" y="476" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -1737,12 +1791,6 @@
         <dc:Bounds x="1615" y="725" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1675" y="736" width="82" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1nyjaew_di" bpmnElement="ExclusiveGateway_1nyjaew" isMarkerVisible="true">
-        <dc:Bounds x="2824" y="699" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2884" y="717" width="62" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0j50pmh_di" bpmnElement="ExclusiveGateway_0j50pmh" isMarkerVisible="true">
@@ -1795,6 +1843,42 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1apsblq_di" bpmnElement="Gateway_1apsblq" isMarkerVisible="true">
         <dc:Bounds x="1455" y="668" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_1068j5g_di" bpmnElement="CallActivity_1068j5g">
+        <dc:Bounds x="2410" y="476" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_0q858dj_di" bpmnElement="ExclusiveGateway_0q858dj" isMarkerVisible="true">
+        <dc:Bounds x="2435" y="372" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1593" y="222" width="56" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1hlhu8m_di" bpmnElement="ExclusiveGateway_1hlhu8m" isMarkerVisible="true">
+        <dc:Bounds x="2545" y="491" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2527" y="441" width="85" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_134af50_di" bpmnElement="Activity_134af50">
+        <dc:Bounds x="2640" y="476" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_04ovq4w_di" bpmnElement="Gateway_04ovq4w" isMarkerVisible="true">
+        <dc:Bounds x="2665" y="588" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_0vigruh_di" bpmnElement="ExclusiveGateway_0vigruh" isMarkerVisible="true">
+        <dc:Bounds x="2824" y="588" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2781" y="606" width="38" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0kabhfi_di" bpmnElement="Gateway_0kabhfi" isMarkerVisible="true">
+        <dc:Bounds x="2665" y="660" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1nyjaew_di" bpmnElement="ExclusiveGateway_1nyjaew" isMarkerVisible="true">
+        <dc:Bounds x="2824" y="715" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2884" y="733" width="62" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/MPAM_DRAFT.bpmn
+++ b/src/main/resources/processes/MPAM_DRAFT.bpmn
@@ -31,12 +31,12 @@
       <bpmn:incoming>SequenceFlow_0aqbfj5</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_03zr4wl</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1ghiqr1</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_1vhqq32</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0dp8d8d</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0gqz21i</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0g9rtos</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1cv2gqf</bpmn:incoming>
       <bpmn:incoming>Flow_0lluryd</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1qrzvht</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="SequenceFlow_0jno6nt" name="false" sourceRef="ExclusiveGateway_0urib3x" targetRef="ServiceTask_0orq4iy">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
@@ -96,10 +96,6 @@
       <bpmn:incoming>SequenceFlow_1i1jcd0</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1xnuvue</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:serviceTask id="ServiceTask_020e9dh" name="Save Request Contribution Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_DraftRequestContribution&#34;), &#34;REQUEST_CONTRIBUTION&#34;)}">
-      <bpmn:incoming>SequenceFlow_1qrzvht</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_1vhqq32</bpmn:outgoing>
-    </bpmn:serviceTask>
     <bpmn:exclusiveGateway id="ExclusiveGateway_0ro8o4c" name="Direction Check">
       <bpmn:incoming>SequenceFlow_1xnuvue</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0yg3lht</bpmn:outgoing>
@@ -115,7 +111,7 @@
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1i1jcd0" sourceRef="ServiceTask_0bgc7h6" targetRef="UserTask_0uyxu2q" />
     <bpmn:sequenceFlow id="SequenceFlow_1xnuvue" sourceRef="UserTask_0uyxu2q" targetRef="ExclusiveGateway_0ro8o4c" />
-    <bpmn:sequenceFlow id="SequenceFlow_1qrzvht" sourceRef="ExclusiveGateway_0981jns" targetRef="ServiceTask_020e9dh">
+    <bpmn:sequenceFlow id="SequenceFlow_1qrzvht" sourceRef="ExclusiveGateway_0981jns" targetRef="EndEvent_168jcnt">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0yg3lht" sourceRef="ExclusiveGateway_0ro8o4c" targetRef="ExclusiveGateway_0981jns">
@@ -127,7 +123,6 @@
     <bpmn:sequenceFlow id="SequenceFlow_0fo9wb7" sourceRef="ExclusiveGateway_0ro8o4c" targetRef="ServiceTask_0orq4iy">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION != "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1vhqq32" sourceRef="ServiceTask_020e9dh" targetRef="EndEvent_168jcnt" />
     <bpmn:serviceTask id="ServiceTask_09dgtiv" name="Business Area" camunda:expression="MPAM_BUSINESS_AREA" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_05qrq6b</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0lq7xmj</bpmn:incoming>
@@ -823,11 +818,6 @@
           <dc:Bounds x="928" y="1884" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1vhqq32_di" bpmnElement="SequenceFlow_1vhqq32">
-        <di:waypoint x="1702" y="958" />
-        <di:waypoint x="1987" y="958" />
-        <di:waypoint x="1987" y="1642" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0fo9wb7_di" bpmnElement="SequenceFlow_0fo9wb7">
         <di:waypoint x="1364" y="933" />
         <di:waypoint x="1364" y="846" />
@@ -848,7 +838,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1qrzvht_di" bpmnElement="SequenceFlow_1qrzvht">
         <di:waypoint x="1468" y="958" />
-        <di:waypoint x="1602" y="958" />
+        <di:waypoint x="1987" y="958" />
+        <di:waypoint x="1987" y="1642" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1xnuvue_di" bpmnElement="SequenceFlow_1xnuvue">
         <di:waypoint x="1301" y="958" />
@@ -969,9 +960,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0uyxu2q_di" bpmnElement="UserTask_0uyxu2q">
         <dc:Bounds x="1201" y="918" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_020e9dh_di" bpmnElement="ServiceTask_020e9dh">
-        <dc:Bounds x="1602" y="918" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0ro8o4c_di" bpmnElement="ExclusiveGateway_0ro8o4c" isMarkerVisible="true">
         <dc:Bounds x="1339" y="933" width="50" height="50" />

--- a/src/main/resources/processes/MPAM_DRAFT_REQUESTED_CONTRIBUTION.bpmn
+++ b/src/main/resources/processes/MPAM_DRAFT_REQUESTED_CONTRIBUTION.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0za2uts" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.2">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0za2uts" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
   <bpmn:process id="MPAM_DRAFT_REQUESTED_CONTRIBUTION" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_0b4aogc</bpmn:outgoing>
@@ -40,22 +40,17 @@
     <bpmn:sequenceFlow id="SequenceFlow_11bp6p4" sourceRef="ExclusiveGateway_0l3rk3f" targetRef="ExclusiveGateway_0xfwwxo">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_19ss4rt" sourceRef="ExclusiveGateway_0xfwwxo" targetRef="ServiceTask_058lxl7">
+    <bpmn:sequenceFlow id="SequenceFlow_19ss4rt" sourceRef="ExclusiveGateway_0xfwwxo" targetRef="ExclusiveGateway_0iva2jo">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftRequestedContributionOutcome != "Pending"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0b4aogc" sourceRef="StartEvent_1" targetRef="ServiceTask_0win31c" />
-    <bpmn:serviceTask id="ServiceTask_058lxl7" name="Clear DueDate" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;DueDate&#34;)}">
-      <bpmn:incoming>SequenceFlow_19ss4rt</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_01ebw4m</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_01ebw4m" sourceRef="ServiceTask_058lxl7" targetRef="ExclusiveGateway_0iva2jo" />
     <bpmn:serviceTask id="ServiceTask_1htucc1" name="Request Campaign" camunda:expression="MPAM_CAMPAIGN_REQUEST" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_1jmk13k</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1isze0w</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0pbimrf</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:exclusiveGateway id="ExclusiveGateway_0iva2jo" name="DraftRequestedContributionOutcome?">
-      <bpmn:incoming>SequenceFlow_01ebw4m</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_19ss4rt</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0b91e77</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1y10mb4</bpmn:outgoing>
     </bpmn:exclusiveGateway>
@@ -106,6 +101,87 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_DRAFT_REQUESTED_CONTRIBUTION">
+      <bpmndi:BPMNEdge id="SequenceFlow_1a3hvst_di" bpmnElement="SequenceFlow_1a3hvst">
+        <di:waypoint x="1357" y="150" />
+        <di:waypoint x="1357" y="81" />
+        <di:waypoint x="443" y="81" />
+        <di:waypoint x="443" y="444" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0jrhdgo_di" bpmnElement="SequenceFlow_0jrhdgo">
+        <di:waypoint x="1695" y="175" />
+        <di:waypoint x="1842" y="175" />
+        <di:waypoint x="1842" y="549" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1y10mb4_di" bpmnElement="SequenceFlow_1y10mb4">
+        <di:waypoint x="1269" y="567" />
+        <di:waypoint x="1824" y="567" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0knn9ma_di" bpmnElement="SequenceFlow_0knn9ma">
+        <di:waypoint x="1472" y="175" />
+        <di:waypoint x="1595" y="175" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_10jl285_di" bpmnElement="SequenceFlow_10jl285">
+        <di:waypoint x="1382" y="175" />
+        <di:waypoint x="1422" y="175" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1wcy6r7_di" bpmnElement="SequenceFlow_1wcy6r7">
+        <di:waypoint x="1294" y="175" />
+        <di:waypoint x="1332" y="175" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0b91e77_di" bpmnElement="SequenceFlow_0b91e77">
+        <di:waypoint x="1244" y="542" />
+        <di:waypoint x="1244" y="490" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1251" y="518" width="82" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0pbimrf_di" bpmnElement="SequenceFlow_0pbimrf">
+        <di:waypoint x="1244" y="299" />
+        <di:waypoint x="1244" y="215" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1isze0w_di" bpmnElement="SequenceFlow_1isze0w">
+        <di:waypoint x="1244" y="410" />
+        <di:waypoint x="1244" y="379" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1jmk13k_di" bpmnElement="SequenceFlow_1jmk13k">
+        <di:waypoint x="1447" y="200" />
+        <di:waypoint x="1447" y="339" />
+        <di:waypoint x="1294" y="339" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0b4aogc_di" bpmnElement="SequenceFlow_0b4aogc">
+        <di:waypoint x="215" y="484" />
+        <di:waypoint x="393" y="484" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_19ss4rt_di" bpmnElement="SequenceFlow_19ss4rt">
+        <di:waypoint x="746" y="567" />
+        <di:waypoint x="1219" y="567" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_11bp6p4_di" bpmnElement="SequenceFlow_11bp6p4">
+        <di:waypoint x="648" y="567" />
+        <di:waypoint x="696" y="567" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0h6xm2k_di" bpmnElement="SequenceFlow_0h6xm2k">
+        <di:waypoint x="493" y="647" />
+        <di:waypoint x="623" y="647" />
+        <di:waypoint x="623" y="592" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_18010p9_di" bpmnElement="SequenceFlow_18010p9">
+        <di:waypoint x="443" y="524" />
+        <di:waypoint x="443" y="607" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0cibkry_di" bpmnElement="SequenceFlow_0cibkry">
+        <di:waypoint x="721" y="542" />
+        <di:waypoint x="721" y="484" />
+        <di:waypoint x="493" y="484" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1w3s635_di" bpmnElement="SequenceFlow_1w3s635">
+        <di:waypoint x="623" y="542" />
+        <di:waypoint x="623" y="484" />
+        <di:waypoint x="493" y="484" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="611" y="463" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="466" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -130,47 +206,6 @@
           <dc:Bounds x="679" y="599" width="85" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1w3s635_di" bpmnElement="SequenceFlow_1w3s635">
-        <di:waypoint x="623" y="542" />
-        <di:waypoint x="623" y="484" />
-        <di:waypoint x="493" y="484" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="611" y="463" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0cibkry_di" bpmnElement="SequenceFlow_0cibkry">
-        <di:waypoint x="721" y="542" />
-        <di:waypoint x="721" y="484" />
-        <di:waypoint x="493" y="484" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_18010p9_di" bpmnElement="SequenceFlow_18010p9">
-        <di:waypoint x="443" y="524" />
-        <di:waypoint x="443" y="607" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0h6xm2k_di" bpmnElement="SequenceFlow_0h6xm2k">
-        <di:waypoint x="493" y="647" />
-        <di:waypoint x="623" y="647" />
-        <di:waypoint x="623" y="592" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_11bp6p4_di" bpmnElement="SequenceFlow_11bp6p4">
-        <di:waypoint x="648" y="567" />
-        <di:waypoint x="696" y="567" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_19ss4rt_di" bpmnElement="SequenceFlow_19ss4rt">
-        <di:waypoint x="746" y="567" />
-        <di:waypoint x="873" y="567" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0b4aogc_di" bpmnElement="SequenceFlow_0b4aogc">
-        <di:waypoint x="215" y="484" />
-        <di:waypoint x="393" y="484" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="ServiceTask_058lxl7_di" bpmnElement="ServiceTask_058lxl7">
-        <dc:Bounds x="873" y="527" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_01ebw4m_di" bpmnElement="SequenceFlow_01ebw4m">
-        <di:waypoint x="973" y="567" />
-        <di:waypoint x="1219" y="567" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ServiceTask_1htucc1_di" bpmnElement="ServiceTask_1htucc1">
         <dc:Bounds x="1194" y="299" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -198,53 +233,6 @@
       <bpmndi:BPMNShape id="ServiceTask_075paor_di" bpmnElement="ServiceTask_075paor">
         <dc:Bounds x="1595" y="135" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1jmk13k_di" bpmnElement="SequenceFlow_1jmk13k">
-        <di:waypoint x="1447" y="200" />
-        <di:waypoint x="1447" y="339" />
-        <di:waypoint x="1294" y="339" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1isze0w_di" bpmnElement="SequenceFlow_1isze0w">
-        <di:waypoint x="1244" y="410" />
-        <di:waypoint x="1244" y="379" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0pbimrf_di" bpmnElement="SequenceFlow_0pbimrf">
-        <di:waypoint x="1244" y="299" />
-        <di:waypoint x="1244" y="215" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0b91e77_di" bpmnElement="SequenceFlow_0b91e77">
-        <di:waypoint x="1244" y="542" />
-        <di:waypoint x="1244" y="490" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1251" y="518" width="82" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1wcy6r7_di" bpmnElement="SequenceFlow_1wcy6r7">
-        <di:waypoint x="1294" y="175" />
-        <di:waypoint x="1332" y="175" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_10jl285_di" bpmnElement="SequenceFlow_10jl285">
-        <di:waypoint x="1382" y="175" />
-        <di:waypoint x="1422" y="175" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0knn9ma_di" bpmnElement="SequenceFlow_0knn9ma">
-        <di:waypoint x="1472" y="175" />
-        <di:waypoint x="1595" y="175" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1y10mb4_di" bpmnElement="SequenceFlow_1y10mb4">
-        <di:waypoint x="1269" y="567" />
-        <di:waypoint x="1824" y="567" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0jrhdgo_di" bpmnElement="SequenceFlow_0jrhdgo">
-        <di:waypoint x="1695" y="175" />
-        <di:waypoint x="1842" y="175" />
-        <di:waypoint x="1842" y="549" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1a3hvst_di" bpmnElement="SequenceFlow_1a3hvst">
-        <di:waypoint x="1357" y="150" />
-        <di:waypoint x="1357" y="81" />
-        <di:waypoint x="443" y="81" />
-        <di:waypoint x="443" y="444" />
-      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/processes/MPAM_TRIAGE_REQUESTED_CONTRIBUTION.bpmn
+++ b/src/main/resources/processes/MPAM_TRIAGE_REQUESTED_CONTRIBUTION.bpmn
@@ -34,16 +34,12 @@
       <bpmn:outgoing>SequenceFlow_10l93df</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1m917qi</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_10l93df" name="else" sourceRef="ExclusiveGateway_0p3mwpr" targetRef="ServiceTask_0u7de46">
+    <bpmn:sequenceFlow id="SequenceFlow_10l93df" name="else" sourceRef="ExclusiveGateway_0p3mwpr" targetRef="ExclusiveGateway_1aiye3g">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageRequestedContributionOutcome != "Pending"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1m917qi" name="pending" sourceRef="ExclusiveGateway_0p3mwpr" targetRef="ServiceTask_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageRequestedContributionOutcome == "Pending"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_0u7de46" name="Clear DueDate" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;DueDate&#34;)}">
-      <bpmn:incoming>SequenceFlow_10l93df</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_1gdsbt3</bpmn:outgoing>
-    </bpmn:serviceTask>
     <bpmn:endEvent id="EndEvent_155qjcq" name="End Stage">
       <bpmn:incoming>SequenceFlow_1eba3c1</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0ssgyv1</bpmn:incoming>
@@ -54,7 +50,7 @@
       <bpmn:outgoing>SequenceFlow_1dmmweu</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:exclusiveGateway id="ExclusiveGateway_1aiye3g" name="TriageRequestedContributionOutcome?">
-      <bpmn:incoming>SequenceFlow_1gdsbt3</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_10l93df</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1eba3c1</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1a5ltb2</bpmn:outgoing>
     </bpmn:exclusiveGateway>
@@ -99,7 +95,6 @@
     <bpmn:sequenceFlow id="SequenceFlow_0t1dhfb" sourceRef="ExclusiveGateway_1vuskiu" targetRef="ServiceTask_0d0na5b">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1gdsbt3" sourceRef="ServiceTask_0u7de46" targetRef="ExclusiveGateway_1aiye3g" />
     <bpmn:sequenceFlow id="SequenceFlow_17wwsjo" sourceRef="ExclusiveGateway_0dlbolw" targetRef="ServiceTask_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -111,15 +106,15 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_TRIAGE_REQUESTED_CONTRIBUTION">
+      <bpmndi:BPMNEdge id="Flow_19ef0w2_di" bpmnElement="Flow_19ef0w2">
+        <di:waypoint x="390" y="532" />
+        <di:waypoint x="485" y="532" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_17wwsjo_di" bpmnElement="SequenceFlow_17wwsjo">
         <di:waypoint x="1378" y="198" />
         <di:waypoint x="1378" y="81" />
         <di:waypoint x="535" y="81" />
         <di:waypoint x="535" y="492" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1gdsbt3_di" bpmnElement="SequenceFlow_1gdsbt3">
-        <di:waypoint x="1058" y="615" />
-        <di:waypoint x="1240" y="615" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0t1dhfb_di" bpmnElement="SequenceFlow_0t1dhfb">
         <di:waypoint x="1493" y="223" />
@@ -175,9 +170,9 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_10l93df_di" bpmnElement="SequenceFlow_10l93df">
         <di:waypoint x="892" y="615" />
-        <di:waypoint x="958" y="615" />
+        <di:waypoint x="1240" y="615" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="915" y="597" width="21" height="14" />
+          <dc:Bounds x="933" y="597" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0x8dpmn_di" bpmnElement="SequenceFlow_0x8dpmn">
@@ -205,10 +200,9 @@
           <dc:Bounds x="703" y="511" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19ef0w2_di" bpmnElement="Flow_19ef0w2">
-        <di:waypoint x="390" y="532" />
-        <di:waypoint x="485" y="532" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="514" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_05nlmnl_di" bpmnElement="ServiceTask_05nlmnl">
         <dc:Bounds x="485" y="492" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -223,9 +217,6 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="777" y="634" width="84" height="40" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0u7de46_di" bpmnElement="ServiceTask_0u7de46">
-        <dc:Bounds x="958" y="575" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_155qjcq_di" bpmnElement="EndEvent_155qjcq">
         <dc:Bounds x="1648" y="597" width="36" height="36" />
@@ -259,9 +250,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0e3golq_di" bpmnElement="ServiceTask_0e3golq">
         <dc:Bounds x="1215" y="458" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="152" y="514" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_18ccgnf_di" bpmnElement="Activity_18ccgnf">
         <dc:Bounds x="290" y="492" width="100" height="80" />


### PR DESCRIPTION
Update MPAM Draft to allow for Multiple Contribitions. This has involved removing the saving of the note in the stage as the values are no longer used at that point. Also encompasses a fix to go back to MPAM Draft Requested Contributions stage if the user escalates and completes the escalation.