### PR TITLE
HOCS-2026 : new workstack "Rejected" column

### DIFF
--- a/src/main/resources/processes/MPAM_DISPATCH.bpmn
+++ b/src/main/resources/processes/MPAM_DISPATCH.bpmn
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0f0c165" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0f0c165" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.2">
   <bpmn:process id="MPAM_DISPATCH" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_1xm6hds</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:serviceTask id="ServiceTask_0b4g59e" name="User Input" camunda:expression="MPAM_DISPATCH_INPUT" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="Screen_UserInput" name="User Input" camunda:expression="MPAM_DISPATCH_INPUT" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_00y2poj</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1xm6hds</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1q3ar1f</bpmn:incoming>
@@ -14,7 +14,7 @@
       <bpmn:incoming>Flow_05292wb</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1aqlt9g</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_0lu66xh" name="Validate User Input">
+    <bpmn:userTask id="Validate_UserInput" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_1aqlt9g</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_07a9jvv</bpmn:outgoing>
     </bpmn:userTask>
@@ -23,22 +23,22 @@
       <bpmn:outgoing>SequenceFlow_00y2poj</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_16rbk3g</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:endEvent id="EndEvent_1twktcd" name="End Stage">
+    <bpmn:endEvent id="EndEvent_MpamDispatch" name="End Stage">
       <bpmn:incoming>SequenceFlow_10lr0eq</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_10b5w9p</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0sx7144</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_04xppk0</bpmn:incoming>
       <bpmn:incoming>Flow_01a96j1</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_00y2poj" name="false" sourceRef="ExclusiveGateway_0qhopqu" targetRef="ServiceTask_0b4g59e">
+    <bpmn:sequenceFlow id="SequenceFlow_00y2poj" name="false" sourceRef="ExclusiveGateway_0qhopqu" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1aqlt9g" sourceRef="ServiceTask_0b4g59e" targetRef="UserTask_0lu66xh" />
-    <bpmn:sequenceFlow id="SequenceFlow_07a9jvv" sourceRef="UserTask_0lu66xh" targetRef="ExclusiveGateway_0qhopqu" />
+    <bpmn:sequenceFlow id="SequenceFlow_1aqlt9g" sourceRef="Screen_UserInput" targetRef="Validate_UserInput" />
+    <bpmn:sequenceFlow id="SequenceFlow_07a9jvv" sourceRef="Validate_UserInput" targetRef="ExclusiveGateway_0qhopqu" />
     <bpmn:sequenceFlow id="SequenceFlow_16rbk3g" sourceRef="ExclusiveGateway_0qhopqu" targetRef="ExclusiveGateway_1tbni0t">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1xm6hds" sourceRef="StartEvent_1" targetRef="ServiceTask_0b4g59e" />
+    <bpmn:sequenceFlow id="SequenceFlow_1xm6hds" sourceRef="StartEvent_1" targetRef="Screen_UserInput" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_1tbni0t" name="DispatchStatus?">
       <bpmn:incoming>SequenceFlow_16rbk3g</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_10lr0eq</bpmn:outgoing>
@@ -48,10 +48,10 @@
       <bpmn:outgoing>SequenceFlow_15watom</bpmn:outgoing>
       <bpmn:outgoing>Flow_08ggksa</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_10lr0eq" name="else" sourceRef="ExclusiveGateway_1tbni0t" targetRef="EndEvent_1twktcd">
+    <bpmn:sequenceFlow id="SequenceFlow_10lr0eq" name="else" sourceRef="ExclusiveGateway_1tbni0t" targetRef="EndEvent_MpamDispatch">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DispatchStatus != "Pending" &amp;&amp; DispatchStatus != "Dispatched-Follow-Up" &amp;&amp; DispatchStatus != "PutOnCampaign" &amp;&amp; DispatchStatus != "ReturnToDraft" &amp;&amp; DispatchStatus != "CloseCaseTelephone"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1q3ar1f" name="Pending" sourceRef="ExclusiveGateway_1tbni0t" targetRef="ServiceTask_0b4g59e">
+    <bpmn:sequenceFlow id="SequenceFlow_1q3ar1f" name="Pending" sourceRef="ExclusiveGateway_1tbni0t" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DispatchStatus == "Pending"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="ServiceTask_0ovavda" name="Dispatched-Follow-Up Input" camunda:expression="MPAM_DISPATCH_FOLLOW_UP_INPUT" camunda:resultVariable="screen">
@@ -88,11 +88,11 @@
     <bpmn:sequenceFlow id="SequenceFlow_1k578ca" sourceRef="ExclusiveGateway_0rvoeoq" targetRef="ExclusiveGateway_1a61kuq">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_10b5w9p" sourceRef="ServiceTask_1fj5q51" targetRef="EndEvent_1twktcd" />
+    <bpmn:sequenceFlow id="SequenceFlow_10b5w9p" sourceRef="ServiceTask_1fj5q51" targetRef="EndEvent_MpamDispatch" />
     <bpmn:sequenceFlow id="SequenceFlow_0fmyo06" name="Dispatched-Follow-Up" sourceRef="ExclusiveGateway_1tbni0t" targetRef="ServiceTask_0ovavda">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DispatchStatus == "Dispatched-Follow-Up"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_09ee0nd" sourceRef="ExclusiveGateway_0rvoeoq" targetRef="ServiceTask_0b4g59e">
+    <bpmn:sequenceFlow id="SequenceFlow_09ee0nd" sourceRef="ExclusiveGateway_0rvoeoq" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION != "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="ServiceTask_1vhkhed" name="Request Campaign" camunda:expression="MPAM_CAMPAIGN_REQUEST" camunda:resultVariable="screen">
@@ -134,19 +134,19 @@
     <bpmn:sequenceFlow id="SequenceFlow_0f29rl5" sourceRef="ExclusiveGateway_0kbch9f" targetRef="ServiceTask_0azedre">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0sx7144" sourceRef="ServiceTask_0azedre" targetRef="EndEvent_1twktcd" />
+    <bpmn:sequenceFlow id="SequenceFlow_0sx7144" sourceRef="ServiceTask_0azedre" targetRef="EndEvent_MpamDispatch" />
     <bpmn:sequenceFlow id="SequenceFlow_0hn33qp" name="PutOnCampaign" sourceRef="ExclusiveGateway_1tbni0t" targetRef="ServiceTask_06diycs">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DispatchStatus == "PutOnCampaign"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1r0q0e5" sourceRef="ExclusiveGateway_1g8elho" targetRef="ServiceTask_0b4g59e">
+    <bpmn:sequenceFlow id="SequenceFlow_1r0q0e5" sourceRef="ExclusiveGateway_1g8elho" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_1thtqcl" name="Return To Draft Input" camunda:expression="MPAM_DISPATCH_RETURN_TO_DRAFT" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="Screen_ReturnToDraftInput" name="Return To Draft Input" camunda:expression="MPAM_DISPATCH_RETURN_TO_DRAFT" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_1u6ahcg</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_15watom</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0snlmfh</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_0aexn2l" name="Validate User Input">
+    <bpmn:userTask id="Validate_ReturnToDraftInput" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_0snlmfh</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1izyub4</bpmn:outgoing>
     </bpmn:userTask>
@@ -160,33 +160,33 @@
       <bpmn:outgoing>SequenceFlow_1u6ahcg</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_007zoax</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1u6ahcg" sourceRef="ExclusiveGateway_1vi0wlt" targetRef="ServiceTask_1thtqcl">
+    <bpmn:sequenceFlow id="SequenceFlow_1u6ahcg" sourceRef="ExclusiveGateway_1vi0wlt" targetRef="Screen_ReturnToDraftInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0snlmfh" sourceRef="ServiceTask_1thtqcl" targetRef="UserTask_0aexn2l" />
-    <bpmn:sequenceFlow id="SequenceFlow_1izyub4" sourceRef="UserTask_0aexn2l" targetRef="ExclusiveGateway_09dvm0d" />
+    <bpmn:sequenceFlow id="SequenceFlow_0snlmfh" sourceRef="Screen_ReturnToDraftInput" targetRef="Validate_ReturnToDraftInput" />
+    <bpmn:sequenceFlow id="SequenceFlow_1izyub4" sourceRef="Validate_ReturnToDraftInput" targetRef="ExclusiveGateway_09dvm0d" />
     <bpmn:sequenceFlow id="SequenceFlow_1m3htub" sourceRef="ExclusiveGateway_09dvm0d" targetRef="ExclusiveGateway_1vi0wlt">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_15watom" sourceRef="ExclusiveGateway_1tbni0t" targetRef="ServiceTask_1thtqcl">
+    <bpmn:sequenceFlow id="SequenceFlow_15watom" sourceRef="ExclusiveGateway_1tbni0t" targetRef="Screen_ReturnToDraftInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DispatchStatus == "ReturnToDraft"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_1ncv1jy" name="Save Return Reason Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_DispatchReturnToDraft&#34;), &#34;REJECT&#34;)}">
+    <bpmn:serviceTask id="Service_SaveReturnReasonNote" name="Save Return Reason Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_DispatchReturnToDraft&#34;), &#34;REJECT&#34;)}">
       <bpmn:incoming>SequenceFlow_007zoax</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_05zf7kt</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_007zoax" sourceRef="ExclusiveGateway_1vi0wlt" targetRef="ServiceTask_1ncv1jy">
+    <bpmn:sequenceFlow id="SequenceFlow_007zoax" sourceRef="ExclusiveGateway_1vi0wlt" targetRef="Service_SaveReturnReasonNote">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_05zf7kt" sourceRef="ServiceTask_1ncv1jy" targetRef="ServiceTask_1gqh0c4" />
-    <bpmn:sequenceFlow id="SequenceFlow_0gd1ade" sourceRef="ExclusiveGateway_09dvm0d" targetRef="ServiceTask_0b4g59e">
+    <bpmn:sequenceFlow id="SequenceFlow_05zf7kt" sourceRef="Service_SaveReturnReasonNote" targetRef="Service_UpdateToRejectedByDispatch" />
+    <bpmn:sequenceFlow id="SequenceFlow_0gd1ade" sourceRef="ExclusiveGateway_09dvm0d" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION != "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_1gqh0c4" name="Update Team for Draft" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_DRAFT&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
-      <bpmn:incoming>SequenceFlow_05zf7kt</bpmn:incoming>
+    <bpmn:serviceTask id="Service_UpdateTeamForDraft" name="Update Team for Draft" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_DRAFT&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
+      <bpmn:incoming>SequenceFlow_0pv0b4d</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_04xppk0</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_04xppk0" sourceRef="ServiceTask_1gqh0c4" targetRef="EndEvent_1twktcd" />
+    <bpmn:sequenceFlow id="SequenceFlow_04xppk0" sourceRef="Service_UpdateTeamForDraft" targetRef="EndEvent_MpamDispatch" />
     <bpmn:userTask id="Activity_0dqpxvd" name="Validate User Input">
       <bpmn:incoming>Flow_0h6rnnj</bpmn:incoming>
       <bpmn:outgoing>Flow_0nt8r1n</bpmn:outgoing>
@@ -221,13 +221,18 @@
     <bpmn:sequenceFlow id="Flow_0ic9zi8" sourceRef="Gateway_0hum8uw" targetRef="Activity_08te8ix">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_01a96j1" sourceRef="Activity_08te8ix" targetRef="EndEvent_1twktcd" />
-    <bpmn:sequenceFlow id="Flow_05292wb" sourceRef="Gateway_08rrjmj" targetRef="ServiceTask_0b4g59e">
+    <bpmn:sequenceFlow id="Flow_01a96j1" sourceRef="Activity_08te8ix" targetRef="EndEvent_MpamDispatch" />
+    <bpmn:sequenceFlow id="Flow_05292wb" sourceRef="Gateway_08rrjmj" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_08ggksa" sourceRef="ExclusiveGateway_1tbni0t" targetRef="Activity_0guckoy">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DispatchStatus == "CloseCaseTelephone"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="Service_UpdateToRejectedByDispatch" name="Update to Rejected by Dispatch" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;Rejected&#34;, &#34;By Dispatch&#34;)}">
+      <bpmn:incoming>SequenceFlow_05zf7kt</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0pv0b4d</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0pv0b4d" sourceRef="Service_UpdateToRejectedByDispatch" targetRef="Service_UpdateTeamForDraft" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_DISPATCH">
@@ -242,15 +247,15 @@
         <di:waypoint x="485" y="456" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01a96j1_di" bpmnElement="Flow_01a96j1">
-        <di:waypoint x="750" y="260" />
-        <di:waypoint x="1300" y="260" />
-        <di:waypoint x="1350" y="470" />
-        <di:waypoint x="1370" y="560" />
+        <di:waypoint x="700" y="190" />
+        <di:waypoint x="700" y="40" />
+        <di:waypoint x="1637" y="40" />
+        <di:waypoint x="1637" y="551" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ic9zi8_di" bpmnElement="Flow_0ic9zi8">
         <di:waypoint x="490" y="315" />
-        <di:waypoint x="490" y="160" />
-        <di:waypoint x="650" y="213" />
+        <di:waypoint x="490" y="230" />
+        <di:waypoint x="650" y="230" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1s2b2g3_di" bpmnElement="Flow_1s2b2g3">
         <di:waypoint x="490" y="365" />
@@ -271,9 +276,9 @@
         <di:waypoint x="750" y="340" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_04xppk0_di" bpmnElement="SequenceFlow_04xppk0">
-        <di:waypoint x="1344" y="1069" />
-        <di:waypoint x="1386" y="1069" />
-        <di:waypoint x="1386" y="587" />
+        <di:waypoint x="1589" y="1069" />
+        <di:waypoint x="1637" y="1069" />
+        <di:waypoint x="1637" y="587" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0gd1ade_di" bpmnElement="SequenceFlow_0gd1ade">
         <di:waypoint x="1026" y="1232" />
@@ -283,12 +288,12 @@
         <di:waypoint x="385" y="503" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_05zf7kt_di" bpmnElement="SequenceFlow_05zf7kt">
-        <di:waypoint x="1193" y="1069" />
-        <di:waypoint x="1244" y="1069" />
+        <di:waypoint x="1269" y="1069" />
+        <di:waypoint x="1331" y="1069" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_007zoax_di" bpmnElement="SequenceFlow_007zoax">
         <di:waypoint x="1051" y="1069" />
-        <di:waypoint x="1093" y="1069" />
+        <di:waypoint x="1169" y="1069" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_15watom_di" bpmnElement="SequenceFlow_15watom">
         <di:waypoint x="650" y="594" />
@@ -327,13 +332,13 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0sx7144_di" bpmnElement="SequenceFlow_0sx7144">
-        <di:waypoint x="1360" y="176" />
-        <di:waypoint x="1386" y="176" />
-        <di:waypoint x="1386" y="551" />
+        <di:waypoint x="1589" y="176" />
+        <di:waypoint x="1637" y="176" />
+        <di:waypoint x="1637" y="551" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0f29rl5_di" bpmnElement="SequenceFlow_0f29rl5">
         <di:waypoint x="1235" y="176" />
-        <di:waypoint x="1260" y="176" />
+        <di:waypoint x="1489" y="176" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0mzxvus_di" bpmnElement="SequenceFlow_0mzxvus">
         <di:waypoint x="1145" y="176" />
@@ -373,8 +378,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_10b5w9p_di" bpmnElement="SequenceFlow_10b5w9p">
         <di:waypoint x="1269" y="796" />
-        <di:waypoint x="1386" y="796" />
-        <di:waypoint x="1386" y="587" />
+        <di:waypoint x="1637" y="796" />
+        <di:waypoint x="1637" y="587" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1k578ca_di" bpmnElement="SequenceFlow_1k578ca">
         <di:waypoint x="1026" y="909" />
@@ -406,9 +411,9 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_10lr0eq_di" bpmnElement="SequenceFlow_10lr0eq">
         <di:waypoint x="675" y="569" />
-        <di:waypoint x="1368" y="569" />
+        <di:waypoint x="1619" y="569" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="710" y="550" width="21" height="14" />
+          <dc:Bounds x="726" y="550" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1xm6hds_di" bpmnElement="SequenceFlow_1xm6hds">
@@ -439,19 +444,19 @@
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="468" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0b4g59e_di" bpmnElement="ServiceTask_0b4g59e">
+      <bpmndi:BPMNShape id="ServiceTask_0b4g59e_di" bpmnElement="Screen_UserInput">
         <dc:Bounds x="385" y="446" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_0lu66xh_di" bpmnElement="UserTask_0lu66xh">
+      <bpmndi:BPMNShape id="UserTask_0lu66xh_di" bpmnElement="Validate_UserInput">
         <dc:Bounds x="385" y="609" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0qhopqu_di" bpmnElement="ExclusiveGateway_0qhopqu" isMarkerVisible="true">
         <dc:Bounds x="545" y="544" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_1twktcd_di" bpmnElement="EndEvent_1twktcd">
-        <dc:Bounds x="1368" y="551" width="36" height="36" />
+      <bpmndi:BPMNShape id="EndEvent_1twktcd_di" bpmnElement="EndEvent_MpamDispatch">
+        <dc:Bounds x="1619" y="551" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1414" y="562" width="52" height="14" />
+          <dc:Bounds x="1665" y="562" width="52" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1tbni0t_di" bpmnElement="ExclusiveGateway_1tbni0t" isMarkerVisible="true">
@@ -494,15 +499,15 @@
         <dc:Bounds x="1185" y="151" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0azedre_di" bpmnElement="ServiceTask_0azedre">
-        <dc:Bounds x="1260" y="136" width="100" height="80" />
+        <dc:Bounds x="1489" y="136" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_06diycs_di" bpmnElement="ServiceTask_06diycs">
         <dc:Bounds x="957" y="411" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1thtqcl_di" bpmnElement="ServiceTask_1thtqcl">
+      <bpmndi:BPMNShape id="ServiceTask_1thtqcl_di" bpmnElement="Screen_ReturnToDraftInput">
         <dc:Bounds x="783" y="1029" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_0aexn2l_di" bpmnElement="UserTask_0aexn2l">
+      <bpmndi:BPMNShape id="UserTask_0aexn2l_di" bpmnElement="Validate_ReturnToDraftInput">
         <dc:Bounds x="783" y="1167" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_09dvm0d_di" bpmnElement="ExclusiveGateway_09dvm0d" isMarkerVisible="true">
@@ -514,11 +519,11 @@
       <bpmndi:BPMNShape id="ExclusiveGateway_1vi0wlt_di" bpmnElement="ExclusiveGateway_1vi0wlt" isMarkerVisible="true">
         <dc:Bounds x="1001" y="1044" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1ncv1jy_di" bpmnElement="ServiceTask_1ncv1jy">
-        <dc:Bounds x="1093" y="1029" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_1ncv1jy_di" bpmnElement="Service_SaveReturnReasonNote">
+        <dc:Bounds x="1169" y="1029" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1gqh0c4_di" bpmnElement="ServiceTask_1gqh0c4">
-        <dc:Bounds x="1244" y="1029" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_1gqh0c4_di" bpmnElement="Service_UpdateTeamForDraft">
+        <dc:Bounds x="1489" y="1029" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0dqpxvd_di" bpmnElement="Activity_0dqpxvd">
         <dc:Bounds x="650" y="300" width="100" height="80" />
@@ -535,6 +540,13 @@
       <bpmndi:BPMNShape id="Activity_08te8ix_di" bpmnElement="Activity_08te8ix">
         <dc:Bounds x="650" y="190" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0tj3fie_di" bpmnElement="Service_UpdateToRejectedByDispatch">
+        <dc:Bounds x="1331" y="1029" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0pv0b4d_di" bpmnElement="SequenceFlow_0pv0b4d">
+        <di:waypoint x="1431" y="1069" />
+        <di:waypoint x="1489" y="1069" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/processes/MPAM_DRAFT.bpmn
+++ b/src/main/resources/processes/MPAM_DRAFT.bpmn
@@ -4,7 +4,7 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_1ivlngt</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:serviceTask id="ServiceTask_0orq4iy" name="User Input" camunda:expression="MPAM_DRAFT_INPUT" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="Screen_UserInput" name="User Input" camunda:expression="MPAM_DRAFT_INPUT" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_0jno6nt</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1ivlngt</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0uxr910</bpmn:incoming>
@@ -18,7 +18,7 @@
       <bpmn:incoming>Flow_1fj82vn</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1u7cdfq</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="Validate_UserInput_00s8k9f" name="Validate User Input">
+    <bpmn:userTask id="Validate_UserInput" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_1u7cdfq</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0sfu5f2</bpmn:outgoing>
     </bpmn:userTask>
@@ -27,31 +27,30 @@
       <bpmn:outgoing>SequenceFlow_0jno6nt</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_00pezmh</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:endEvent id="EndEvent_168jcnt" name="End Stage">
-      <bpmn:incoming>SequenceFlow_0aqbfj5</bpmn:incoming>
+    <bpmn:endEvent id="EndEvent_MpamDraft" name="End Stage">
       <bpmn:incoming>SequenceFlow_03zr4wl</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_1ghiqr1</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1vhqq32</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0dp8d8d</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0gqz21i</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0g9rtos</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1cv2gqf</bpmn:incoming>
       <bpmn:incoming>Flow_0lluryd</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_008xny7</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_0jno6nt" name="false" sourceRef="ExclusiveGateway_0urib3x" targetRef="ServiceTask_0orq4iy">
+    <bpmn:sequenceFlow id="SequenceFlow_0jno6nt" name="false" sourceRef="ExclusiveGateway_0urib3x" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1u7cdfq" sourceRef="ServiceTask_0orq4iy" targetRef="Validate_UserInput_00s8k9f" />
-    <bpmn:sequenceFlow id="SequenceFlow_0sfu5f2" sourceRef="Validate_UserInput_00s8k9f" targetRef="ExclusiveGateway_0ytznox" />
+    <bpmn:sequenceFlow id="SequenceFlow_1u7cdfq" sourceRef="Screen_UserInput" targetRef="Validate_UserInput" />
+    <bpmn:sequenceFlow id="SequenceFlow_0sfu5f2" sourceRef="Validate_UserInput" targetRef="ExclusiveGateway_0ytznox" />
     <bpmn:sequenceFlow id="SequenceFlow_00pezmh" sourceRef="ExclusiveGateway_0urib3x" targetRef="ExclusiveGateway_0i7ko22">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1ivlngt" sourceRef="StartEvent_1" targetRef="ServiceTask_0orq4iy" />
-    <bpmn:serviceTask id="ServiceTask_0gan568" name="Update Team for QA" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_QA&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
+    <bpmn:sequenceFlow id="SequenceFlow_1ivlngt" sourceRef="StartEvent_1" targetRef="Screen_UserInput" />
+    <bpmn:serviceTask id="Service_UpdateTeamForQa" name="Update Team for QA" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_QA&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
       <bpmn:incoming>SequenceFlow_0pjwwfb</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0aqbfj5</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0aqbfj5" sourceRef="ServiceTask_0gan568" targetRef="EndEvent_168jcnt" />
+    <bpmn:sequenceFlow id="SequenceFlow_0aqbfj5" sourceRef="Service_UpdateTeamForQa" targetRef="Service_ClearRejected" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_0i7ko22" name="Pending?">
       <bpmn:incoming>SequenceFlow_00pezmh</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_005sc5v</bpmn:outgoing>
@@ -60,7 +59,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_005sc5v" sourceRef="ExclusiveGateway_0i7ko22" targetRef="Gateway_0b9xe9y">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus != "Pending"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0uxr910" sourceRef="ExclusiveGateway_0i7ko22" targetRef="ServiceTask_0orq4iy">
+    <bpmn:sequenceFlow id="SequenceFlow_0uxr910" sourceRef="ExclusiveGateway_0i7ko22" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus == "Pending"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_0vqlqgx" name="DraftStatus?">
@@ -73,20 +72,20 @@
       <bpmn:outgoing>SequenceFlow_1fr0z6a</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1pja3kr</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_0pjwwfb" name="QA" sourceRef="ExclusiveGateway_0vqlqgx" targetRef="ServiceTask_0gan568">
+    <bpmn:sequenceFlow id="SequenceFlow_0pjwwfb" name="QA" sourceRef="ExclusiveGateway_0vqlqgx" targetRef="Service_UpdateTeamForQa">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus == "QA"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_03zr4wl" sourceRef="ExclusiveGateway_0vqlqgx" targetRef="EndEvent_168jcnt">
+    <bpmn:sequenceFlow id="SequenceFlow_03zr4wl" sourceRef="ExclusiveGateway_0vqlqgx" targetRef="EndEvent_MpamDraft">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus != "QA" &amp;&amp; DraftStatus != "Dispatch" &amp;&amp; DraftStatus != "RequestContribution" &amp;&amp; DraftStatus != "PutOnCampaign" &amp;&amp; DraftStatus != "ReturnToTriage" &amp;&amp; DraftStatus != "Escalate" &amp;&amp; DraftStatus != "CloseCaseTelephone"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_11r8lcn" name="Update Team for Dispatch" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_DISPATCH&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
+    <bpmn:serviceTask id="Service_UpdateTeamForDispatch" name="Update Team for Dispatch" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_DISPATCH&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
       <bpmn:incoming>SequenceFlow_1aeymqx</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1ghiqr1</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_1aeymqx" name="Dispatch" sourceRef="ExclusiveGateway_0vqlqgx" targetRef="ServiceTask_11r8lcn">
+    <bpmn:sequenceFlow id="SequenceFlow_1aeymqx" name="Dispatch" sourceRef="ExclusiveGateway_0vqlqgx" targetRef="Service_UpdateTeamForDispatch">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus == "Dispatch"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1ghiqr1" sourceRef="ServiceTask_11r8lcn" targetRef="EndEvent_168jcnt" />
+    <bpmn:sequenceFlow id="SequenceFlow_1ghiqr1" sourceRef="Service_UpdateTeamForDispatch" targetRef="Service_ClearRejected" />
     <bpmn:serviceTask id="ServiceTask_0bgc7h6" name="Request Contribution Input" camunda:expression="MPAM_DRAFT_REQUEST_CONTRIBUTION_INPUT" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_1cyjbu4</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1ovhqwj</bpmn:incoming>
@@ -124,10 +123,10 @@
     <bpmn:sequenceFlow id="SequenceFlow_1ovhqwj" name="RequestContribution" sourceRef="ExclusiveGateway_0vqlqgx" targetRef="ServiceTask_0bgc7h6">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus == "RequestContribution"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0fo9wb7" sourceRef="ExclusiveGateway_0ro8o4c" targetRef="ServiceTask_0orq4iy">
+    <bpmn:sequenceFlow id="SequenceFlow_0fo9wb7" sourceRef="ExclusiveGateway_0ro8o4c" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION != "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1vhqq32" sourceRef="ServiceTask_020e9dh" targetRef="EndEvent_168jcnt" />
+    <bpmn:sequenceFlow id="SequenceFlow_1vhqq32" sourceRef="ServiceTask_020e9dh" targetRef="EndEvent_MpamDraft" />
     <bpmn:serviceTask id="ServiceTask_09dgtiv" name="Business Area" camunda:expression="MPAM_BUSINESS_AREA" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_05qrq6b</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0lq7xmj</bpmn:incoming>
@@ -175,8 +174,8 @@
     <bpmn:sequenceFlow id="SequenceFlow_0lq7xmj" sourceRef="ExclusiveGateway_0ytznox" targetRef="ServiceTask_09dgtiv">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "UpdateBusinessArea"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0dp8d8d" sourceRef="ServiceTask_02f5ipq" targetRef="EndEvent_168jcnt" />
-    <bpmn:sequenceFlow id="SequenceFlow_15tk81s" name="BACKWARD" sourceRef="ExclusiveGateway_0244uy2" targetRef="ServiceTask_0orq4iy">
+    <bpmn:sequenceFlow id="SequenceFlow_0dp8d8d" sourceRef="ServiceTask_02f5ipq" targetRef="EndEvent_MpamDraft" />
+    <bpmn:sequenceFlow id="SequenceFlow_15tk81s" name="BACKWARD" sourceRef="ExclusiveGateway_0244uy2" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="Screen_RefTypeToOfficial_0ia1i5c" name="Reference Type To Offical" camunda:expression="MPAM_REFTYPE_TO_OFFICIAL" camunda:resultVariable="screen">
@@ -206,7 +205,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_0a5rk4w" name="FORWARD" sourceRef="ExclusiveGateway_1v05dfs" targetRef="ExclusiveGateway_1fuk0q6">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0mdieu9" sourceRef="ExclusiveGateway_1v05dfs" targetRef="ServiceTask_0orq4iy">
+    <bpmn:sequenceFlow id="SequenceFlow_0mdieu9" sourceRef="ExclusiveGateway_1v05dfs" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0654hf2" sourceRef="ExclusiveGateway_0ytznox" targetRef="ExclusiveGateway_10wtbjv">
@@ -253,7 +252,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_1uojgpn" sourceRef="ExclusiveGateway_10wtbjv" targetRef="Screen_ReferenceTypeToMinisterial_1unkg32">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${RefType == "Official"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1y4lk7l" sourceRef="ExclusiveGateway_0ofzr32" targetRef="ServiceTask_0orq4iy">
+    <bpmn:sequenceFlow id="SequenceFlow_1y4lk7l" sourceRef="ExclusiveGateway_0ofzr32" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_0324wwr">
@@ -328,20 +327,20 @@
     <bpmn:sequenceFlow id="SequenceFlow_1g3wsd7" name="PutOnCampaign" sourceRef="ExclusiveGateway_0vqlqgx" targetRef="ServiceTask_0odp2jk">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus == "PutOnCampaign"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0gqz21i" sourceRef="ServiceTask_18twh6m" targetRef="EndEvent_168jcnt" />
-    <bpmn:sequenceFlow id="SequenceFlow_103d2ja" sourceRef="ExclusiveGateway_0t7v4cm" targetRef="ServiceTask_0orq4iy">
+    <bpmn:sequenceFlow id="SequenceFlow_0gqz21i" sourceRef="ServiceTask_18twh6m" targetRef="EndEvent_MpamDraft" />
+    <bpmn:sequenceFlow id="SequenceFlow_103d2ja" sourceRef="ExclusiveGateway_0t7v4cm" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_04x3wer" name="Return to Triage Input" camunda:expression="MPAM_DRAFT_RETURN_TO_TRIAGE_INPUT" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="Screen_ReturnToTriageInput" name="Return to Triage Input" camunda:expression="MPAM_DRAFT_RETURN_TO_TRIAGE_INPUT" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_0x3n8a2</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1fr0z6a</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1ub6tn0</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_19pg3ps" name="Validate User Input">
+    <bpmn:userTask id="Validate_ReturnToTriageInput" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_1ub6tn0</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1san5kn</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:serviceTask id="ServiceTask_1g130bo" name="Save Return Reason Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_DraftReturnToTriage&#34;), &#34;REJECT&#34;)}">
+    <bpmn:serviceTask id="Service_SaveReturnReasonNote" name="Save Return Reason Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_DraftReturnToTriage&#34;), &#34;REJECT&#34;)}">
       <bpmn:incoming>SequenceFlow_0jqm2sf</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_09z9m8w</bpmn:outgoing>
     </bpmn:serviceTask>
@@ -355,29 +354,29 @@
       <bpmn:outgoing>SequenceFlow_0x3n8a2</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0jqm2sf</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_0x3n8a2" sourceRef="ExclusiveGateway_11eld8l" targetRef="ServiceTask_04x3wer">
+    <bpmn:sequenceFlow id="SequenceFlow_0x3n8a2" sourceRef="ExclusiveGateway_11eld8l" targetRef="Screen_ReturnToTriageInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1ub6tn0" sourceRef="ServiceTask_04x3wer" targetRef="UserTask_19pg3ps" />
-    <bpmn:sequenceFlow id="SequenceFlow_1san5kn" sourceRef="UserTask_19pg3ps" targetRef="ExclusiveGateway_1vqjfvv" />
-    <bpmn:sequenceFlow id="SequenceFlow_0jqm2sf" sourceRef="ExclusiveGateway_11eld8l" targetRef="ServiceTask_1g130bo">
+    <bpmn:sequenceFlow id="SequenceFlow_1ub6tn0" sourceRef="Screen_ReturnToTriageInput" targetRef="Validate_ReturnToTriageInput" />
+    <bpmn:sequenceFlow id="SequenceFlow_1san5kn" sourceRef="Validate_ReturnToTriageInput" targetRef="ExclusiveGateway_1vqjfvv" />
+    <bpmn:sequenceFlow id="SequenceFlow_0jqm2sf" sourceRef="ExclusiveGateway_11eld8l" targetRef="Service_SaveReturnReasonNote">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1fa0o3g" sourceRef="ExclusiveGateway_1vqjfvv" targetRef="ExclusiveGateway_11eld8l">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1fr0z6a" name="ReturnToTriage" sourceRef="ExclusiveGateway_0vqlqgx" targetRef="ServiceTask_04x3wer">
+    <bpmn:sequenceFlow id="SequenceFlow_1fr0z6a" name="ReturnToTriage" sourceRef="ExclusiveGateway_0vqlqgx" targetRef="Screen_ReturnToTriageInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus == "ReturnToTriage"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_09z9m8w" sourceRef="ServiceTask_1g130bo" targetRef="ServiceTask_1q6dy1p" />
-    <bpmn:sequenceFlow id="SequenceFlow_00322v6" sourceRef="ExclusiveGateway_1vqjfvv" targetRef="ServiceTask_0orq4iy">
+    <bpmn:sequenceFlow id="SequenceFlow_09z9m8w" sourceRef="Service_SaveReturnReasonNote" targetRef="Service_UpdateToRejectedByDraft" />
+    <bpmn:sequenceFlow id="SequenceFlow_00322v6" sourceRef="ExclusiveGateway_1vqjfvv" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION != "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_1q6dy1p" name="Update Team for Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_TRIAGE&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
-      <bpmn:incoming>SequenceFlow_09z9m8w</bpmn:incoming>
+    <bpmn:serviceTask id="Service_UpdateTeamForTriage" name="Update Team for Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_TRIAGE&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
+      <bpmn:incoming>SequenceFlow_0zjzk4u</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0g9rtos</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0g9rtos" sourceRef="ServiceTask_1q6dy1p" targetRef="EndEvent_168jcnt" />
+    <bpmn:sequenceFlow id="SequenceFlow_0g9rtos" sourceRef="Service_UpdateTeamForTriage" targetRef="EndEvent_MpamDraft" />
     <bpmn:userTask id="UserTask_1p8m3a6" name="Escalate to Workflow Manager Input">
       <bpmn:incoming>SequenceFlow_1e18l7v</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1a585n6</bpmn:outgoing>
@@ -415,10 +414,10 @@
     <bpmn:sequenceFlow id="SequenceFlow_1h3zog3" sourceRef="Gateway_1epylox" targetRef="ServiceTask_1kt4ox6">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1c2609g" sourceRef="Gateway_1gfg1ja" targetRef="ServiceTask_0orq4iy">
+    <bpmn:sequenceFlow id="SequenceFlow_1c2609g" sourceRef="Gateway_1gfg1ja" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION != "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1cv2gqf" sourceRef="ServiceTask_10701e0" targetRef="EndEvent_168jcnt" />
+    <bpmn:sequenceFlow id="SequenceFlow_1cv2gqf" sourceRef="ServiceTask_10701e0" targetRef="EndEvent_MpamDraft" />
     <bpmn:serviceTask id="Service_SaveRefTypeChangeCaseNote_1yc1ce2" name="Save Ref Type Change Case Note" camunda:expression="${bpmnService.createCaseConversionNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_TriageChangeCaseType&#34;))}">
       <bpmn:incoming>SequenceFlow_1pkybrv</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0jenwmy</bpmn:incoming>
@@ -458,14 +457,14 @@
     <bpmn:sequenceFlow id="Flow_038qx54" sourceRef="Gateway_1lkkdav" targetRef="Gateway_1a9m6zu">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1fj82vn" name="Return To Triage" sourceRef="Gateway_1lkkdav" targetRef="ServiceTask_0orq4iy">
+    <bpmn:sequenceFlow id="Flow_1fj82vn" name="Return To Triage" sourceRef="Gateway_1lkkdav" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="Activity_0dr9jrd" name="Save Close Case Notes" camunda:expression="${bpmnService.createCaseNote(execution.getVariable(&#34;CaseUUID&#34;), execution.getVariable(&#34;CaseNote_CaseClose&#34;),&#34;CLOSE_CASE_TELEPHONE&#34;)}">
       <bpmn:incoming>Flow_0k28sec</bpmn:incoming>
       <bpmn:outgoing>Flow_0lluryd</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0lluryd" sourceRef="Activity_0dr9jrd" targetRef="EndEvent_168jcnt" />
+    <bpmn:sequenceFlow id="Flow_0lluryd" sourceRef="Activity_0dr9jrd" targetRef="EndEvent_MpamDraft" />
     <bpmn:exclusiveGateway id="Gateway_0b9xe9y">
       <bpmn:incoming>SequenceFlow_005sc5v</bpmn:incoming>
       <bpmn:outgoing>Flow_06gx7kj</bpmn:outgoing>
@@ -479,6 +478,17 @@
       <bpmn:outgoing>SequenceFlow_1lhbixe</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_1lhbixe" sourceRef="Service_ClearMinisterialValues_0xqy6p5" targetRef="ExclusiveGateway_0324wwr" />
+    <bpmn:serviceTask id="Service_UpdateToRejectedByDraft" name="Update to Rejected by Draft" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;Rejected&#34;, &#34;By Draft&#34;)}">
+      <bpmn:incoming>SequenceFlow_09z9m8w</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0zjzk4u</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0zjzk4u" sourceRef="Service_UpdateToRejectedByDraft" targetRef="Service_UpdateTeamForTriage" />
+    <bpmn:serviceTask id="Service_ClearRejected" name="Clear Rejected" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;Rejected&#34;)}">
+      <bpmn:incoming>SequenceFlow_0aqbfj5</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1ghiqr1</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_008xny7</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_008xny7" sourceRef="Service_ClearRejected" targetRef="EndEvent_MpamDraft" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_DRAFT">
@@ -578,7 +588,7 @@
         <di:waypoint x="1339" y="200" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0g9rtos_di" bpmnElement="SequenceFlow_0g9rtos">
-        <di:waypoint x="1903" y="581" />
+        <di:waypoint x="1961" y="581" />
         <di:waypoint x="1987" y="581" />
         <di:waypoint x="1987" y="1642" />
       </bpmndi:BPMNEdge>
@@ -590,7 +600,7 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_09z9m8w_di" bpmnElement="SequenceFlow_09z9m8w">
         <di:waypoint x="1702" y="581" />
-        <di:waypoint x="1803" y="581" />
+        <di:waypoint x="1733" y="581" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1fr0z6a_di" bpmnElement="SequenceFlow_1fr0z6a">
         <di:waypoint x="1011" y="1635" />
@@ -787,8 +797,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0dp8d8d_di" bpmnElement="SequenceFlow_0dp8d8d">
         <di:waypoint x="1310" y="1988" />
-        <di:waypoint x="1404" y="1988" />
-        <di:waypoint x="1404" y="1660" />
+        <di:waypoint x="1593" y="1988" />
+        <di:waypoint x="1593" y="1660" />
         <di:waypoint x="1969" y="1660" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0lq7xmj_di" bpmnElement="SequenceFlow_0lq7xmj">
@@ -872,9 +882,9 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1ghiqr1_di" bpmnElement="SequenceFlow_1ghiqr1">
         <di:waypoint x="1310" y="1867" />
-        <di:waypoint x="1404" y="1867" />
-        <di:waypoint x="1404" y="1660" />
-        <di:waypoint x="1969" y="1660" />
+        <di:waypoint x="1360" y="1867" />
+        <di:waypoint x="1360" y="1748" />
+        <di:waypoint x="1404" y="1748" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1aeymqx_di" bpmnElement="SequenceFlow_1aeymqx">
         <di:waypoint x="1011" y="1685" />
@@ -908,8 +918,6 @@
       <bpmndi:BPMNEdge id="SequenceFlow_0aqbfj5_di" bpmnElement="SequenceFlow_0aqbfj5">
         <di:waypoint x="1310" y="1748" />
         <di:waypoint x="1404" y="1748" />
-        <di:waypoint x="1404" y="1660" />
-        <di:waypoint x="1969" y="1660" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1ivlngt_di" bpmnElement="SequenceFlow_1ivlngt">
         <di:waypoint x="192" y="1577" />
@@ -938,22 +946,22 @@
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="156" y="1559" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0orq4iy_di" bpmnElement="ServiceTask_0orq4iy">
+      <bpmndi:BPMNShape id="ServiceTask_0orq4iy_di" bpmnElement="Screen_UserInput">
         <dc:Bounds x="363" y="1537" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_00s8k9f_di" bpmnElement="Validate_UserInput_00s8k9f">
+      <bpmndi:BPMNShape id="UserTask_00s8k9f_di" bpmnElement="Validate_UserInput">
         <dc:Bounds x="363" y="1700" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0urib3x_di" bpmnElement="ExclusiveGateway_0urib3x" isMarkerVisible="true">
         <dc:Bounds x="568" y="1635" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_168jcnt_di" bpmnElement="EndEvent_168jcnt">
+      <bpmndi:BPMNShape id="EndEvent_168jcnt_di" bpmnElement="EndEvent_MpamDraft">
         <dc:Bounds x="1969" y="1642" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1961" y="1688" width="52" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0gan568_di" bpmnElement="ServiceTask_0gan568">
+      <bpmndi:BPMNShape id="ServiceTask_0gan568_di" bpmnElement="Service_UpdateTeamForQa">
         <dc:Bounds x="1210" y="1708" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0i7ko22_di" bpmnElement="ExclusiveGateway_0i7ko22" isMarkerVisible="true">
@@ -968,7 +976,7 @@
           <dc:Bounds x="930" y="1677" width="62" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_11r8lcn_di" bpmnElement="ServiceTask_11r8lcn">
+      <bpmndi:BPMNShape id="ServiceTask_11r8lcn_di" bpmnElement="Service_UpdateTeamForDispatch">
         <dc:Bounds x="1210" y="1827" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0bgc7h6_di" bpmnElement="ServiceTask_0bgc7h6">
@@ -1079,13 +1087,13 @@
       <bpmndi:BPMNShape id="ServiceTask_0odp2jk_di" bpmnElement="ServiceTask_0odp2jk">
         <dc:Bounds x="1201" y="1480" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_04x3wer_di" bpmnElement="ServiceTask_04x3wer">
+      <bpmndi:BPMNShape id="ServiceTask_04x3wer_di" bpmnElement="Screen_ReturnToTriageInput">
         <dc:Bounds x="1201" y="705" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_19pg3ps_di" bpmnElement="UserTask_19pg3ps">
+      <bpmndi:BPMNShape id="UserTask_19pg3ps_di" bpmnElement="Validate_ReturnToTriageInput">
         <dc:Bounds x="1201" y="541" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1g130bo_di" bpmnElement="ServiceTask_1g130bo">
+      <bpmndi:BPMNShape id="ServiceTask_1g130bo_di" bpmnElement="Service_SaveReturnReasonNote">
         <dc:Bounds x="1602" y="541" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1vqjfvv_di" bpmnElement="ExclusiveGateway_1vqjfvv" isMarkerVisible="true">
@@ -1097,8 +1105,8 @@
       <bpmndi:BPMNShape id="ExclusiveGateway_11eld8l_di" bpmnElement="ExclusiveGateway_11eld8l" isMarkerVisible="true">
         <dc:Bounds x="1418" y="556" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1q6dy1p_di" bpmnElement="ServiceTask_1q6dy1p">
-        <dc:Bounds x="1803" y="541" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_1q6dy1p_di" bpmnElement="Service_UpdateTeamForTriage">
+        <dc:Bounds x="1861" y="541" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1p8m3a6_di" bpmnElement="UserTask_1p8m3a6">
         <dc:Bounds x="1201" y="160" width="100" height="80" />
@@ -1145,6 +1153,22 @@
       <bpmndi:BPMNEdge id="SequenceFlow_1lhbixe_di" bpmnElement="SequenceFlow_1lhbixe">
         <di:waypoint x="1260" y="2537" />
         <di:waypoint x="1260" y="2362" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0oqgjmq_di" bpmnElement="Service_UpdateToRejectedByDraft">
+        <dc:Bounds x="1733" y="541" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0zjzk4u_di" bpmnElement="SequenceFlow_0zjzk4u">
+        <di:waypoint x="1833" y="581" />
+        <di:waypoint x="1861" y="581" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_1vg3hoa_di" bpmnElement="Service_ClearRejected">
+        <dc:Bounds x="1404" y="1708" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_008xny7_di" bpmnElement="SequenceFlow_008xny7">
+        <di:waypoint x="1504" y="1748" />
+        <di:waypoint x="1593" y="1748" />
+        <di:waypoint x="1593" y="1660" />
+        <di:waypoint x="1969" y="1660" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/MPAM_PO.bpmn
+++ b/src/main/resources/processes/MPAM_PO.bpmn
@@ -4,7 +4,7 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_1qy83vz</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:serviceTask id="ServiceTask_1gzmmti" name="User Input" camunda:expression="MPAM_PO_INPUT" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="Screen_UserInput" name="User Input" camunda:expression="MPAM_PO_INPUT" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_00z4amg</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1qy83vz</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_01lome5</bpmn:incoming>
@@ -14,7 +14,7 @@
       <bpmn:incoming>SequenceFlow_0m8nsyv</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0w1broe</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_07rpvqq" name="Validate User Input">
+    <bpmn:userTask id="Validate_UserInput" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_0w1broe</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1kavusf</bpmn:outgoing>
     </bpmn:userTask>
@@ -23,20 +23,20 @@
       <bpmn:outgoing>SequenceFlow_00z4amg</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_05zbf4f</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:endEvent id="EndEvent_1gha3p7" name="End Stage">
+    <bpmn:endEvent id="EndEvent_MpamPo" name="End Stage">
       <bpmn:incoming>SequenceFlow_1cgadsc</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1ee3qna</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_03bvdso</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_00z4amg" name="false" sourceRef="ExclusiveGateway_1vg3xdk" targetRef="ServiceTask_1gzmmti">
+    <bpmn:sequenceFlow id="SequenceFlow_00z4amg" name="false" sourceRef="ExclusiveGateway_1vg3xdk" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0w1broe" sourceRef="ServiceTask_1gzmmti" targetRef="UserTask_07rpvqq" />
-    <bpmn:sequenceFlow id="SequenceFlow_1kavusf" sourceRef="UserTask_07rpvqq" targetRef="ExclusiveGateway_1vg3xdk" />
+    <bpmn:sequenceFlow id="SequenceFlow_0w1broe" sourceRef="Screen_UserInput" targetRef="Validate_UserInput" />
+    <bpmn:sequenceFlow id="SequenceFlow_1kavusf" sourceRef="Validate_UserInput" targetRef="ExclusiveGateway_1vg3xdk" />
     <bpmn:sequenceFlow id="SequenceFlow_05zbf4f" sourceRef="ExclusiveGateway_1vg3xdk" targetRef="ExclusiveGateway_0xwxq6v">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1qy83vz" sourceRef="StartEvent_1" targetRef="ServiceTask_1gzmmti" />
+    <bpmn:sequenceFlow id="SequenceFlow_1qy83vz" sourceRef="StartEvent_1" targetRef="Screen_UserInput" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_1wmdkv9" name="PoStatus?">
       <bpmn:incoming>SequenceFlow_0dnm7od</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_166uhix</bpmn:outgoing>
@@ -47,20 +47,20 @@
     <bpmn:sequenceFlow id="SequenceFlow_166uhix" name="else" sourceRef="ExclusiveGateway_1wmdkv9" targetRef="ServiceTask_05mhyhd">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PoStatus != "Reject-PfS" &amp;&amp; PoStatus != "Dispatched-Follow-Up" &amp;&amp; PoStatus != "PutOnCampaign" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_0rac55u" name="Update Team for Draft" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_DRAFT&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
-      <bpmn:incoming>SequenceFlow_0avpl15</bpmn:incoming>
+    <bpmn:serviceTask id="Service_UpdateTeamForDraft" name="Update Team for Draft" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_DRAFT&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
+      <bpmn:incoming>SequenceFlow_0j1rwm8</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1cgadsc</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0tdq7la" name="Reject to Draft" sourceRef="ExclusiveGateway_1wmdkv9" targetRef="ServiceTask_1jo7fu5">
+    <bpmn:sequenceFlow id="SequenceFlow_0tdq7la" name="Reject to Draft" sourceRef="ExclusiveGateway_1wmdkv9" targetRef="Screen_RejectToDraft">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PoStatus == "Reject-PfS"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1cgadsc" sourceRef="ServiceTask_0rac55u" targetRef="EndEvent_1gha3p7" />
-    <bpmn:serviceTask id="ServiceTask_1jo7fu5" name="User Input" camunda:expression="MPAM_PO_REJECT_PFS" camunda:resultVariable="screen">
+    <bpmn:sequenceFlow id="SequenceFlow_1cgadsc" sourceRef="Service_UpdateTeamForDraft" targetRef="EndEvent_MpamPo" />
+    <bpmn:serviceTask id="Screen_RejectToDraft" name="Reject to Draft" camunda:expression="MPAM_PO_REJECT_PFS" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_0qn193s</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0tdq7la</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_09tchhe</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_0126wtb" name="Validate User Input">
+    <bpmn:userTask id="Validate_RejectToDraft" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_09tchhe</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0mv2muj</bpmn:outgoing>
     </bpmn:userTask>
@@ -74,25 +74,25 @@
       <bpmn:outgoing>SequenceFlow_1pkjx1c</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_01lome5</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_0qn193s" name="false" sourceRef="ExclusiveGateway_16ruuen" targetRef="ServiceTask_1jo7fu5">
+    <bpmn:sequenceFlow id="SequenceFlow_0qn193s" name="false" sourceRef="ExclusiveGateway_16ruuen" targetRef="Screen_RejectToDraft">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_09tchhe" sourceRef="ServiceTask_1jo7fu5" targetRef="UserTask_0126wtb" />
-    <bpmn:sequenceFlow id="SequenceFlow_0mv2muj" sourceRef="UserTask_0126wtb" targetRef="ExclusiveGateway_0wkaeod" />
+    <bpmn:sequenceFlow id="SequenceFlow_09tchhe" sourceRef="Screen_RejectToDraft" targetRef="Validate_RejectToDraft" />
+    <bpmn:sequenceFlow id="SequenceFlow_0mv2muj" sourceRef="Validate_RejectToDraft" targetRef="ExclusiveGateway_0wkaeod" />
     <bpmn:sequenceFlow id="SequenceFlow_1pkjx1c" sourceRef="ExclusiveGateway_0wkaeod" targetRef="ExclusiveGateway_16ruuen">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1uelfix" sourceRef="ExclusiveGateway_16ruuen" targetRef="ServiceTask_0ulpzaj">
+    <bpmn:sequenceFlow id="SequenceFlow_1uelfix" sourceRef="ExclusiveGateway_16ruuen" targetRef="Service_SaveRejectPfsNote">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_01lome5" sourceRef="ExclusiveGateway_0wkaeod" targetRef="ServiceTask_1gzmmti">
+    <bpmn:sequenceFlow id="SequenceFlow_01lome5" sourceRef="ExclusiveGateway_0wkaeod" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_0ulpzaj" name="Save Reject PfS Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_RejectPfs&#34;), &#34;REJECT&#34;)}">
+    <bpmn:serviceTask id="Service_SaveRejectPfsNote" name="Save Reject PfS Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_RejectPfs&#34;), &#34;REJECT&#34;)}">
       <bpmn:incoming>SequenceFlow_1uelfix</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0avpl15</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0avpl15" sourceRef="ServiceTask_0ulpzaj" targetRef="ServiceTask_0rac55u" />
+    <bpmn:sequenceFlow id="SequenceFlow_0avpl15" sourceRef="Service_SaveRejectPfsNote" targetRef="Service_UpdateToRejectedByPo" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_0xwxq6v" name="Pending?">
       <bpmn:incoming>SequenceFlow_05zbf4f</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0dnm7od</bpmn:outgoing>
@@ -101,7 +101,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_0dnm7od" sourceRef="ExclusiveGateway_0xwxq6v" targetRef="ExclusiveGateway_1wmdkv9">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PoStatus != "Pending"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1arl1ga" sourceRef="ExclusiveGateway_0xwxq6v" targetRef="ServiceTask_1gzmmti">
+    <bpmn:sequenceFlow id="SequenceFlow_1arl1ga" sourceRef="ExclusiveGateway_0xwxq6v" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PoStatus == "Pending"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="ServiceTask_05mhyhd" name="User Input" camunda:expression="MPAM_PO_DISPATCH" camunda:resultVariable="screen">
@@ -132,10 +132,10 @@
     <bpmn:sequenceFlow id="SequenceFlow_0knl4ix" sourceRef="ExclusiveGateway_0gkgvb6" targetRef="ExclusiveGateway_0r96bk4">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1u6bh3z" sourceRef="ExclusiveGateway_0gkgvb6" targetRef="ServiceTask_1gzmmti">
+    <bpmn:sequenceFlow id="SequenceFlow_1u6bh3z" sourceRef="ExclusiveGateway_0gkgvb6" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1ee3qna" sourceRef="ExclusiveGateway_0r96bk4" targetRef="EndEvent_1gha3p7">
+    <bpmn:sequenceFlow id="SequenceFlow_1ee3qna" sourceRef="ExclusiveGateway_0r96bk4" targetRef="EndEvent_MpamPo">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="ServiceTask_0c509g3" name="Dispatched-Follow-Up Input" camunda:expression="MPAM_PO_DISPATCH_FOLLOW_UP_INPUT" camunda:resultVariable="screen">
@@ -175,10 +175,10 @@
     <bpmn:sequenceFlow id="SequenceFlow_10hac1o" name="Dispatched-Follow-Up" sourceRef="ExclusiveGateway_1wmdkv9" targetRef="ServiceTask_0c509g3">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PoStatus == "Dispatched-Follow-Up"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1pylyiy" sourceRef="ExclusiveGateway_19lcani" targetRef="ServiceTask_1gzmmti">
+    <bpmn:sequenceFlow id="SequenceFlow_1pylyiy" sourceRef="ExclusiveGateway_19lcani" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION != "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_03bvdso" sourceRef="ServiceTask_05fiu85" targetRef="EndEvent_1gha3p7" />
+    <bpmn:sequenceFlow id="SequenceFlow_03bvdso" sourceRef="ServiceTask_05fiu85" targetRef="EndEvent_MpamPo" />
     <bpmn:serviceTask id="ServiceTask_0wgike1" name="Request Campaign" camunda:expression="MPAM_CAMPAIGN_REQUEST" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_0v9zdbh</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1ukv2t8</bpmn:incoming>
@@ -218,29 +218,34 @@
     <bpmn:sequenceFlow id="SequenceFlow_0jsib7h" sourceRef="ExclusiveGateway_0swwqd2" targetRef="ServiceTask_0q5dmp1">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0m8nsyv" sourceRef="ExclusiveGateway_070ltot" targetRef="ServiceTask_1gzmmti">
+    <bpmn:sequenceFlow id="SequenceFlow_0m8nsyv" sourceRef="ExclusiveGateway_070ltot" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0fn0692" name="PutOnCampaign" sourceRef="ExclusiveGateway_1wmdkv9" targetRef="ServiceTask_1bi8ryl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PoStatus == "PutOnCampaign"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0981kg3" sourceRef="ServiceTask_0q5dmp1" targetRef="ExclusiveGateway_0gkgvb6" />
+    <bpmn:serviceTask id="Service_UpdateToRejectedByPo" name="Update to Rejected by PO" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;Rejected&#34;, &#34;By PO&#34;)}">
+      <bpmn:incoming>SequenceFlow_0avpl15</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0j1rwm8</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0j1rwm8" sourceRef="Service_UpdateToRejectedByPo" targetRef="Service_UpdateTeamForDraft" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_PO">
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="692" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1gzmmti_di" bpmnElement="ServiceTask_1gzmmti">
+      <bpmndi:BPMNShape id="ServiceTask_1gzmmti_di" bpmnElement="Screen_UserInput">
         <dc:Bounds x="385" y="670" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_07rpvqq_di" bpmnElement="UserTask_07rpvqq">
+      <bpmndi:BPMNShape id="UserTask_07rpvqq_di" bpmnElement="Validate_UserInput">
         <dc:Bounds x="385" y="833" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1vg3xdk_di" bpmnElement="ExclusiveGateway_1vg3xdk" isMarkerVisible="true">
         <dc:Bounds x="590" y="768" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_1gha3p7_di" bpmnElement="EndEvent_1gha3p7">
+      <bpmndi:BPMNShape id="EndEvent_1gha3p7_di" bpmnElement="EndEvent_MpamPo">
         <dc:Bounds x="1670" y="775" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1662" y="751" width="52" height="14" />
@@ -286,8 +291,8 @@
           <dc:Bounds x="837" y="709" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="ServiceTask_0rac55u_di" bpmnElement="ServiceTask_0rac55u">
-        <dc:Bounds x="1426" y="1099" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_0rac55u_di" bpmnElement="Service_UpdateTeamForDraft">
+        <dc:Bounds x="1470" y="1099" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0tdq7la_di" bpmnElement="SequenceFlow_0tdq7la">
         <di:waypoint x="777" y="818" />
@@ -298,15 +303,15 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1cgadsc_di" bpmnElement="SequenceFlow_1cgadsc">
-        <di:waypoint x="1526" y="1139" />
+        <di:waypoint x="1570" y="1139" />
         <di:waypoint x="1605" y="1139" />
         <di:waypoint x="1605" y="793" />
         <di:waypoint x="1670" y="793" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="ServiceTask_1jo7fu5_di" bpmnElement="ServiceTask_1jo7fu5">
+      <bpmndi:BPMNShape id="ServiceTask_1jo7fu5_di" bpmnElement="Screen_RejectToDraft">
         <dc:Bounds x="882" y="1016" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_0126wtb_di" bpmnElement="UserTask_0126wtb">
+      <bpmndi:BPMNShape id="UserTask_0126wtb_di" bpmnElement="Validate_RejectToDraft">
         <dc:Bounds x="882" y="1179" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_16ruuen_di" bpmnElement="ExclusiveGateway_16ruuen" isMarkerVisible="true">
@@ -341,7 +346,7 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1uelfix_di" bpmnElement="SequenceFlow_1uelfix">
         <di:waypoint x="1137" y="1139" />
-        <di:waypoint x="1225" y="1139" />
+        <di:waypoint x="1185" y="1139" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_01lome5_di" bpmnElement="SequenceFlow_01lome5">
         <di:waypoint x="1047" y="1244" />
@@ -350,12 +355,12 @@
         <di:waypoint x="291" y="710" />
         <di:waypoint x="385" y="710" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="ServiceTask_0ulpzaj_di" bpmnElement="ServiceTask_0ulpzaj">
-        <dc:Bounds x="1225" y="1099" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_0ulpzaj_di" bpmnElement="Service_SaveRejectPfsNote">
+        <dc:Bounds x="1185" y="1099" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0avpl15_di" bpmnElement="SequenceFlow_0avpl15">
-        <di:waypoint x="1325" y="1139" />
-        <di:waypoint x="1426" y="1139" />
+        <di:waypoint x="1285" y="1139" />
+        <di:waypoint x="1328" y="1139" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_0xwxq6v_di" bpmnElement="ExclusiveGateway_0xwxq6v" isMarkerVisible="true">
         <dc:Bounds x="672" y="768" width="50" height="50" />
@@ -539,8 +544,15 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0981kg3_di" bpmnElement="SequenceFlow_0981kg3">
         <di:waypoint x="1228" y="211" />
-        <di:waypoint x="1493" y="211" />
-        <di:waypoint x="1493" y="470" />
+        <di:waypoint x="1479" y="211" />
+        <di:waypoint x="1479" y="483" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_0njfgwu_di" bpmnElement="Service_UpdateToRejectedByPo">
+        <dc:Bounds x="1328" y="1099" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j1rwm8_di" bpmnElement="SequenceFlow_0j1rwm8">
+        <di:waypoint x="1428" y="1139" />
+        <di:waypoint x="1470" y="1139" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/MPAM_QA.bpmn
+++ b/src/main/resources/processes/MPAM_QA.bpmn
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1a2e3rj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1a2e3rj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.2">
   <bpmn:process id="MPAM_QA" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_0gds0wz</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:serviceTask id="ServiceTask_16s0y5f" name="User Input" camunda:expression="MPAM_QA_INPUT" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="Screen_UserInput" name="User Input" camunda:expression="MPAM_QA_INPUT" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_1hlxbez</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0gds0wz</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1e0ekpm</bpmn:incoming>
@@ -15,7 +15,7 @@
       <bpmn:incoming>Flow_0bam9gx</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0zpho9a</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_1o3wy0c" name="Validate User Input">
+    <bpmn:userTask id="Validate_UserInput" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_0zpho9a</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_17lpgk5</bpmn:outgoing>
     </bpmn:userTask>
@@ -24,7 +24,7 @@
       <bpmn:outgoing>SequenceFlow_1hlxbez</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_06mtb4k</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:endEvent id="EndEvent_1vzq41u" name="End Stage">
+    <bpmn:endEvent id="EndEvent_MpamQa" name="End Stage">
       <bpmn:incoming>SequenceFlow_1d2kn7r</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0wzwk56</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1wz2naw</bpmn:incoming>
@@ -34,15 +34,15 @@
       <bpmn:incoming>SequenceFlow_0q7gev6</bpmn:incoming>
       <bpmn:incoming>Flow_1ml757g</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_1hlxbez" name="false" sourceRef="ExclusiveGateway_0rjn86d" targetRef="ServiceTask_16s0y5f">
+    <bpmn:sequenceFlow id="SequenceFlow_1hlxbez" name="false" sourceRef="ExclusiveGateway_0rjn86d" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0zpho9a" sourceRef="ServiceTask_16s0y5f" targetRef="UserTask_1o3wy0c" />
-    <bpmn:sequenceFlow id="SequenceFlow_17lpgk5" sourceRef="UserTask_1o3wy0c" targetRef="ExclusiveGateway_0rjn86d" />
+    <bpmn:sequenceFlow id="SequenceFlow_0zpho9a" sourceRef="Screen_UserInput" targetRef="Validate_UserInput" />
+    <bpmn:sequenceFlow id="SequenceFlow_17lpgk5" sourceRef="Validate_UserInput" targetRef="ExclusiveGateway_0rjn86d" />
     <bpmn:sequenceFlow id="SequenceFlow_06mtb4k" sourceRef="ExclusiveGateway_0rjn86d" targetRef="ExclusiveGateway_0vd6hib">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0gds0wz" sourceRef="StartEvent_1" targetRef="ServiceTask_16s0y5f" />
+    <bpmn:sequenceFlow id="SequenceFlow_0gds0wz" sourceRef="StartEvent_1" targetRef="Screen_UserInput" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_1m1c3o1">
       <bpmn:incoming>SequenceFlow_19vy1pn</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0qjmcre</bpmn:outgoing>
@@ -73,12 +73,12 @@
     <bpmn:sequenceFlow id="SequenceFlow_0ecwsab" name="else" sourceRef="ExclusiveGateway_0duns45" targetRef="Gateway_098y43t">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QaStatus != "PutOnCampaign"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_0gqk0h1" name="User Input" camunda:expression="MPAM_QA_REJECT_TRIAGE" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="Screen_RejectToTriage" name="Reject to Triage" camunda:expression="MPAM_QA_REJECT_TRIAGE" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_1l467l2</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1w1bk55</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0z21yga</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_14u86jx" name="Validate User Input">
+    <bpmn:userTask id="Validate_RejectToTriage" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_0z21yga</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_05j5z80</bpmn:outgoing>
     </bpmn:userTask>
@@ -87,20 +87,20 @@
       <bpmn:outgoing>SequenceFlow_1l467l2</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0eflrvu</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1l467l2" name="false" sourceRef="ExclusiveGateway_07j3q1l" targetRef="ServiceTask_0gqk0h1">
+    <bpmn:sequenceFlow id="SequenceFlow_1l467l2" name="false" sourceRef="ExclusiveGateway_07j3q1l" targetRef="Screen_RejectToTriage">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0z21yga" sourceRef="ServiceTask_0gqk0h1" targetRef="UserTask_14u86jx" />
-    <bpmn:sequenceFlow id="SequenceFlow_05j5z80" sourceRef="UserTask_14u86jx" targetRef="ExclusiveGateway_1n28k6c" />
-    <bpmn:sequenceFlow id="SequenceFlow_1w1bk55" name="Reject-Triage" sourceRef="Gateway_098y43t" targetRef="ServiceTask_0gqk0h1">
+    <bpmn:sequenceFlow id="SequenceFlow_0z21yga" sourceRef="Screen_RejectToTriage" targetRef="Validate_RejectToTriage" />
+    <bpmn:sequenceFlow id="SequenceFlow_05j5z80" sourceRef="Validate_RejectToTriage" targetRef="ExclusiveGateway_1n28k6c" />
+    <bpmn:sequenceFlow id="SequenceFlow_1w1bk55" name="Reject-Triage" sourceRef="Gateway_098y43t" targetRef="Screen_RejectToTriage">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QaStatus == "Reject-Triage"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_1vkpdlf" name="User Input" camunda:expression="MPAM_QA_REJECT_DRAFT" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="Screen_RejectToDraft" name="Reject to Draft" camunda:expression="MPAM_QA_REJECT_DRAFT" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_0c27lxw</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_04motai</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0sq1ja8</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_12zaj3l" name="Validate User Input">
+    <bpmn:userTask id="Validate_RejectToDraft" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_0sq1ja8</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0tggl13</bpmn:outgoing>
     </bpmn:userTask>
@@ -109,30 +109,30 @@
       <bpmn:outgoing>SequenceFlow_0c27lxw</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0h46aek</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_0c27lxw" name="false" sourceRef="ExclusiveGateway_00j6ur4" targetRef="ServiceTask_1vkpdlf">
+    <bpmn:sequenceFlow id="SequenceFlow_0c27lxw" name="false" sourceRef="ExclusiveGateway_00j6ur4" targetRef="Screen_RejectToDraft">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0sq1ja8" sourceRef="ServiceTask_1vkpdlf" targetRef="UserTask_12zaj3l" />
-    <bpmn:sequenceFlow id="SequenceFlow_0tggl13" sourceRef="UserTask_12zaj3l" targetRef="ExclusiveGateway_1veku4y" />
-    <bpmn:sequenceFlow id="SequenceFlow_04motai" name="Rejext as " sourceRef="ExclusiveGateway_0yvc8gk" targetRef="ServiceTask_1vkpdlf">
+    <bpmn:sequenceFlow id="SequenceFlow_0sq1ja8" sourceRef="Screen_RejectToDraft" targetRef="Validate_RejectToDraft" />
+    <bpmn:sequenceFlow id="SequenceFlow_0tggl13" sourceRef="Validate_RejectToDraft" targetRef="ExclusiveGateway_1veku4y" />
+    <bpmn:sequenceFlow id="SequenceFlow_04motai" name="Reject-Draft" sourceRef="ExclusiveGateway_0yvc8gk" targetRef="Screen_RejectToDraft">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QaStatus == "Reject-Draft"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_0jm5xg2" name="Save Reject Triage Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_RejectTriage&#34;), &#34;REJECT&#34;)}">
+    <bpmn:serviceTask id="Service_SaveRejectTriageNote" name="Save Reject Triage Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_RejectTriage&#34;), &#34;REJECT&#34;)}">
       <bpmn:incoming>SequenceFlow_0eflrvu</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1l3ptb9</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0eflrvu" sourceRef="ExclusiveGateway_07j3q1l" targetRef="ServiceTask_0jm5xg2">
+    <bpmn:sequenceFlow id="SequenceFlow_0eflrvu" sourceRef="ExclusiveGateway_07j3q1l" targetRef="Service_SaveRejectTriageNote">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1l3ptb9" sourceRef="ServiceTask_0jm5xg2" targetRef="ServiceTask_0yovaxi" />
-    <bpmn:serviceTask id="ServiceTask_0659w2l" name="Save Reject Draft Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_RejectDraft&#34;), &#34;REJECT&#34;)}">
+    <bpmn:sequenceFlow id="SequenceFlow_1l3ptb9" sourceRef="Service_SaveRejectTriageNote" targetRef="Service_UpdateToRejectedByQa_RejectToTriage" />
+    <bpmn:serviceTask id="Service_SaveRejectDraftNote" name="Save Reject Draft Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_RejectDraft&#34;), &#34;REJECT&#34;)}">
       <bpmn:incoming>SequenceFlow_0h46aek</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_10q6bzw</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0h46aek" sourceRef="ExclusiveGateway_00j6ur4" targetRef="ServiceTask_0659w2l">
+    <bpmn:sequenceFlow id="SequenceFlow_0h46aek" sourceRef="ExclusiveGateway_00j6ur4" targetRef="Service_SaveRejectDraftNote">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_10q6bzw" sourceRef="ServiceTask_0659w2l" targetRef="ServiceTask_02ttrxt" />
+    <bpmn:sequenceFlow id="SequenceFlow_10q6bzw" sourceRef="Service_SaveRejectDraftNote" targetRef="Service_UpdateToRejectedByQa_RejectToDraft" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_1n28k6c" name="Direction Check">
       <bpmn:incoming>SequenceFlow_05j5z80</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0e8c4i7</bpmn:outgoing>
@@ -149,31 +149,31 @@
     <bpmn:sequenceFlow id="SequenceFlow_0myhgqq" sourceRef="ExclusiveGateway_1veku4y" targetRef="ExclusiveGateway_00j6ur4">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0e27r14" sourceRef="ExclusiveGateway_1veku4y" targetRef="ServiceTask_16s0y5f">
+    <bpmn:sequenceFlow id="SequenceFlow_0e27r14" sourceRef="ExclusiveGateway_1veku4y" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1e0ekpm" sourceRef="ExclusiveGateway_1n28k6c" targetRef="ServiceTask_16s0y5f">
+    <bpmn:sequenceFlow id="SequenceFlow_1e0ekpm" sourceRef="ExclusiveGateway_1n28k6c" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1d2kn7r" sourceRef="ServiceTask_1mw4ofo" targetRef="EndEvent_1vzq41u" />
-    <bpmn:serviceTask id="ServiceTask_0yovaxi" name="Update Team for Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_TRIAGE&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
-      <bpmn:incoming>SequenceFlow_1l3ptb9</bpmn:incoming>
+    <bpmn:sequenceFlow id="SequenceFlow_1d2kn7r" sourceRef="ServiceTask_1mw4ofo" targetRef="EndEvent_MpamQa" />
+    <bpmn:serviceTask id="Service_UpdateTeamForTriage" name="Update Team for Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_TRIAGE&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
+      <bpmn:incoming>SequenceFlow_030bd6y</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0wzwk56</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0wzwk56" sourceRef="ServiceTask_0yovaxi" targetRef="EndEvent_1vzq41u" />
-    <bpmn:serviceTask id="ServiceTask_02ttrxt" name="Update Team for Draft" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_DRAFT&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
-      <bpmn:incoming>SequenceFlow_10q6bzw</bpmn:incoming>
+    <bpmn:sequenceFlow id="SequenceFlow_0wzwk56" sourceRef="Service_UpdateTeamForTriage" targetRef="EndEvent_MpamQa" />
+    <bpmn:serviceTask id="Service_UpdateTeamForDraft" name="Update Team for Draft" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_DRAFT&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
+      <bpmn:incoming>SequenceFlow_1n873we</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1wz2naw</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_1wz2naw" sourceRef="ServiceTask_02ttrxt" targetRef="EndEvent_1vzq41u" />
-    <bpmn:sequenceFlow id="SequenceFlow_0uvfaap" sourceRef="ServiceTask_1bcj2sl" targetRef="EndEvent_1vzq41u" />
+    <bpmn:sequenceFlow id="SequenceFlow_1wz2naw" sourceRef="Service_UpdateTeamForDraft" targetRef="EndEvent_MpamQa" />
+    <bpmn:sequenceFlow id="SequenceFlow_0uvfaap" sourceRef="ServiceTask_1bcj2sl" targetRef="EndEvent_MpamQa" />
     <bpmn:sequenceFlow id="SequenceFlow_0qjmcre" sourceRef="ExclusiveGateway_1m1c3o1" targetRef="ServiceTask_1bcj2sl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QaStatus == "Approve" &amp;&amp; RefType == "Official"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_05y9ucc" sourceRef="ExclusiveGateway_1m1c3o1" targetRef="ServiceTask_1mw4ofo">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QaStatus == "Approve" &amp;&amp; RefType == "Ministerial"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0cf8q9q" sourceRef="ExclusiveGateway_1m1c3o1" targetRef="EndEvent_1vzq41u">
+    <bpmn:sequenceFlow id="SequenceFlow_0cf8q9q" sourceRef="ExclusiveGateway_1m1c3o1" targetRef="EndEvent_MpamQa">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QaStatus != "Approve"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_0vd6hib" name="Pending?">
@@ -184,7 +184,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_0p1wref" sourceRef="ExclusiveGateway_0vd6hib" targetRef="ExclusiveGateway_0yvc8gk">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QaStatus != "Pending"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_05dstmy" sourceRef="ExclusiveGateway_0vd6hib" targetRef="ServiceTask_16s0y5f">
+    <bpmn:sequenceFlow id="SequenceFlow_05dstmy" sourceRef="ExclusiveGateway_0vd6hib" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QaStatus == "Pending"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="ServiceTask_0q156oe" name="Request Campaign" camunda:expression="MPAM_CAMPAIGN_REQUEST" camunda:resultVariable="screen">
@@ -226,8 +226,8 @@
     <bpmn:sequenceFlow id="SequenceFlow_0y3jw59" sourceRef="ExclusiveGateway_0v6sam9" targetRef="ServiceTask_158yaw7">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_17tnwbu" sourceRef="ServiceTask_158yaw7" targetRef="EndEvent_1vzq41u" />
-    <bpmn:sequenceFlow id="SequenceFlow_101nsr5" sourceRef="ExclusiveGateway_1vauneq" targetRef="ServiceTask_16s0y5f">
+    <bpmn:sequenceFlow id="SequenceFlow_17tnwbu" sourceRef="ServiceTask_158yaw7" targetRef="EndEvent_MpamQa" />
+    <bpmn:sequenceFlow id="SequenceFlow_101nsr5" sourceRef="ExclusiveGateway_1vauneq" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0zqf6b5" name="PutOnCampaign" sourceRef="ExclusiveGateway_0duns45" targetRef="ServiceTask_11cpbw1">
@@ -280,7 +280,7 @@
       <bpmn:outgoing>SequenceFlow_0q7gev6</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_1kwqa44" sourceRef="UserTask_1u19uk3" targetRef="ExclusiveGateway_0qyjbmm" />
-    <bpmn:sequenceFlow id="SequenceFlow_0wlokb1" sourceRef="ExclusiveGateway_0qyjbmm" targetRef="ServiceTask_16s0y5f">
+    <bpmn:sequenceFlow id="SequenceFlow_0wlokb1" sourceRef="ExclusiveGateway_0qyjbmm" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1wl8ag1" sourceRef="ExclusiveGateway_0nj1h9p" targetRef="ServiceTask_1bdgvxm">
@@ -289,7 +289,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_1sclh7v" sourceRef="ExclusiveGateway_0nj1h9p" targetRef="ServiceTask_01jjuey">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0q7gev6" sourceRef="ServiceTask_01jjuey" targetRef="EndEvent_1vzq41u" />
+    <bpmn:sequenceFlow id="SequenceFlow_0q7gev6" sourceRef="ServiceTask_01jjuey" targetRef="EndEvent_MpamQa" />
     <bpmn:userTask id="Activity_0oiigje" name="Validate User Input">
       <bpmn:incoming>Flow_03ri432</bpmn:incoming>
       <bpmn:outgoing>Flow_18x1vbr</bpmn:outgoing>
@@ -327,10 +327,10 @@
     <bpmn:sequenceFlow id="Flow_1q5doi0" sourceRef="Gateway_1gcvuyn" targetRef="Activity_1w2u9t3">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QaStatus == "CloseCaseTelephone"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0bam9gx" sourceRef="Gateway_0a4w4qi" targetRef="ServiceTask_16s0y5f">
+    <bpmn:sequenceFlow id="Flow_0bam9gx" sourceRef="Gateway_0a4w4qi" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1ml757g" sourceRef="Activity_0mmuzje" targetRef="EndEvent_1vzq41u" />
+    <bpmn:sequenceFlow id="Flow_1ml757g" sourceRef="Activity_0mmuzje" targetRef="EndEvent_MpamQa" />
     <bpmn:exclusiveGateway id="Gateway_1gcvuyn">
       <bpmn:incoming>SequenceFlow_1fz6snx</bpmn:incoming>
       <bpmn:outgoing>Flow_1wt1ab7</bpmn:outgoing>
@@ -339,467 +339,489 @@
     <bpmn:sequenceFlow id="Flow_1wt1ab7" sourceRef="Gateway_1gcvuyn" targetRef="ExclusiveGateway_0duns45">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QaStatus != "CloseCaseTelephone"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="Service_UpdateToRejectedByQa_RejectToTriage" name="Update to Rejected by QA" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;Rejected&#34;, &#34;By QA&#34;)}">
+      <bpmn:incoming>SequenceFlow_1l3ptb9</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_030bd6y</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_030bd6y" sourceRef="Service_UpdateToRejectedByQa_RejectToTriage" targetRef="Service_UpdateTeamForTriage" />
+    <bpmn:serviceTask id="Service_UpdateToRejectedByQa_RejectToDraft" name="Update to Rejected by QA" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;Rejected&#34;, &#34;By QA&#34;)}">
+      <bpmn:incoming>SequenceFlow_10q6bzw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1n873we</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1n873we" sourceRef="Service_UpdateToRejectedByQa_RejectToDraft" targetRef="Service_UpdateTeamForDraft" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_QA">
       <bpmndi:BPMNEdge id="Flow_1wt1ab7_di" bpmnElement="Flow_1wt1ab7">
-        <di:waypoint x="895" y="714" />
-        <di:waypoint x="923" y="714" />
+        <di:waypoint x="895" y="772" />
+        <di:waypoint x="923" y="772" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ml757g_di" bpmnElement="Flow_1ml757g">
-        <di:waypoint x="720" y="345" />
-        <di:waypoint x="1110" y="490" />
-        <di:waypoint x="1580" y="490" />
-        <di:waypoint x="1794" y="702" />
+        <di:waypoint x="670" y="363" />
+        <di:waypoint x="670" y="81" />
+        <di:waypoint x="1807" y="81" />
+        <di:waypoint x="1807" y="754" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0bam9gx_di" bpmnElement="Flow_0bam9gx">
-        <di:waypoint x="550" y="480" />
-        <di:waypoint x="550" y="601" />
-        <di:waypoint x="459" y="601" />
+        <di:waypoint x="550" y="538" />
+        <di:waypoint x="550" y="659" />
+        <di:waypoint x="459" y="659" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1q5doi0_di" bpmnElement="Flow_1q5doi0">
-        <di:waypoint x="870" y="689" />
-        <di:waypoint x="870" y="495" />
+        <di:waypoint x="870" y="747" />
+        <di:waypoint x="870" y="553" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1j1nl0c_di" bpmnElement="Flow_1j1nl0c">
-        <di:waypoint x="460" y="430" />
-        <di:waypoint x="460" y="275" />
-        <di:waypoint x="620" y="328" />
+        <di:waypoint x="460" y="488" />
+        <di:waypoint x="460" y="403" />
+        <di:waypoint x="620" y="403" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1mzik3v_di" bpmnElement="Flow_1mzik3v">
-        <di:waypoint x="460" y="480" />
-        <di:waypoint x="460" y="525" />
-        <di:waypoint x="800" y="525" />
-        <di:waypoint x="800" y="495" />
+        <di:waypoint x="460" y="538" />
+        <di:waypoint x="460" y="583" />
+        <di:waypoint x="800" y="583" />
+        <di:waypoint x="800" y="553" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0l4g4rl_di" bpmnElement="Flow_0l4g4rl">
-        <di:waypoint x="525" y="455" />
-        <di:waypoint x="485" y="455" />
+        <di:waypoint x="525" y="513" />
+        <di:waypoint x="485" y="513" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_18x1vbr_di" bpmnElement="Flow_18x1vbr">
-        <di:waypoint x="620" y="455" />
-        <di:waypoint x="575" y="455" />
+        <di:waypoint x="620" y="513" />
+        <di:waypoint x="575" y="513" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_03ri432_di" bpmnElement="Flow_03ri432">
-        <di:waypoint x="780" y="455" />
-        <di:waypoint x="720" y="455" />
+        <di:waypoint x="780" y="513" />
+        <di:waypoint x="720" y="513" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0q7gev6_di" bpmnElement="SequenceFlow_0q7gev6">
-        <di:waypoint x="1680" y="415" />
-        <di:waypoint x="1807" y="415" />
-        <di:waypoint x="1807" y="696" />
+        <di:waypoint x="1680" y="473" />
+        <di:waypoint x="1807" y="473" />
+        <di:waypoint x="1807" y="754" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1sclh7v_di" bpmnElement="SequenceFlow_1sclh7v">
-        <di:waypoint x="1515" y="415" />
-        <di:waypoint x="1580" y="415" />
+        <di:waypoint x="1515" y="473" />
+        <di:waypoint x="1580" y="473" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1wl8ag1_di" bpmnElement="SequenceFlow_1wl8ag1">
-        <di:waypoint x="1490" y="440" />
-        <di:waypoint x="1490" y="550" />
-        <di:waypoint x="1280" y="550" />
+        <di:waypoint x="1490" y="498" />
+        <di:waypoint x="1490" y="608" />
+        <di:waypoint x="1280" y="608" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0wlokb1_di" bpmnElement="SequenceFlow_0wlokb1">
-        <di:waypoint x="1400" y="390" />
-        <di:waypoint x="1400" y="80" />
-        <di:waypoint x="409" y="80" />
-        <di:waypoint x="409" y="591" />
+        <di:waypoint x="1400" y="448" />
+        <di:waypoint x="1400" y="138" />
+        <di:waypoint x="409" y="138" />
+        <di:waypoint x="409" y="649" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1kwqa44_di" bpmnElement="SequenceFlow_1kwqa44">
-        <di:waypoint x="1280" y="415" />
-        <di:waypoint x="1375" y="415" />
+        <di:waypoint x="1280" y="473" />
+        <di:waypoint x="1375" y="473" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1599ayj_di" bpmnElement="SequenceFlow_1599ayj">
-        <di:waypoint x="1425" y="415" />
-        <di:waypoint x="1465" y="415" />
+        <di:waypoint x="1425" y="473" />
+        <di:waypoint x="1465" y="473" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ws6691_di" bpmnElement="SequenceFlow_1ws6691">
-        <di:waypoint x="1230" y="689" />
-        <di:waypoint x="1230" y="590" />
+        <di:waypoint x="1230" y="747" />
+        <di:waypoint x="1230" y="648" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1238" y="617" width="83" height="27" />
+          <dc:Bounds x="1238" y="675" width="83" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1kxiz2v_di" bpmnElement="SequenceFlow_1kxiz2v">
-        <di:waypoint x="1230" y="510" />
-        <di:waypoint x="1230" y="460" />
+        <di:waypoint x="1230" y="568" />
+        <di:waypoint x="1230" y="518" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_19vy1pn_di" bpmnElement="SequenceFlow_19vy1pn">
-        <di:waypoint x="1255" y="714" />
-        <di:waypoint x="1455" y="714" />
+        <di:waypoint x="1255" y="772" />
+        <di:waypoint x="1455" y="772" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0m6pdl7_di" bpmnElement="SequenceFlow_0m6pdl7">
-        <di:waypoint x="1105" y="714" />
-        <di:waypoint x="1205" y="714" />
+        <di:waypoint x="1105" y="772" />
+        <di:waypoint x="1205" y="772" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0zqf6b5_di" bpmnElement="SequenceFlow_0zqf6b5">
-        <di:waypoint x="948" y="689" />
-        <di:waypoint x="948" y="495" />
+        <di:waypoint x="948" y="747" />
+        <di:waypoint x="948" y="553" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="960" y="564" width="82" height="14" />
+          <dc:Bounds x="960" y="622" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_101nsr5_di" bpmnElement="SequenceFlow_101nsr5">
-        <di:waypoint x="1061" y="155" />
-        <di:waypoint x="1061" y="80" />
-        <di:waypoint x="409" y="80" />
-        <di:waypoint x="409" y="591" />
+        <di:waypoint x="1061" y="213" />
+        <di:waypoint x="1061" y="138" />
+        <di:waypoint x="409" y="138" />
+        <di:waypoint x="409" y="649" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_17tnwbu_di" bpmnElement="SequenceFlow_17tnwbu">
-        <di:waypoint x="1350" y="180" />
-        <di:waypoint x="1807" y="180" />
-        <di:waypoint x="1807" y="696" />
+        <di:waypoint x="1350" y="238" />
+        <di:waypoint x="1807" y="238" />
+        <di:waypoint x="1807" y="754" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0y3jw59_di" bpmnElement="SequenceFlow_0y3jw59">
-        <di:waypoint x="1176" y="180" />
-        <di:waypoint x="1250" y="180" />
+        <di:waypoint x="1176" y="238" />
+        <di:waypoint x="1250" y="238" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_115dc00_di" bpmnElement="SequenceFlow_115dc00">
-        <di:waypoint x="1086" y="180" />
-        <di:waypoint x="1126" y="180" />
+        <di:waypoint x="1086" y="238" />
+        <di:waypoint x="1126" y="238" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1wxucoq_di" bpmnElement="SequenceFlow_1wxucoq">
-        <di:waypoint x="998" y="180" />
-        <di:waypoint x="1036" y="180" />
+        <di:waypoint x="998" y="238" />
+        <di:waypoint x="1036" y="238" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0x7nddu_di" bpmnElement="SequenceFlow_0x7nddu">
-        <di:waypoint x="948" y="304" />
-        <di:waypoint x="948" y="220" />
+        <di:waypoint x="948" y="362" />
+        <di:waypoint x="948" y="278" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1ndsi80_di" bpmnElement="SequenceFlow_1ndsi80">
-        <di:waypoint x="948" y="415" />
-        <di:waypoint x="948" y="384" />
+        <di:waypoint x="948" y="473" />
+        <di:waypoint x="948" y="442" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0eye33n_di" bpmnElement="SequenceFlow_0eye33n">
-        <di:waypoint x="1151" y="205" />
-        <di:waypoint x="1151" y="344" />
-        <di:waypoint x="998" y="344" />
+        <di:waypoint x="1151" y="263" />
+        <di:waypoint x="1151" y="402" />
+        <di:waypoint x="998" y="402" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_05dstmy_di" bpmnElement="SequenceFlow_05dstmy">
+        <di:waypoint x="715" y="747" />
         <di:waypoint x="715" y="689" />
-        <di:waypoint x="715" y="631" />
-        <di:waypoint x="459" y="631" />
+        <di:waypoint x="459" y="689" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0p1wref_di" bpmnElement="SequenceFlow_0p1wref">
-        <di:waypoint x="740" y="714" />
-        <di:waypoint x="775" y="714" />
+        <di:waypoint x="740" y="772" />
+        <di:waypoint x="775" y="772" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0cf8q9q_di" bpmnElement="SequenceFlow_0cf8q9q">
-        <di:waypoint x="1505" y="714" />
-        <di:waypoint x="1789" y="714" />
+        <di:waypoint x="1505" y="772" />
+        <di:waypoint x="1789" y="772" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_05y9ucc_di" bpmnElement="SequenceFlow_05y9ucc">
-        <di:waypoint x="1480" y="739" />
-        <di:waypoint x="1480" y="794" />
-        <di:waypoint x="1536" y="794" />
+        <di:waypoint x="1480" y="797" />
+        <di:waypoint x="1480" y="852" />
+        <di:waypoint x="1536" y="852" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0qjmcre_di" bpmnElement="SequenceFlow_0qjmcre">
+        <di:waypoint x="1480" y="747" />
         <di:waypoint x="1480" y="689" />
-        <di:waypoint x="1480" y="631" />
-        <di:waypoint x="1536" y="631" />
+        <di:waypoint x="1536" y="689" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0uvfaap_di" bpmnElement="SequenceFlow_0uvfaap">
-        <di:waypoint x="1636" y="631" />
-        <di:waypoint x="1679" y="631" />
-        <di:waypoint x="1679" y="714" />
-        <di:waypoint x="1789" y="714" />
+        <di:waypoint x="1636" y="689" />
+        <di:waypoint x="1679" y="689" />
+        <di:waypoint x="1679" y="772" />
+        <di:waypoint x="1789" y="772" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1wz2naw_di" bpmnElement="SequenceFlow_1wz2naw">
-        <di:waypoint x="1636" y="1318" />
-        <di:waypoint x="1734" y="1318" />
-        <di:waypoint x="1734" y="714" />
-        <di:waypoint x="1789" y="714" />
+        <di:waypoint x="1766" y="1376" />
+        <di:waypoint x="1807" y="1376" />
+        <di:waypoint x="1807" y="790" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0wzwk56_di" bpmnElement="SequenceFlow_0wzwk56">
-        <di:waypoint x="1638" y="1019" />
-        <di:waypoint x="1734" y="1019" />
-        <di:waypoint x="1734" y="714" />
-        <di:waypoint x="1789" y="714" />
+        <di:waypoint x="1766" y="1077" />
+        <di:waypoint x="1807" y="1077" />
+        <di:waypoint x="1807" y="790" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1d2kn7r_di" bpmnElement="SequenceFlow_1d2kn7r">
-        <di:waypoint x="1636" y="794" />
-        <di:waypoint x="1679" y="794" />
-        <di:waypoint x="1679" y="714" />
-        <di:waypoint x="1789" y="714" />
+        <di:waypoint x="1636" y="852" />
+        <di:waypoint x="1679" y="852" />
+        <di:waypoint x="1679" y="772" />
+        <di:waypoint x="1789" y="772" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1e0ekpm_di" bpmnElement="SequenceFlow_1e0ekpm">
-        <di:waypoint x="1200" y="1124" />
-        <di:waypoint x="1200" y="1166" />
-        <di:waypoint x="273" y="1166" />
-        <di:waypoint x="273" y="631" />
-        <di:waypoint x="359" y="631" />
+        <di:waypoint x="1200" y="1182" />
+        <di:waypoint x="1200" y="1224" />
+        <di:waypoint x="272" y="1224" />
+        <di:waypoint x="272" y="689" />
+        <di:waypoint x="359" y="689" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0e27r14_di" bpmnElement="SequenceFlow_0e27r14">
-        <di:waypoint x="1186" y="1423" />
-        <di:waypoint x="1186" y="1477" />
-        <di:waypoint x="272" y="1477" />
-        <di:waypoint x="272" y="631" />
-        <di:waypoint x="359" y="631" />
+        <di:waypoint x="1200" y="1481" />
+        <di:waypoint x="1200" y="1535" />
+        <di:waypoint x="272" y="1535" />
+        <di:waypoint x="272" y="689" />
+        <di:waypoint x="359" y="689" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0myhgqq_di" bpmnElement="SequenceFlow_0myhgqq">
-        <di:waypoint x="1211" y="1398" />
-        <di:waypoint x="1251" y="1398" />
-        <di:waypoint x="1251" y="1343" />
+        <di:waypoint x="1225" y="1456" />
+        <di:waypoint x="1251" y="1456" />
+        <di:waypoint x="1251" y="1401" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0e8c4i7_di" bpmnElement="SequenceFlow_0e8c4i7">
-        <di:waypoint x="1225" y="1099" />
-        <di:waypoint x="1251" y="1099" />
-        <di:waypoint x="1251" y="1044" />
+        <di:waypoint x="1225" y="1157" />
+        <di:waypoint x="1251" y="1157" />
+        <di:waypoint x="1251" y="1102" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_10q6bzw_di" bpmnElement="SequenceFlow_10q6bzw">
-        <di:waypoint x="1460" y="1318" />
-        <di:waypoint x="1536" y="1318" />
+        <di:waypoint x="1430" y="1376" />
+        <di:waypoint x="1498" y="1376" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0h46aek_di" bpmnElement="SequenceFlow_0h46aek">
-        <di:waypoint x="1276" y="1318" />
-        <di:waypoint x="1360" y="1318" />
+        <di:waypoint x="1276" y="1376" />
+        <di:waypoint x="1330" y="1376" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1l3ptb9_di" bpmnElement="SequenceFlow_1l3ptb9">
-        <di:waypoint x="1460" y="1019" />
-        <di:waypoint x="1536" y="1019" />
+        <di:waypoint x="1430" y="1077" />
+        <di:waypoint x="1498" y="1077" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0eflrvu_di" bpmnElement="SequenceFlow_0eflrvu">
-        <di:waypoint x="1276" y="1019" />
-        <di:waypoint x="1360" y="1019" />
+        <di:waypoint x="1276" y="1077" />
+        <di:waypoint x="1330" y="1077" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_04motai_di" bpmnElement="SequenceFlow_04motai">
-        <di:waypoint x="800" y="739" />
-        <di:waypoint x="800" y="1235" />
-        <di:waypoint x="1021" y="1235" />
+        <di:waypoint x="800" y="797" />
+        <di:waypoint x="800" y="1293" />
+        <di:waypoint x="1030" y="1293" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="793" y="984" width="46" height="14" />
+          <dc:Bounds x="734" y="835" width="59" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0tggl13_di" bpmnElement="SequenceFlow_0tggl13">
-        <di:waypoint x="1121" y="1398" />
-        <di:waypoint x="1161" y="1398" />
+        <di:waypoint x="1130" y="1456" />
+        <di:waypoint x="1175" y="1456" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0sq1ja8_di" bpmnElement="SequenceFlow_0sq1ja8">
-        <di:waypoint x="1071" y="1275" />
-        <di:waypoint x="1071" y="1358" />
+        <di:waypoint x="1080" y="1333" />
+        <di:waypoint x="1080" y="1416" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0c27lxw_di" bpmnElement="SequenceFlow_0c27lxw">
+        <di:waypoint x="1251" y="1351" />
         <di:waypoint x="1251" y="1293" />
-        <di:waypoint x="1251" y="1235" />
-        <di:waypoint x="1121" y="1235" />
+        <di:waypoint x="1130" y="1293" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1239" y="1214" width="24" height="14" />
+          <dc:Bounds x="1239" y="1272" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1w1bk55_di" bpmnElement="SequenceFlow_1w1bk55">
-        <di:waypoint x="1080" y="739" />
-        <di:waypoint x="1080" y="896" />
+        <di:waypoint x="1080" y="797" />
+        <di:waypoint x="1080" y="954" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1089" y="745" width="66" height="14" />
+          <dc:Bounds x="1089" y="803" width="66" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_05j5z80_di" bpmnElement="SequenceFlow_05j5z80">
-        <di:waypoint x="1130" y="1099" />
-        <di:waypoint x="1175" y="1099" />
+        <di:waypoint x="1130" y="1157" />
+        <di:waypoint x="1175" y="1157" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0z21yga_di" bpmnElement="SequenceFlow_0z21yga">
-        <di:waypoint x="1080" y="976" />
-        <di:waypoint x="1080" y="1059" />
+        <di:waypoint x="1080" y="1034" />
+        <di:waypoint x="1080" y="1117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1l467l2_di" bpmnElement="SequenceFlow_1l467l2">
+        <di:waypoint x="1251" y="1052" />
         <di:waypoint x="1251" y="994" />
-        <di:waypoint x="1251" y="936" />
-        <di:waypoint x="1130" y="936" />
+        <di:waypoint x="1130" y="994" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1239" y="915" width="24" height="14" />
+          <dc:Bounds x="1239" y="973" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0ecwsab_di" bpmnElement="SequenceFlow_0ecwsab">
-        <di:waypoint x="973" y="714" />
-        <di:waypoint x="1055" y="714" />
+        <di:waypoint x="973" y="772" />
+        <di:waypoint x="1055" y="772" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1030" y="691" width="21" height="14" />
+          <dc:Bounds x="1030" y="749" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1fz6snx_di" bpmnElement="SequenceFlow_1fz6snx">
-        <di:waypoint x="825" y="714" />
-        <di:waypoint x="845" y="714" />
+        <di:waypoint x="825" y="772" />
+        <di:waypoint x="845" y="772" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0gds0wz_di" bpmnElement="SequenceFlow_0gds0wz">
-        <di:waypoint x="192" y="631" />
-        <di:waypoint x="359" y="631" />
+        <di:waypoint x="192" y="689" />
+        <di:waypoint x="359" y="689" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_06mtb4k_di" bpmnElement="SequenceFlow_06mtb4k">
-        <di:waypoint x="614" y="714" />
-        <di:waypoint x="690" y="714" />
+        <di:waypoint x="614" y="772" />
+        <di:waypoint x="690" y="772" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_17lpgk5_di" bpmnElement="SequenceFlow_17lpgk5">
-        <di:waypoint x="459" y="794" />
-        <di:waypoint x="589" y="794" />
-        <di:waypoint x="589" y="739" />
+        <di:waypoint x="459" y="852" />
+        <di:waypoint x="589" y="852" />
+        <di:waypoint x="589" y="797" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0zpho9a_di" bpmnElement="SequenceFlow_0zpho9a">
-        <di:waypoint x="409" y="671" />
-        <di:waypoint x="409" y="754" />
+        <di:waypoint x="409" y="729" />
+        <di:waypoint x="409" y="812" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1hlxbez_di" bpmnElement="SequenceFlow_1hlxbez">
+        <di:waypoint x="589" y="747" />
         <di:waypoint x="589" y="689" />
-        <di:waypoint x="589" y="631" />
-        <di:waypoint x="459" y="631" />
+        <di:waypoint x="459" y="689" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="577" y="610" width="24" height="14" />
+          <dc:Bounds x="577" y="668" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="156" y="613" width="36" height="36" />
+        <dc:Bounds x="156" y="671" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_16s0y5f_di" bpmnElement="ServiceTask_16s0y5f">
-        <dc:Bounds x="359" y="591" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_16s0y5f_di" bpmnElement="Screen_UserInput">
+        <dc:Bounds x="359" y="649" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_1o3wy0c_di" bpmnElement="UserTask_1o3wy0c">
-        <dc:Bounds x="359" y="754" width="100" height="80" />
+      <bpmndi:BPMNShape id="UserTask_1o3wy0c_di" bpmnElement="Validate_UserInput">
+        <dc:Bounds x="359" y="812" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0rjn86d_di" bpmnElement="ExclusiveGateway_0rjn86d" isMarkerVisible="true">
-        <dc:Bounds x="564" y="689" width="50" height="50" />
+        <dc:Bounds x="564" y="747" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_1vzq41u_di" bpmnElement="EndEvent_1vzq41u">
-        <dc:Bounds x="1789" y="696" width="36" height="36" />
+      <bpmndi:BPMNShape id="EndEvent_1vzq41u_di" bpmnElement="EndEvent_MpamQa">
+        <dc:Bounds x="1789" y="754" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1781" y="742" width="52" height="14" />
+          <dc:Bounds x="1835" y="765" width="52" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1m1c3o1_di" bpmnElement="ExclusiveGateway_1m1c3o1" isMarkerVisible="true">
-        <dc:Bounds x="1455" y="689" width="50" height="50" />
+        <dc:Bounds x="1455" y="747" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1bcj2sl_di" bpmnElement="ServiceTask_1bcj2sl">
-        <dc:Bounds x="1536" y="591" width="100" height="80" />
+        <dc:Bounds x="1536" y="649" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1mw4ofo_di" bpmnElement="ServiceTask_1mw4ofo">
-        <dc:Bounds x="1536" y="754" width="100" height="80" />
+        <dc:Bounds x="1536" y="812" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0yvc8gk_di" bpmnElement="ExclusiveGateway_0yvc8gk" isMarkerVisible="true">
-        <dc:Bounds x="775" y="689" width="50" height="50" />
+        <dc:Bounds x="775" y="747" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="774" y="673" width="52" height="14" />
+          <dc:Bounds x="774" y="731" width="52" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0duns45_di" bpmnElement="ExclusiveGateway_0duns45" isMarkerVisible="true">
-        <dc:Bounds x="923" y="689" width="50" height="50" />
+        <dc:Bounds x="923" y="747" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="964" y="679" width="52" height="14" />
+          <dc:Bounds x="964" y="737" width="52" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0gqk0h1_di" bpmnElement="ServiceTask_0gqk0h1">
-        <dc:Bounds x="1030" y="896" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_0gqk0h1_di" bpmnElement="Screen_RejectToTriage">
+        <dc:Bounds x="1030" y="954" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_14u86jx_di" bpmnElement="UserTask_14u86jx">
-        <dc:Bounds x="1030" y="1059" width="100" height="80" />
+      <bpmndi:BPMNShape id="UserTask_14u86jx_di" bpmnElement="Validate_RejectToTriage">
+        <dc:Bounds x="1030" y="1117" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_07j3q1l_di" bpmnElement="ExclusiveGateway_07j3q1l" isMarkerVisible="true">
-        <dc:Bounds x="1226" y="994" width="50" height="50" />
+        <dc:Bounds x="1226" y="1052" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1vkpdlf_di" bpmnElement="ServiceTask_1vkpdlf">
-        <dc:Bounds x="1021" y="1195" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_1vkpdlf_di" bpmnElement="Screen_RejectToDraft">
+        <dc:Bounds x="1030" y="1253" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_12zaj3l_di" bpmnElement="UserTask_12zaj3l">
-        <dc:Bounds x="1021" y="1358" width="100" height="80" />
+      <bpmndi:BPMNShape id="UserTask_12zaj3l_di" bpmnElement="Validate_RejectToDraft">
+        <dc:Bounds x="1030" y="1416" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_00j6ur4_di" bpmnElement="ExclusiveGateway_00j6ur4" isMarkerVisible="true">
-        <dc:Bounds x="1226" y="1293" width="50" height="50" />
+        <dc:Bounds x="1226" y="1351" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0jm5xg2_di" bpmnElement="ServiceTask_0jm5xg2">
-        <dc:Bounds x="1360" y="979" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_0jm5xg2_di" bpmnElement="Service_SaveRejectTriageNote">
+        <dc:Bounds x="1330" y="1037" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0659w2l_di" bpmnElement="ServiceTask_0659w2l">
-        <dc:Bounds x="1360" y="1278" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_0659w2l_di" bpmnElement="Service_SaveRejectDraftNote">
+        <dc:Bounds x="1330" y="1336" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1n28k6c_di" bpmnElement="ExclusiveGateway_1n28k6c" isMarkerVisible="true">
-        <dc:Bounds x="1175" y="1074" width="50" height="50" />
+        <dc:Bounds x="1175" y="1132" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1161" y="1050" width="78" height="14" />
+          <dc:Bounds x="1161" y="1108" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1veku4y_di" bpmnElement="ExclusiveGateway_1veku4y" isMarkerVisible="true">
-        <dc:Bounds x="1161" y="1373" width="50" height="50" />
+        <dc:Bounds x="1175" y="1431" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1147" y="1349" width="78" height="14" />
+          <dc:Bounds x="1161" y="1407" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0yovaxi_di" bpmnElement="ServiceTask_0yovaxi">
-        <dc:Bounds x="1536" y="979" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_0yovaxi_di" bpmnElement="Service_UpdateTeamForTriage">
+        <dc:Bounds x="1666" y="1037" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_02ttrxt_di" bpmnElement="ServiceTask_02ttrxt">
-        <dc:Bounds x="1536" y="1278" width="100" height="80" />
+      <bpmndi:BPMNShape id="ServiceTask_02ttrxt_di" bpmnElement="Service_UpdateTeamForDraft">
+        <dc:Bounds x="1666" y="1336" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0vd6hib_di" bpmnElement="ExclusiveGateway_0vd6hib" isMarkerVisible="true">
-        <dc:Bounds x="690" y="689" width="50" height="50" />
+        <dc:Bounds x="690" y="747" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="692" y="746" width="47" height="14" />
+          <dc:Bounds x="692" y="804" width="47" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0q156oe_di" bpmnElement="ServiceTask_0q156oe">
-        <dc:Bounds x="898" y="304" width="100" height="80" />
+        <dc:Bounds x="898" y="362" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_1rbr6sp_di" bpmnElement="UserTask_1rbr6sp">
-        <dc:Bounds x="898" y="140" width="100" height="80" />
+        <dc:Bounds x="898" y="198" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1vauneq_di" bpmnElement="ExclusiveGateway_1vauneq" isMarkerVisible="true">
-        <dc:Bounds x="1036" y="155" width="50" height="50" />
+        <dc:Bounds x="1036" y="213" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1022" y="215" width="78" height="14" />
+          <dc:Bounds x="1022" y="273" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0v6sam9_di" bpmnElement="ExclusiveGateway_0v6sam9" isMarkerVisible="true">
-        <dc:Bounds x="1126" y="155" width="50" height="50" />
+        <dc:Bounds x="1126" y="213" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_158yaw7_di" bpmnElement="ServiceTask_158yaw7">
-        <dc:Bounds x="1250" y="140" width="100" height="80" />
+        <dc:Bounds x="1250" y="198" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_11cpbw1_di" bpmnElement="ServiceTask_11cpbw1">
-        <dc:Bounds x="898" y="415" width="100" height="80" />
+        <dc:Bounds x="898" y="473" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_098y43t_di" bpmnElement="Gateway_098y43t" isMarkerVisible="true">
-        <dc:Bounds x="1055" y="689" width="50" height="50" />
+        <dc:Bounds x="1055" y="747" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1096" y="679" width="52" height="14" />
+          <dc:Bounds x="1096" y="737" width="52" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_03sl25d_di" bpmnElement="ExclusiveGateway_03sl25d" isMarkerVisible="true">
-        <dc:Bounds x="1205" y="689" width="50" height="50" />
+        <dc:Bounds x="1205" y="747" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1246" y="679" width="52" height="14" />
+          <dc:Bounds x="1246" y="737" width="52" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1bdgvxm_di" bpmnElement="ServiceTask_1bdgvxm">
-        <dc:Bounds x="1180" y="510" width="100" height="80" />
+        <dc:Bounds x="1180" y="568" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1u19uk3_di" bpmnElement="UserTask_1u19uk3">
-        <dc:Bounds x="1180" y="380" width="100" height="80" />
+        <dc:Bounds x="1180" y="438" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0qyjbmm_di" bpmnElement="ExclusiveGateway_0qyjbmm" isMarkerVisible="true">
-        <dc:Bounds x="1375" y="390" width="50" height="50" />
+        <dc:Bounds x="1375" y="448" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1361" y="450" width="78" height="14" />
+          <dc:Bounds x="1361" y="508" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0nj1h9p_di" bpmnElement="ExclusiveGateway_0nj1h9p" isMarkerVisible="true">
-        <dc:Bounds x="1465" y="390" width="50" height="50" />
+        <dc:Bounds x="1465" y="448" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_01jjuey_di" bpmnElement="ServiceTask_01jjuey">
-        <dc:Bounds x="1580" y="375" width="100" height="80" />
+        <dc:Bounds x="1580" y="433" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0oiigje_di" bpmnElement="Activity_0oiigje">
-        <dc:Bounds x="620" y="415" width="100" height="80" />
+        <dc:Bounds x="620" y="473" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_05rt11q_di" bpmnElement="Gateway_05rt11q" isMarkerVisible="true">
-        <dc:Bounds x="435" y="430" width="50" height="50" />
+        <dc:Bounds x="435" y="488" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1w2u9t3_di" bpmnElement="Activity_1w2u9t3">
-        <dc:Bounds x="780" y="415" width="100" height="80" />
+        <dc:Bounds x="780" y="473" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0a4w4qi_di" bpmnElement="Gateway_0a4w4qi" isMarkerVisible="true">
-        <dc:Bounds x="525" y="430" width="50" height="50" />
+        <dc:Bounds x="525" y="488" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0mmuzje_di" bpmnElement="Activity_0mmuzje">
-        <dc:Bounds x="620" y="305" width="100" height="80" />
+        <dc:Bounds x="620" y="363" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1gcvuyn_di" bpmnElement="Gateway_1gcvuyn" isMarkerVisible="true">
-        <dc:Bounds x="845" y="689" width="50" height="50" />
+        <dc:Bounds x="845" y="747" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1dci0nt_di" bpmnElement="Service_UpdateToRejectedByQa_RejectToTriage">
+        <dc:Bounds x="1498" y="1037" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_030bd6y_di" bpmnElement="SequenceFlow_030bd6y">
+        <di:waypoint x="1598" y="1077" />
+        <di:waypoint x="1666" y="1077" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_041i7td_di" bpmnElement="Service_UpdateToRejectedByQa_RejectToDraft">
+        <dc:Bounds x="1498" y="1336" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1n873we_di" bpmnElement="SequenceFlow_1n873we">
+        <di:waypoint x="1598" y="1376" />
+        <di:waypoint x="1666" y="1376" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/processes/MPAM_TRIAGE.bpmn
+++ b/src/main/resources/processes/MPAM_TRIAGE.bpmn
@@ -4,7 +4,7 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_0x8dpmn</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:serviceTask id="Screen_UserInput_05nlmnl" name="User Input" camunda:expression="MPAM_TRIAGE_INPUT" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="Screen_UserInput" name="User Input" camunda:expression="MPAM_TRIAGE_INPUT" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_06v8hsn</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1m917qi</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0x8dpmn</bpmn:incoming>
@@ -19,7 +19,7 @@
       <bpmn:incoming>Flow_1gxj9d4</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_16wwh9z</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="Validate_UserInput_0jxw8et" name="Validate User Input">
+    <bpmn:userTask id="Validate_UserInput" name="Validate User Input">
       <bpmn:incoming>SequenceFlow_16wwh9z</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1da9mhc</bpmn:outgoing>
     </bpmn:userTask>
@@ -28,29 +28,29 @@
       <bpmn:outgoing>SequenceFlow_06v8hsn</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1co3k2r</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:endEvent id="EndEvent_1golwf2" name="End Stage">
-      <bpmn:incoming>SequenceFlow_0kcq8md</bpmn:incoming>
+    <bpmn:endEvent id="EndEvent_MpamTriage" name="End Stage">
       <bpmn:incoming>SequenceFlow_1vaolyx</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_10u8lqt</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_108azcx</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_09iq9he</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0ksl1cg</bpmn:incoming>
       <bpmn:incoming>Flow_19ce18n</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_0ojtjqk</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_06v8hsn" name="false" sourceRef="ExclusiveGateway_13qjvzx" targetRef="Screen_UserInput_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_06v8hsn" name="false" sourceRef="ExclusiveGateway_13qjvzx" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_16wwh9z" sourceRef="Screen_UserInput_05nlmnl" targetRef="Validate_UserInput_0jxw8et" />
-    <bpmn:sequenceFlow id="SequenceFlow_1da9mhc" sourceRef="Validate_UserInput_0jxw8et" targetRef="ExclusiveGateway_08l5d8b" />
+    <bpmn:sequenceFlow id="SequenceFlow_16wwh9z" sourceRef="Screen_UserInput" targetRef="Validate_UserInput" />
+    <bpmn:sequenceFlow id="SequenceFlow_1da9mhc" sourceRef="Validate_UserInput" targetRef="ExclusiveGateway_08l5d8b" />
     <bpmn:sequenceFlow id="SequenceFlow_1co3k2r" sourceRef="ExclusiveGateway_13qjvzx" targetRef="ExclusiveGateway_0p3mwpr">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0x8dpmn" sourceRef="StartEvent_1" targetRef="Screen_UserInput_05nlmnl" />
-    <bpmn:serviceTask id="ServiceTask_1ds9yik" name="Update Team for Draft" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_DRAFT&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
+    <bpmn:sequenceFlow id="SequenceFlow_0x8dpmn" sourceRef="StartEvent_1" targetRef="Screen_UserInput" />
+    <bpmn:serviceTask id="Service_UpdateTeamForDraft" name="Update Team for Draft" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_DRAFT&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
       <bpmn:incoming>SequenceFlow_102vcza</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0kcq8md</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0kcq8md" sourceRef="ServiceTask_1ds9yik" targetRef="EndEvent_1golwf2" />
+    <bpmn:sequenceFlow id="SequenceFlow_0kcq8md" sourceRef="Service_UpdateTeamForDraft" targetRef="Service_ClearRejected" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_0p3mwpr" name="TriageOutcome?">
       <bpmn:incoming>SequenceFlow_1co3k2r</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_10l93df</bpmn:outgoing>
@@ -59,7 +59,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_10l93df" name="else" sourceRef="ExclusiveGateway_0p3mwpr" targetRef="Gateway_1g01f59">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageOutcome != "Pending"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1m917qi" name="pending" sourceRef="ExclusiveGateway_0p3mwpr" targetRef="Screen_UserInput_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_1m917qi" name="pending" sourceRef="ExclusiveGateway_0p3mwpr" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageOutcome == "Pending"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_1ivf0n0" name="TriageOutcome?">
@@ -67,10 +67,10 @@
       <bpmn:outgoing>SequenceFlow_102vcza</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1vaolyx</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_102vcza" name="SendToDraft" sourceRef="ExclusiveGateway_1ivf0n0" targetRef="ServiceTask_1ds9yik">
+    <bpmn:sequenceFlow id="SequenceFlow_102vcza" name="SendToDraft" sourceRef="ExclusiveGateway_1ivf0n0" targetRef="Service_UpdateTeamForDraft">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageOutcome == "SendToDraft"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1vaolyx" name="else" sourceRef="ExclusiveGateway_1ivf0n0" targetRef="EndEvent_1golwf2">
+    <bpmn:sequenceFlow id="SequenceFlow_1vaolyx" name="else" sourceRef="ExclusiveGateway_1ivf0n0" targetRef="EndEvent_MpamTriage">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageOutcome != "SendToDraft"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_08l5d8b" name="Direction Check">
@@ -156,12 +156,12 @@
       <bpmn:incoming>SequenceFlow_1enm75p</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1sq5itz</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_1sq5itz" sourceRef="ServiceTask_060ccpx" targetRef="Screen_UserInput_05nlmnl" />
+    <bpmn:sequenceFlow id="SequenceFlow_1sq5itz" sourceRef="ServiceTask_060ccpx" targetRef="Screen_UserInput" />
     <bpmn:serviceTask id="ServiceTask_0hpe5ym" name="Clear Temp Enquiry Subject" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;tempEnquirySubject&#34;)}">
       <bpmn:incoming>SequenceFlow_0enh4xh</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1101m5b</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_1101m5b" sourceRef="ServiceTask_0hpe5ym" targetRef="Screen_UserInput_05nlmnl" />
+    <bpmn:sequenceFlow id="SequenceFlow_1101m5b" sourceRef="ServiceTask_0hpe5ym" targetRef="Screen_UserInput" />
     <bpmn:sequenceFlow id="SequenceFlow_1enm75p" name="BACKWARD" sourceRef="ExclusiveGateway_1iftjr8" targetRef="ServiceTask_060ccpx">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -194,7 +194,7 @@
       <bpmn:outgoing>SequenceFlow_10u8lqt</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_0rbinee" sourceRef="UserTask_0bqjeeg" targetRef="ExclusiveGateway_05idho6" />
-    <bpmn:sequenceFlow id="SequenceFlow_10u8lqt" sourceRef="ServiceTask_0702omj" targetRef="EndEvent_1golwf2" />
+    <bpmn:sequenceFlow id="SequenceFlow_10u8lqt" sourceRef="ServiceTask_0702omj" targetRef="EndEvent_MpamTriage" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_05idho6" name="Direction Check">
       <bpmn:incoming>SequenceFlow_0rbinee</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0cjqztr</bpmn:outgoing>
@@ -203,7 +203,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_0cjqztr" sourceRef="ExclusiveGateway_05idho6" targetRef="ExclusiveGateway_08miue5">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1bypsoj" sourceRef="ExclusiveGateway_05idho6" targetRef="Screen_UserInput_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_1bypsoj" sourceRef="ExclusiveGateway_05idho6" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_08miue5">
@@ -252,8 +252,8 @@
     <bpmn:sequenceFlow id="SequenceFlow_1tf4edx" sourceRef="ExclusiveGateway_1jzkkkl" targetRef="ServiceTask_04cd41z">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_108azcx" sourceRef="ServiceTask_04cd41z" targetRef="EndEvent_1golwf2" />
-    <bpmn:sequenceFlow id="SequenceFlow_0j5xv9g" name="BACKWARD" sourceRef="ExclusiveGateway_03cn7o8" targetRef="Screen_UserInput_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_108azcx" sourceRef="ServiceTask_04cd41z" targetRef="EndEvent_MpamTriage" />
+    <bpmn:sequenceFlow id="SequenceFlow_0j5xv9g" name="BACKWARD" sourceRef="ExclusiveGateway_03cn7o8" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1mlhuzu" name="UpdateBusinessArea" sourceRef="ExclusiveGateway_08l5d8b" targetRef="ServiceTask_06e7e59">
@@ -292,7 +292,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_0nrrrl7" name="UpdateRefType" sourceRef="ExclusiveGateway_08l5d8b" targetRef="ExclusiveGateway_02jphpz">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "UpdateRefType"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0roihnf" sourceRef="ExclusiveGateway_0lgtxxn" targetRef="Screen_UserInput_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_0roihnf" sourceRef="ExclusiveGateway_0lgtxxn" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="Screen_ReferenceTypeToMinisterial_1c5qr22" name="Reference Type To Ministerial" camunda:expression="MPAM_REFTYPE_TO_MINISTERIAL" camunda:resultVariable="screen">
@@ -333,7 +333,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_0475c6m" sourceRef="ExclusiveGateway_02jphpz" targetRef="Screen_ReferenceTypeToMinisterial_1c5qr22">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${RefType == "Official"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_03cktte" sourceRef="ExclusiveGateway_0tzco2c" targetRef="Screen_UserInput_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_03cktte" sourceRef="ExclusiveGateway_0tzco2c" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1xbbggi" sourceRef="ExclusiveGateway_0z4gzdc" targetRef="Service_UpdateRefTypeToMinisterial_0ai6870">
@@ -404,7 +404,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_094r7km" name="PutOnCampaign" sourceRef="ExclusiveGateway_0mmxl4e" targetRef="ServiceTask_1uwrjca">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageOutcome == "PutOnCampaign"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_09fnnt9" sourceRef="ExclusiveGateway_0sd09rb" targetRef="Screen_UserInput_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_09fnnt9" sourceRef="ExclusiveGateway_0sd09rb" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1legare" sourceRef="ExclusiveGateway_13i24qr" targetRef="ServiceTask_1t6qiuf">
@@ -414,7 +414,7 @@
       <bpmn:incoming>SequenceFlow_1legare</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_09iq9he</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_09iq9he" sourceRef="ServiceTask_1t6qiuf" targetRef="EndEvent_1golwf2" />
+    <bpmn:sequenceFlow id="SequenceFlow_09iq9he" sourceRef="ServiceTask_1t6qiuf" targetRef="EndEvent_MpamTriage" />
     <bpmn:serviceTask id="ServiceTask_1uwrjca" name="Clear CampaignType" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;CampaignType&#34;)}">
       <bpmn:incoming>SequenceFlow_094r7km</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0cc989h</bpmn:outgoing>
@@ -465,10 +465,10 @@
     <bpmn:sequenceFlow id="SequenceFlow_11xj7za" sourceRef="ExclusiveGateway_0rfbi5i" targetRef="ServiceTask_0b7jhew">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0sk755u" sourceRef="ExclusiveGateway_0o1sjlo" targetRef="Screen_UserInput_05nlmnl">
+    <bpmn:sequenceFlow id="SequenceFlow_0sk755u" sourceRef="ExclusiveGateway_0o1sjlo" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0ksl1cg" sourceRef="ServiceTask_1bkf5fp" targetRef="EndEvent_1golwf2" />
+    <bpmn:sequenceFlow id="SequenceFlow_0ksl1cg" sourceRef="ServiceTask_1bkf5fp" targetRef="EndEvent_MpamTriage" />
     <bpmn:serviceTask id="Service_SaveRefTypeChangeCaseNote_1sobox0" name="Save Ref Type Change Case Note" camunda:expression="${bpmnService.createCaseConversionNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_TriageChangeCaseType&#34;))}">
       <bpmn:incoming>SequenceFlow_0cz2azb</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_17gv9sk</bpmn:incoming>
@@ -520,15 +520,20 @@
     <bpmn:sequenceFlow id="Flow_1slp2aw" sourceRef="Gateway_1g01f59" targetRef="Activity_06vopxz">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageOutcome == "CloseCaseTelephone"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1gxj9d4" sourceRef="Gateway_15nvntw" targetRef="Screen_UserInput_05nlmnl">
+    <bpmn:sequenceFlow id="Flow_1gxj9d4" sourceRef="Gateway_15nvntw" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_19ce18n" sourceRef="Activity_1rzz5vn" targetRef="EndEvent_1golwf2" />
+    <bpmn:sequenceFlow id="Flow_19ce18n" sourceRef="Activity_1rzz5vn" targetRef="EndEvent_MpamTriage" />
     <bpmn:serviceTask id="Service_ClearMinisterialValues_05l3eed" name="Clear Ministerial values" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;MinSignOffTeam&#34;, &#34;Addressee&#34;)}">
       <bpmn:incoming>SequenceFlow_10jivty</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_00sgdbb</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_00sgdbb" sourceRef="Service_ClearMinisterialValues_05l3eed" targetRef="ExclusiveGateway_0d3wc9s" />
+    <bpmn:serviceTask id="Service_ClearRejected" name="Clear Rejected" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;Rejected&#34;)}">
+      <bpmn:incoming>SequenceFlow_0kcq8md</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0ojtjqk</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0ojtjqk" sourceRef="Service_ClearRejected" targetRef="EndEvent_MpamTriage" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_TRIAGE">
@@ -1016,8 +1021,7 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0kcq8md_di" bpmnElement="SequenceFlow_0kcq8md">
         <di:waypoint x="2134" y="515" />
-        <di:waypoint x="2349" y="515" />
-        <di:waypoint x="2349" y="620" />
+        <di:waypoint x="2193" y="515" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0x8dpmn_di" bpmnElement="SequenceFlow_0x8dpmn">
         <di:waypoint x="192" y="556" />
@@ -1046,22 +1050,22 @@
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="156" y="538" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_05nlmnl_di" bpmnElement="Screen_UserInput_05nlmnl">
+      <bpmndi:BPMNShape id="ServiceTask_05nlmnl_di" bpmnElement="Screen_UserInput">
         <dc:Bounds x="380" y="516" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_0jxw8et_di" bpmnElement="Validate_UserInput_0jxw8et">
+      <bpmndi:BPMNShape id="UserTask_0jxw8et_di" bpmnElement="Validate_UserInput">
         <dc:Bounds x="380" y="758" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_13qjvzx_di" bpmnElement="ExclusiveGateway_13qjvzx" isMarkerVisible="true">
         <dc:Bounds x="585" y="614" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_1golwf2_di" bpmnElement="EndEvent_1golwf2">
+      <bpmndi:BPMNShape id="EndEvent_1golwf2_di" bpmnElement="EndEvent_MpamTriage">
         <dc:Bounds x="2331" y="621" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="2378" y="632" width="52" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1ds9yik_di" bpmnElement="ServiceTask_1ds9yik">
+      <bpmndi:BPMNShape id="ServiceTask_1ds9yik_di" bpmnElement="Service_UpdateTeamForDraft">
         <dc:Bounds x="2034" y="475" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0p3mwpr_di" bpmnElement="ExclusiveGateway_0p3mwpr" isMarkerVisible="true">
@@ -1286,6 +1290,14 @@
       <bpmndi:BPMNEdge id="SequenceFlow_00sgdbb_di" bpmnElement="SequenceFlow_00sgdbb">
         <di:waypoint x="1522" y="1425" />
         <di:waypoint x="1522" y="1232" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_03upndg_di" bpmnElement="Service_ClearRejected">
+        <dc:Bounds x="2193" y="475" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ojtjqk_di" bpmnElement="SequenceFlow_0ojtjqk">
+        <di:waypoint x="2293" y="515" />
+        <di:waypoint x="2349" y="515" />
+        <di:waypoint x="2349" y="621" />
       </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMDispatch.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMDispatch.java
@@ -1,0 +1,74 @@
+package uk.gov.digital.ho.hocs.workflow.processes;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.camunda.bpm.scenario.ProcessScenario;
+import org.camunda.bpm.scenario.Scenario;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.withVariables;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+@Deployment(resources = "processes/MPAM_DISPATCH.bpmn")
+public class MPAMDispatch {
+
+    @Rule
+    @ClassRule
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
+            .assertClassCoverageAtLeast(0.2)
+            .build();
+
+    @Rule
+    public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+    @Mock
+    BpmnService bpmnService;
+    @Mock
+    private ProcessScenario processScenario;
+
+    @Before
+    public void setup() {
+        Mocks.register("bpmnService", bpmnService);
+    }
+
+    @Test
+    public void whenReturnToDraft_thenSavesCasenote_andUpdatesRejected_andUpdatesTeam() {
+
+        when(processScenario.waitsAtUserTask("Validate_UserInput"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "FORWARD",
+                        "DispatchStatus", "ReturnToDraft")));
+        when(processScenario.waitsAtUserTask("Validate_ReturnToDraftInput"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "FORWARD",
+                        "CaseNote_DispatchReturnToDraft", "Casenote Reject")));
+
+        Scenario.run(processScenario)
+                .startByKey("MPAM_DISPATCH")
+                .execute();
+
+        verify(processScenario).hasCompleted("Screen_ReturnToDraftInput");
+        verify(processScenario).hasCompleted("Service_SaveReturnReasonNote");
+        verify(bpmnService).updateAllocationNote(any(), any(), eq("Casenote Reject"), eq("REJECT"));
+        verify(processScenario).hasCompleted("Service_UpdateToRejectedByDispatch");
+        verify(bpmnService).updateValue(any(), any(), eq("Rejected"), eq("By Dispatch"));
+        verify(processScenario).hasCompleted("Service_UpdateTeamForDraft");
+        verify(bpmnService).updateTeamByStageAndTexts(any(), any(), eq("MPAM_DRAFT"), eq("QueueTeamUUID"), eq("QueueTeamName"), eq("BusArea"), eq("RefType"));
+        verify(processScenario).hasFinished("EndEvent_MpamDispatch");
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMPo.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMPo.java
@@ -1,0 +1,74 @@
+package uk.gov.digital.ho.hocs.workflow.processes;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.camunda.bpm.scenario.ProcessScenario;
+import org.camunda.bpm.scenario.Scenario;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.withVariables;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+@Deployment(resources = "processes/MPAM_PO.bpmn")
+public class MPAMPo {
+
+    @Rule
+    @ClassRule
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
+            .assertClassCoverageAtLeast(0.2)
+            .build();
+
+    @Rule
+    public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+    @Mock
+    BpmnService bpmnService;
+    @Mock
+    private ProcessScenario processScenario;
+
+    @Before
+    public void setup() {
+        Mocks.register("bpmnService", bpmnService);
+    }
+
+    @Test
+    public void whenRejectDraft_thenSavesCasenote_andUpdatesRejected_andUpdatesTeam() {
+
+        when(processScenario.waitsAtUserTask("Validate_UserInput"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "FORWARD",
+                        "PoStatus", "Reject-PfS")));
+        when(processScenario.waitsAtUserTask("Validate_RejectToDraft"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "FORWARD",
+                        "CaseNote_RejectPfs", "Casenote Reject")));
+
+        Scenario.run(processScenario)
+                .startByKey("MPAM_PO")
+                .execute();
+
+        verify(processScenario).hasCompleted("Screen_RejectToDraft");
+        verify(processScenario).hasCompleted("Service_SaveRejectPfsNote");
+        verify(bpmnService).updateAllocationNote(any(), any(), eq("Casenote Reject"), eq("REJECT"));
+        verify(processScenario).hasCompleted("Service_UpdateToRejectedByPo");
+        verify(bpmnService).updateValue(any(), any(), eq("Rejected"), eq("By PO"));
+        verify(processScenario).hasCompleted("Service_UpdateTeamForDraft");
+        verify(bpmnService).updateTeamByStageAndTexts(any(), any(), eq("MPAM_DRAFT"), eq("QueueTeamUUID"), eq("QueueTeamName"), eq("BusArea"), eq("RefType"));
+        verify(processScenario).hasFinished("EndEvent_MpamPo");
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMQa.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMQa.java
@@ -1,0 +1,101 @@
+package uk.gov.digital.ho.hocs.workflow.processes;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.camunda.bpm.scenario.ProcessScenario;
+import org.camunda.bpm.scenario.Scenario;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.withVariables;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+@Deployment(resources = "processes/MPAM_QA.bpmn")
+public class MPAMQa {
+
+    @Rule
+    @ClassRule
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
+            .assertClassCoverageAtLeast(0.2)
+            .build();
+
+    @Rule
+    public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+    @Mock
+    BpmnService bpmnService;
+    @Mock
+    private ProcessScenario processScenario;
+
+    @Before
+    public void setup() {
+        Mocks.register("bpmnService", bpmnService);
+    }
+
+    @Test
+    public void whenRejectDraft_thenSavesCasenote_andUpdatesRejected_andUpdatesTeam() {
+
+        when(processScenario.waitsAtUserTask("Validate_UserInput"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "FORWARD",
+                        "QaStatus", "Reject-Draft")));
+        when(processScenario.waitsAtUserTask("Validate_RejectToDraft"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "FORWARD",
+                        "CaseNote_RejectDraft", "Casenote Reject")));
+
+        Scenario.run(processScenario)
+                .startByKey("MPAM_QA")
+                .execute();
+
+        verify(processScenario).hasCompleted("Screen_RejectToDraft");
+        verify(processScenario).hasCompleted("Service_SaveRejectDraftNote");
+        verify(bpmnService).updateAllocationNote(any(), any(), eq("Casenote Reject"), eq("REJECT"));
+        verify(processScenario).hasCompleted("Service_UpdateToRejectedByQa_RejectToDraft");
+        verify(bpmnService).updateValue(any(), any(), eq("Rejected"), eq("By QA"));
+        verify(processScenario).hasCompleted("Service_UpdateTeamForDraft");
+        verify(bpmnService).updateTeamByStageAndTexts(any(), any(), eq("MPAM_DRAFT"), eq("QueueTeamUUID"), eq("QueueTeamName"), eq("BusArea"), eq("RefType"));
+        verify(processScenario).hasFinished("EndEvent_MpamQa");
+    }
+
+    @Test
+    public void whenRejectTriage_thenSavesCasenote_andUpdatesRejected_andUpdatesTeam() {
+
+        when(processScenario.waitsAtUserTask("Validate_UserInput"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "FORWARD",
+                        "QaStatus", "Reject-Triage")));
+        when(processScenario.waitsAtUserTask("Validate_RejectToTriage"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "FORWARD",
+                        "CaseNote_RejectTriage", "Casenote Reject")));
+
+        Scenario.run(processScenario)
+                .startByKey("MPAM_QA")
+                .execute();
+
+        verify(processScenario).hasCompleted("Screen_RejectToTriage");
+        verify(processScenario).hasCompleted("Service_SaveRejectTriageNote");
+        verify(bpmnService).updateAllocationNote(any(), any(), eq("Casenote Reject"), eq("REJECT"));
+        verify(processScenario).hasCompleted("Service_UpdateToRejectedByQa_RejectToTriage");
+        verify(bpmnService).updateValue(any(), any(), eq("Rejected"), eq("By QA"));
+        verify(processScenario).hasCompleted("Service_UpdateTeamForTriage");
+        verify(bpmnService).updateTeamByStageAndTexts(any(), any(), eq("MPAM_TRIAGE"), eq("QueueTeamUUID"), eq("QueueTeamName"), eq("BusArea"), eq("RefType"));
+        verify(processScenario).hasFinished("EndEvent_MpamQa");
+    }
+}


### PR DESCRIPTION
Set new "Rejected" value when moving back from: Draft, QA (to Triage), QA (to Draft), PO, Dispatch.
Clear new "Rejected" value when moving from: Triage->Draft, Draft->QA, Draft->Dispatch (B-Ref only).
Renamed some Camunda boxes to improve readability of workflow unit tests for each of the eight scenarios above.