### PR TITLE
Drone tagging for installing docker image using casework

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -42,7 +42,7 @@ pipeline:
       - docker tag hocs-workflow quay.io/ukhomeofficedigital/hocs-workflow:build-$${DRONE_BUILD_NUMBER}
       - docker push quay.io/ukhomeofficedigital/hocs-workflow:build-$${DRONE_BUILD_NUMBER}
       - export BRANCH_NAME_TAGFRIENDLY=`echo "$${DRONE_COMMIT_BRANCH}" | sed 's$/$_$g'`
-      - docker tag hocs-casework quay.io/ukhomeofficedigital/hocs-workflow:branch-$${BRANCH_NAME_TAGFRIENDLY}
+      - docker tag hocs-workflow quay.io/ukhomeofficedigital/hocs-workflow:branch-$${BRANCH_NAME_TAGFRIENDLY}
       - docker push quay.io/ukhomeofficedigital/hocs-workflow:branch-$${BRANCH_NAME_TAGFRIENDLY}
     when:
       branch: [master, epic/*]


### PR DESCRIPTION
As a result of the change to allow for workflow epic builds we are currently tagging the wrong project. This change rectifies this to be workflow instead of casework.