### PR TITLE
Fix name of project incorrect - was worflow and not workflow

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -58,7 +58,7 @@ pipeline:
     commands:
       - docker login -u="ukhomeofficedigital+hocs" -p=$${DOCKER_PASSWORD} quay.io
       - docker tag hocs-workflow quay.io/ukhomeofficedigital/hocs-workflow:latest
-      - docker push quay.io/ukhomeofficedigital/hocs-worflow:latest
+      - docker push quay.io/ukhomeofficedigital/hocs-workflow:latest
     when:
       branch: [master, epic/*]
       event: push


### PR DESCRIPTION
Project name was incorrectly spelt worflow instead of workflow in drone.yml `install-docker-image-latest`step. 
This change ensures that the pipeline can be ran successfully.