### PR TITLE
HOCS-2364: Update variable placement

### DIFF
--- a/src/main/resources/processes/MPAM.bpmn
+++ b/src/main/resources/processes/MPAM.bpmn
@@ -63,6 +63,7 @@
       <bpmn:extensionElements>
         <camunda:in source="DraftUUID" target="StageUUID" />
         <camunda:in sourceExpression="MPAM_DRAFT" target="StageWorkFlow" />
+        <camunda:in variables="all" />
         <camunda:in businessKey="#{execution.processBusinessKey}" />
         <camunda:out source="StageUUID" target="DraftUUID" />
         <camunda:out source="DateReceived" target="DateReceived" />
@@ -82,7 +83,6 @@
         <camunda:in source="&#34;&#34;" target="RefTypeStatus" />
         <camunda:out source="RefTypeStatus" target="RefTypeStatus" />
         <camunda:out source="LastUpdatedByUserUUID" target="CampaignUserUUID" />
-        <camunda:in variables="all" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1lxdhh3</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0pe8uiv</bpmn:incoming>


### PR DESCRIPTION
Update the all variable placement to allow for the further down blanking out of RefTypeStatus and BusAreaStatus to take affect. This was changed previously incorrectly.