### PR TITLE
HOCS-2283 - Fix markup teams being updated when team disabled

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
@@ -179,17 +179,35 @@ public class BpmnService {
         Map<String, String> teamsForTopic = new HashMap<>();
 
         if (StringUtils.hasText(draftingUUIDString)) {
-            log.info("Overwriting draft team with {}", draftingUUIDString);
             TeamDto draftingTeam = infoClient.getTeam(UUID.fromString(draftingUUIDString));
-            teamsForTopic.put("OverrideDraftingTeamUUID", draftingTeam.getUuid().toString());
-            teamsForTopic.put("OverrideDraftingTeamName", draftingTeam.getDisplayName());
+
+            if (draftingTeam.isActive()){
+                teamsForTopic.put("OverrideDraftingTeamUUID", draftingTeam.getUuid().toString());
+                teamsForTopic.put("OverrideDraftingTeamName", draftingTeam.getDisplayName());
+                log.info("Overwriting draft team with {}", draftingUUIDString);
+            }
+            else {
+                teamsForTopic.put("OverrideDraftingTeamUUID", null);
+                teamsForTopic.put("OverrideDraftingTeamName", null);
+                log.info("Removing Override Drafting Team as selected team was inactive.");
+            }
+
+
         }
 
         if (StringUtils.hasText(privateOfficeUUIDString)) {
-            log.info("Overwriting po team with {}", privateOfficeUUIDString);
             TeamDto pOTeam = infoClient.getTeam(UUID.fromString(privateOfficeUUIDString));
-            teamsForTopic.put("OverridePOTeamUUID", pOTeam.getUuid().toString());
-            teamsForTopic.put("OverridePOTeamName", pOTeam.getDisplayName());
+            if (pOTeam.isActive()){
+                teamsForTopic.put("OverridePOTeamUUID", pOTeam.getUuid().toString());
+                teamsForTopic.put("OverridePOTeamName", pOTeam.getDisplayName());
+                log.info("Overwriting po team with {}", privateOfficeUUIDString);
+            }
+            else{
+                teamsForTopic.put("OverridePOTeamUUID", null);
+                teamsForTopic.put("OverridePOTeamName", null);
+                log.info("Removing Override PO Team as selected team was inactive.");
+            }
+
         }
 
         if (!teamsForTopic.isEmpty()) {

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/BpmnServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/BpmnServiceTest.java
@@ -149,6 +149,30 @@ public class BpmnServiceTest {
     }
 
     @Test
+    public void shouldUpdateDataRemoveOverrideDraftingTeams() {
+
+        UUID draftingString = UUID.randomUUID();
+
+        String teamName = "Team1";
+        TeamDto team = new TeamDto(teamName, draftingString, false, new HashSet<>());
+        Map<String, String> teamsForTopic = new HashMap<>();
+        teamsForTopic.put("OverrideDraftingTeamUUID", null);
+        teamsForTopic.put("OverrideDraftingTeamName", null);
+
+        when(infoClient.getTeam(draftingString)).thenReturn(team);
+
+        bpmnService.updateTeamSelection(caseUUID, stageUUID, draftingString.toString(), null);
+
+        verify(infoClient, times(1)).getTeam(draftingString);
+        verify(camundaClient, times(1)).updateTask(UUID.fromString(stageUUID), teamsForTopic);
+        verify(caseworkClient, times(1)).updateCase(UUID.fromString(caseUUID), UUID.fromString(stageUUID), teamsForTopic);
+
+        verifyZeroInteractions(caseworkClient);
+        verifyZeroInteractions(camundaClient);
+        verifyZeroInteractions(infoClient);
+    }
+
+    @Test
     public void shouldUpdateDataNewPOTeams() {
 
         UUID privateOfficeString = UUID.randomUUID();
@@ -158,6 +182,30 @@ public class BpmnServiceTest {
         Map<String, String> teamsForTopic = new HashMap<>();
         teamsForTopic.put("OverridePOTeamUUID", privateOfficeString.toString());
         teamsForTopic.put("OverridePOTeamName", teamName);
+
+        when(infoClient.getTeam(privateOfficeString)).thenReturn(team);
+
+        bpmnService.updateTeamSelection(caseUUID, stageUUID, null, privateOfficeString.toString());
+
+        verify(infoClient, times(1)).getTeam(privateOfficeString);
+        verify(camundaClient, times(1)).updateTask(UUID.fromString(stageUUID), teamsForTopic);
+        verify(caseworkClient, times(1)).updateCase(UUID.fromString(caseUUID), UUID.fromString(stageUUID), teamsForTopic);
+
+        verifyZeroInteractions(caseworkClient);
+        verifyZeroInteractions(camundaClient);
+        verifyZeroInteractions(infoClient);
+    }
+
+    @Test
+    public void shouldUpdateDataRemoveOverridePOTeams() {
+
+        UUID privateOfficeString = UUID.randomUUID();
+
+        String teamName = "Team1";
+        TeamDto team = new TeamDto(teamName, privateOfficeString, false, new HashSet<>());
+        Map<String, String> teamsForTopic = new HashMap<>();
+        teamsForTopic.put("OverridePOTeamUUID", null);
+        teamsForTopic.put("OverridePOTeamName", null);
 
         when(infoClient.getTeam(privateOfficeString)).thenReturn(team);
 


### PR DESCRIPTION
Fix for when an override markup team has been disabled and the case is then updated with no override team selected. The case should no longer have an override team selected and the _correct_ initial team(s) should be selected.

- Branched from #377 as changes to the `updateTeamSelection` meant I could implement a simpler solution.
- Added a check into `updateTeamSelection` to see if Override Teams are inactive. If they are, remove them by setting null.
- Add tests to `BpmnServiceTest`.