### PR TITLE
HOCS-2405: handle backwards from misallocations screen

### DIFF
--- a/src/main/resources/processes/MPAM_TRANSFER.bpmn
+++ b/src/main/resources/processes/MPAM_TRANSFER.bpmn
@@ -7,14 +7,15 @@
     <bpmn:serviceTask id="Activity_15jdyd3" name="User Input" camunda:expression="MPAM_TRANSFER_INPUT" camunda:resultVariable="screen">
       <bpmn:incoming>Flow_0y1ahtg</bpmn:incoming>
       <bpmn:incoming>Flow_01edicv</bpmn:incoming>
+      <bpmn:incoming>Flow_0c5aec8</bpmn:incoming>
       <bpmn:outgoing>Flow_10hrhs5</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0y1ahtg" sourceRef="StartEvent_1" targetRef="Activity_15jdyd3" />
-    <bpmn:userTask id="Activity_1rqb3kj" name="Validate User Input">
+    <bpmn:userTask id="Validate_UserInput_Transfer" name="Validate User Input">
       <bpmn:incoming>Flow_10hrhs5</bpmn:incoming>
       <bpmn:outgoing>Flow_1ihyknj</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:sequenceFlow id="Flow_10hrhs5" sourceRef="Activity_15jdyd3" targetRef="Activity_1rqb3kj" />
+    <bpmn:sequenceFlow id="Flow_10hrhs5" sourceRef="Activity_15jdyd3" targetRef="Validate_UserInput_Transfer" />
     <bpmn:exclusiveGateway id="Gateway_0xgutdt" name="IsValid?">
       <bpmn:incoming>Flow_1ihyknj</bpmn:incoming>
       <bpmn:outgoing>Flow_01edicv</bpmn:outgoing>
@@ -23,8 +24,8 @@
     <bpmn:sequenceFlow id="Flow_01edicv" name="false" sourceRef="Gateway_0xgutdt" targetRef="Activity_15jdyd3">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1ihyknj" sourceRef="Activity_1rqb3kj" targetRef="Gateway_0xgutdt" />
-    <bpmn:endEvent id="Event_0dl0sia" name="End Stage&#10;&#10;">
+    <bpmn:sequenceFlow id="Flow_1ihyknj" sourceRef="Validate_UserInput_Transfer" targetRef="Gateway_0xgutdt" />
+    <bpmn:endEvent id="EndEvent_MpamTransfer" name="End Stage&#10;&#10;">
       <bpmn:incoming>Flow_152qw0a</bpmn:incoming>
       <bpmn:incoming>Flow_18k8e5m</bpmn:incoming>
       <bpmn:incoming>Flow_0gg9t91</bpmn:incoming>
@@ -42,32 +43,32 @@
       <bpmn:outgoing>Flow_1nthk5l</bpmn:outgoing>
       <bpmn:outgoing>Flow_1f7xchk</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_152qw0a" name="Transfer Accepted" sourceRef="Gateway_1kvs6l2" targetRef="Event_0dl0sia">
+    <bpmn:sequenceFlow id="Flow_152qw0a" name="Transfer Accepted" sourceRef="Gateway_1kvs6l2" targetRef="EndEvent_MpamTransfer">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TransferOutcome == 'TransferAccepted'}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1nthk5l" name="Transfer Rejected" sourceRef="Gateway_1kvs6l2" targetRef="Activity_18fmvw3">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TransferOutcome == 'TransferRejected'}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_18k8e5m" sourceRef="Activity_0isuqez" targetRef="Event_0dl0sia" />
+    <bpmn:sequenceFlow id="Flow_18k8e5m" sourceRef="Activity_0isuqez" targetRef="EndEvent_MpamTransfer" />
     <bpmn:serviceTask id="Activity_18fmvw3" name="User Input" camunda:expression="MPAM_UPDATE_BUS_AREA_ON_TRANSFER_EXIT" camunda:resultVariable="screen">
       <bpmn:incoming>Flow_00y55ab</bpmn:incoming>
       <bpmn:incoming>Flow_1nthk5l</bpmn:incoming>
       <bpmn:outgoing>Flow_1uhs1tg</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="Activity_0380gol" name="Validate User Input">
+    <bpmn:userTask id="Validate_UserInput_RejectUpdateBusinessArea" name="Validate User Input">
       <bpmn:incoming>Flow_1uhs1tg</bpmn:incoming>
       <bpmn:outgoing>Flow_1qmoefm</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:exclusiveGateway id="Gateway_1s99wiu" name="IsValid?">
-      <bpmn:incoming>Flow_1qmoefm</bpmn:incoming>
+      <bpmn:incoming>Flow_1opz3eb</bpmn:incoming>
       <bpmn:outgoing>Flow_00y55ab</bpmn:outgoing>
       <bpmn:outgoing>Flow_1dbhlsq</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_00y55ab" name="false" sourceRef="Gateway_1s99wiu" targetRef="Activity_18fmvw3">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1uhs1tg" sourceRef="Activity_18fmvw3" targetRef="Activity_0380gol" />
-    <bpmn:sequenceFlow id="Flow_1qmoefm" sourceRef="Activity_0380gol" targetRef="Gateway_1s99wiu" />
+    <bpmn:sequenceFlow id="Flow_1uhs1tg" sourceRef="Activity_18fmvw3" targetRef="Validate_UserInput_RejectUpdateBusinessArea" />
+    <bpmn:sequenceFlow id="Flow_1qmoefm" sourceRef="Validate_UserInput_RejectUpdateBusinessArea" targetRef="Gateway_01sw7ug" />
     <bpmn:sequenceFlow id="Flow_1dbhlsq" sourceRef="Gateway_1s99wiu" targetRef="Activity_0isuqez">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -78,133 +79,159 @@
     <bpmn:sequenceFlow id="Flow_1f7xchk" sourceRef="Gateway_1kvs6l2" targetRef="Activity_1ogqztp">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TransferOutcome == 'SaveDeadline'}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0gg9t91" sourceRef="Activity_1ogqztp" targetRef="Event_0dl0sia" />
+    <bpmn:sequenceFlow id="Flow_0gg9t91" sourceRef="Activity_1ogqztp" targetRef="EndEvent_MpamTransfer" />
+    <bpmn:exclusiveGateway id="Gateway_01sw7ug" name="Direction?">
+      <bpmn:incoming>Flow_1qmoefm</bpmn:incoming>
+      <bpmn:outgoing>Flow_1opz3eb</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0c5aec8</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1opz3eb" sourceRef="Gateway_01sw7ug" targetRef="Gateway_1s99wiu">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0c5aec8" sourceRef="Gateway_01sw7ug" targetRef="Activity_15jdyd3">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION != "FORWARD"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_TRANSFER">
+      <bpmndi:BPMNEdge id="Flow_0gg9t91_di" bpmnElement="Flow_0gg9t91">
+        <di:waypoint x="1000" y="570" />
+        <di:waypoint x="1186" y="570" />
+        <di:waypoint x="1186" y="440" />
+        <di:waypoint x="1372" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f7xchk_di" bpmnElement="Flow_1f7xchk">
+        <di:waypoint x="750" y="465" />
+        <di:waypoint x="750" y="570" />
+        <di:waypoint x="900" y="570" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1dbhlsq_di" bpmnElement="Flow_1dbhlsq">
-        <di:waypoint x="1125" y="237" />
-        <di:waypoint x="1200" y="237" />
+        <di:waypoint x="1125" y="287" />
+        <di:waypoint x="1200" y="287" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1qmoefm_di" bpmnElement="Flow_1qmoefm">
-        <di:waypoint x="950" y="237" />
-        <di:waypoint x="1075" y="237" />
+        <di:waypoint x="950" y="170" />
+        <di:waypoint x="1075" y="170" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1uhs1tg_di" bpmnElement="Flow_1uhs1tg">
-        <di:waypoint x="900" y="160" />
-        <di:waypoint x="900" y="197" />
+        <di:waypoint x="900" y="247" />
+        <di:waypoint x="900" y="210" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_00y55ab_di" bpmnElement="Flow_00y55ab">
-        <di:waypoint x="1100" y="212" />
-        <di:waypoint x="1100" y="120" />
-        <di:waypoint x="950" y="120" />
+        <di:waypoint x="1075" y="287" />
+        <di:waypoint x="950" y="287" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1103" y="163" width="24" height="14" />
+          <dc:Bounds x="1008" y="263" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_18k8e5m_di" bpmnElement="Flow_18k8e5m">
-        <di:waypoint x="1300" y="237" />
-        <di:waypoint x="1350" y="237" />
-        <di:waypoint x="1350" y="390" />
-        <di:waypoint x="1372" y="390" />
+        <di:waypoint x="1300" y="287" />
+        <di:waypoint x="1350" y="287" />
+        <di:waypoint x="1350" y="440" />
+        <di:waypoint x="1372" y="440" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1nthk5l_di" bpmnElement="Flow_1nthk5l">
-        <di:waypoint x="750" y="365" />
-        <di:waypoint x="750" y="120" />
-        <di:waypoint x="850" y="120" />
+        <di:waypoint x="750" y="415" />
+        <di:waypoint x="750" y="287" />
+        <di:waypoint x="850" y="287" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="722" y="247" width="88" height="14" />
+          <dc:Bounds x="722" y="350" width="88" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_152qw0a_di" bpmnElement="Flow_152qw0a">
-        <di:waypoint x="775" y="390" />
-        <di:waypoint x="1372" y="390" />
+        <di:waypoint x="775" y="440" />
+        <di:waypoint x="1372" y="440" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1029" y="372" width="90" height="14" />
+          <dc:Bounds x="1029" y="422" width="90" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_09ucsi7_di" bpmnElement="Flow_09ucsi7">
-        <di:waypoint x="675" y="390" />
-        <di:waypoint x="725" y="390" />
+        <di:waypoint x="675" y="440" />
+        <di:waypoint x="725" y="440" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="690" y="372" width="19" height="14" />
+          <dc:Bounds x="690" y="422" width="19" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ihyknj_di" bpmnElement="Flow_1ihyknj">
-        <di:waypoint x="500" y="390" />
-        <di:waypoint x="625" y="390" />
+        <di:waypoint x="500" y="440" />
+        <di:waypoint x="625" y="440" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_01edicv_di" bpmnElement="Flow_01edicv">
-        <di:waypoint x="650" y="365" />
-        <di:waypoint x="650" y="237" />
-        <di:waypoint x="500" y="237" />
+        <di:waypoint x="650" y="415" />
+        <di:waypoint x="650" y="287" />
+        <di:waypoint x="500" y="287" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="653" y="298" width="24" height="14" />
+          <dc:Bounds x="653" y="348" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_10hrhs5_di" bpmnElement="Flow_10hrhs5">
-        <di:waypoint x="450" y="277" />
-        <di:waypoint x="450" y="350" />
+        <di:waypoint x="450" y="327" />
+        <di:waypoint x="450" y="400" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0y1ahtg_di" bpmnElement="Flow_0y1ahtg">
-        <di:waypoint x="215" y="237" />
-        <di:waypoint x="400" y="237" />
+        <di:waypoint x="215" y="287" />
+        <di:waypoint x="400" y="287" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1f7xchk_di" bpmnElement="Flow_1f7xchk">
-        <di:waypoint x="750" y="415" />
-        <di:waypoint x="750" y="520" />
-        <di:waypoint x="900" y="520" />
+      <bpmndi:BPMNEdge id="Flow_1opz3eb_di" bpmnElement="Flow_1opz3eb">
+        <di:waypoint x="1100" y="195" />
+        <di:waypoint x="1100" y="262" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0gg9t91_di" bpmnElement="Flow_0gg9t91">
-        <di:waypoint x="1000" y="520" />
-        <di:waypoint x="1186" y="520" />
-        <di:waypoint x="1186" y="390" />
-        <di:waypoint x="1372" y="390" />
+      <bpmndi:BPMNEdge id="Flow_0c5aec8_di" bpmnElement="Flow_0c5aec8">
+        <di:waypoint x="1100" y="145" />
+        <di:waypoint x="1100" y="80" />
+        <di:waypoint x="450" y="80" />
+        <di:waypoint x="450" y="247" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="219" width="36" height="36" />
+        <dc:Bounds x="179" y="269" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="166" y="262" width="64" height="14" />
+          <dc:Bounds x="166" y="312" width="64" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0ix4vid_di" bpmnElement="Activity_15jdyd3">
-        <dc:Bounds x="400" y="197" width="100" height="80" />
+        <dc:Bounds x="400" y="247" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0bxnunx_di" bpmnElement="Activity_1rqb3kj">
-        <dc:Bounds x="400" y="350" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_0bxnunx_di" bpmnElement="Validate_UserInput_Transfer">
+        <dc:Bounds x="400" y="400" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0xgutdt_di" bpmnElement="Gateway_0xgutdt" isMarkerVisible="true">
-        <dc:Bounds x="625" y="365" width="50" height="50" />
+        <dc:Bounds x="625" y="415" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="631" y="413" width="39" height="14" />
+          <dc:Bounds x="631" y="463" width="39" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0dl0sia_di" bpmnElement="Event_0dl0sia">
-        <dc:Bounds x="1372" y="372" width="36" height="36" />
+      <bpmndi:BPMNShape id="Event_0dl0sia_di" bpmnElement="EndEvent_MpamTransfer">
+        <dc:Bounds x="1372" y="422" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1364" y="415" width="52" height="40" />
+          <dc:Bounds x="1364" y="465" width="52" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0isuqez_di" bpmnElement="Activity_0isuqez">
-        <dc:Bounds x="1200" y="197" width="100" height="80" />
+        <dc:Bounds x="1200" y="247" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1kvs6l2_di" bpmnElement="Gateway_1kvs6l2" isMarkerVisible="true">
-        <dc:Bounds x="725" y="365" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_18fmvw3_di" bpmnElement="Activity_18fmvw3">
-        <dc:Bounds x="850" y="80" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0380gol_di" bpmnElement="Activity_0380gol">
-        <dc:Bounds x="850" y="197" width="100" height="80" />
+        <dc:Bounds x="725" y="415" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1s99wiu_di" bpmnElement="Gateway_1s99wiu" isMarkerVisible="true">
-        <dc:Bounds x="1075" y="212" width="50" height="50" />
+        <dc:Bounds x="1075" y="262" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1081" y="260" width="39" height="14" />
+          <dc:Bounds x="1080" y="323" width="39" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1ogqztp_di" bpmnElement="Activity_1ogqztp">
-        <dc:Bounds x="900" y="480" width="100" height="80" />
+        <dc:Bounds x="900" y="530" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18fmvw3_di" bpmnElement="Activity_18fmvw3">
+        <dc:Bounds x="850" y="247" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0380gol_di" bpmnElement="Validate_UserInput_RejectUpdateBusinessArea">
+        <dc:Bounds x="850" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_01sw7ug_di" bpmnElement="Gateway_01sw7ug" isMarkerVisible="true">
+        <dc:Bounds x="1075" y="145" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1135" y="163" width="50" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMTransfer.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMTransfer.java
@@ -1,0 +1,70 @@
+package uk.gov.digital.ho.hocs.workflow.processes;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.camunda.bpm.scenario.ProcessScenario;
+import org.camunda.bpm.scenario.Scenario;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.withVariables;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+@Deployment(resources = "processes/MPAM_TRANSFER.bpmn")
+public class MPAMTransfer {
+
+    @Rule
+    @ClassRule
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
+            .assertClassCoverageAtLeast(0.78)
+            .build();
+
+    @Rule
+    public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+    @Mock
+    BpmnService bpmnService;
+    @Mock
+    private ProcessScenario processScenario;
+
+    @Before
+    public void setup() {
+        Mocks.register("bpmnService", bpmnService);
+    }
+
+    @Test
+    public void whenTransferReject_thenGoBack_thenRepeatAndProceed() {
+        when(processScenario.waitsAtUserTask("Validate_UserInput_Transfer"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "TransferOutcome", "TransferRejected")));
+
+        when(processScenario.waitsAtUserTask("Validate_UserInput_RejectUpdateBusinessArea"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "BACKWARD")))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "FORWARD",
+                        "valid", true)));
+
+        Scenario.run(processScenario)
+                .startByKey("MPAM_TRANSFER")
+                .execute();
+
+        verify(processScenario, times(2)).hasCompleted("Activity_15jdyd3");
+        verify(processScenario, times(2)).hasCompleted("Activity_18fmvw3");
+        verify(bpmnService, times(1)).updateTeamByStageAndTexts(any(), any(), eq("MPAM_TRIAGE"), eq("QueueTeamUUID"),
+                eq("QueueTeamName"), eq("BusArea"), eq("RefType"));
+        verify(processScenario).hasFinished("EndEvent_MpamTransfer");
+    }
+}


### PR DESCRIPTION
At present we don't have a way of handling the back button
when returning from the MPAM_UPDATE_BUS_AREA_ON_TRANSFER_EXIT 
screen. This change adds the workflow requirements to return to
 the previous screen.