### PR TITLE
Hocs 2471 - draft/po team override

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ dependencies {
 	implementation 'org.projectlombok:lombok:1.18.16'
 	compileOnly group: 'org.projectlombok', name: 'lombok', version: '1.18.6'
 	annotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.6'
+	testAnnotationProcessor group: 'org.projectlombok', name: 'lombok', version: '1.18.6'
 
 	testImplementation('org.springframework.boot:spring-boot-starter-test')
 	testImplementation("org.apache.camel:camel-test-spring:${camelVersion}")

--- a/src/main/resources/processes/DCU_DTEN.bpmn
+++ b/src/main/resources/processes/DCU_DTEN.bpmn
@@ -36,6 +36,8 @@
         <camunda:out source="DraftingTeamUUID" target="DraftingTeamUUID" />
         <camunda:out source="POTeamUUID" target="POTeamUUID" />
         <camunda:in source="&#34;&#34;" target="DraftingTeamUUID" />
+        <camunda:out source="OverrideDraftingTeamUUID" target="OverrideDraftingTeamUUID" />
+        <camunda:out source="OverridePOTeamUUID" target="OverridePOTeamUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_18mb2fq</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1ii85y3</bpmn:incoming>
@@ -87,7 +89,7 @@
         <camunda:out source="OfflineQA" target="OfflineQA" />
         <camunda:in sourceExpression="DCU_DTEN_INITIAL_DRAFT" target="StageType" />
         <camunda:out sourceExpression="${execution.getVariable(&#34;InitialDraftDecision&#34;) == &#34;REJECT&#34; ?  &#34;INITIAL_DRAFT_REJECT&#34; : execution.getVariable(&#34;OfflineQA&#34;) == &#34;TRUE&#34; ? &#34;ALLOCATE_PRIVATE_OFFICE&#34; : &#34;ALLOCATE_TEAM&#34; }" target="EmailType" />
-        <camunda:in source="DraftingTeamUUID" target="AllocationTeamUUID" />
+        <camunda:in sourceExpression="${execution.getVariable(&#34;OverrideDraftingTeamUUID&#34;) == null ? execution.getVariable(&#34;DraftingTeamUUID&#34;) : execution.getVariable(&#34;OverrideDraftingTeamUUID&#34;) }" target="AllocationTeamUUID" />
         <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_04i3gn3</bpmn:incoming>
@@ -132,7 +134,7 @@
         <camunda:in sourceExpression="DCU_DTEN_QA_RESPONSE" target="StageType" />
         <camunda:out sourceExpression="${execution.getVariable(QAResponseDecision) == &#34;REJECT&#34; ?  &#34;QA_REJECT&#34; : &#34;ALLOCATE_TEAM&#34;}" target="EmailType" />
         <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
-        <camunda:in source="DraftingTeamUUID" target="AllocationTeamUUID" />
+        <camunda:in sourceExpression="${execution.getVariable(&#34;OverrideDraftingTeamUUID&#34;) == null ? execution.getVariable(&#34;DraftingTeamUUID&#34;) : execution.getVariable(&#34;OverrideDraftingTeamUUID&#34;) }" target="AllocationTeamUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_06rxrum</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1gic80p</bpmn:outgoing>
@@ -148,7 +150,7 @@
         <camunda:in sourceExpression="DCU_DTEN_PRIVATE_OFFICE" target="StageType" />
         <camunda:out sourceExpression="${execution.getVariable(PrivateOfficeDecision) == &#34;REJECT&#34; ? &#34;PRIVATE_OFFICE_REJECT&#34; : &#34;ALLOCATE_TEAM&#34;}" target="EmailType" />
         <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
-        <camunda:in sourceExpression="${execution.getVariable(&#34;PrivateOfficeOverridePOTeamUUID&#34;) == null ? execution.getVariable(&#34;POTeamUUID&#34;) : execution.getVariable(&#34;PrivateOfficeOverridePOTeamUUID&#34;) }" target="AllocationTeamUUID" />
+        <camunda:in sourceExpression="${execution.getVariable(&#34;PrivateOfficeOverridePOTeamUUID&#34;) == null ? (execution.getVariable(&#34;OverridePOTeamUUID&#34;) == null ? execution.getVariable(&#34;POTeamUUID&#34;) : execution.getVariable(&#34;OverridePOTeamUUID&#34;)) : execution.getVariable(&#34;PrivateOfficeOverridePOTeamUUID&#34;) }" target="AllocationTeamUUID" />
         <camunda:out source="PrivateOfficeOverridePOTeamUUID" target="PrivateOfficeOverridePOTeamUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0y1hwz5</bpmn:incoming>

--- a/src/main/resources/processes/DCU_DTEN.bpmn
+++ b/src/main/resources/processes/DCU_DTEN.bpmn
@@ -18,11 +18,11 @@
     <bpmn:sequenceFlow id="SequenceFlow_058p133" name="OGD" sourceRef="ExclusiveGateway_1j2nbeb" targetRef="Task_0wqz5qj">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${MarkupDecision == "OGD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_04i3gn3" name="FAQ OR MARKUP" sourceRef="ExclusiveGateway_1j2nbeb" targetRef="CallActivity_1ket68y">
+    <bpmn:sequenceFlow id="SequenceFlow_04i3gn3" name="FAQ OR MARKUP" sourceRef="ExclusiveGateway_1j2nbeb" targetRef="InitialDraft_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${MarkupDecision == "FAQ" || MarkupDecision == "PR"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1kbehe7" sourceRef="Task_1grynar" targetRef="ExclusiveGateway_1j2nbeb" />
-    <bpmn:callActivity id="Task_1grynar" name="Mark Up" calledElement="STAGE">
+    <bpmn:sequenceFlow id="SequenceFlow_1kbehe7" sourceRef="MarkUp_CallActivity" targetRef="ExclusiveGateway_1j2nbeb" />
+    <bpmn:callActivity id="MarkUp_CallActivity" name="Mark Up" calledElement="STAGE">
       <bpmn:extensionElements>
         <camunda:in source="MarkupUUID" target="StageUUID" />
         <camunda:in sourceExpression="DCU_DTEN_MARKUP" target="StageWorkFlow" />
@@ -76,8 +76,8 @@
       <bpmn:incoming>SequenceFlow_1fmqxh8</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_18mb2fq</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:sequenceFlow id="SequenceFlow_18mb2fq" sourceRef="CallActivity_0sc1113" targetRef="Task_1grynar" />
-    <bpmn:callActivity id="CallActivity_1ket68y" name="Initial Draft" calledElement="STAGE">
+    <bpmn:sequenceFlow id="SequenceFlow_18mb2fq" sourceRef="CallActivity_0sc1113" targetRef="MarkUp_CallActivity" />
+    <bpmn:callActivity id="InitialDraft_CallActivity" name="Initial Draft" calledElement="STAGE">
       <bpmn:extensionElements>
         <camunda:in source="InitialDraftUUID" target="StageUUID" />
         <camunda:in sourceExpression="DCU_DTEN_INITIAL_DRAFT" target="StageWorkFlow" />
@@ -102,8 +102,8 @@
       <bpmn:outgoing>SequenceFlow_0occ9ef</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0hodmse</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1no0ocj" sourceRef="CallActivity_1ket68y" targetRef="ExclusiveGateway_1wtjsxs" />
-    <bpmn:sequenceFlow id="SequenceFlow_0occ9ef" name="REJECT" sourceRef="ExclusiveGateway_1wtjsxs" targetRef="Task_1grynar">
+    <bpmn:sequenceFlow id="SequenceFlow_1no0ocj" sourceRef="InitialDraft_CallActivity" targetRef="ExclusiveGateway_1wtjsxs" />
+    <bpmn:sequenceFlow id="SequenceFlow_0occ9ef" name="REJECT" sourceRef="ExclusiveGateway_1wtjsxs" targetRef="MarkUp_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${InitialDraftDecision == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:callActivity id="CallActivity_0ttmlei" name="No Reply Needed Confirmation" calledElement="STAGE">
@@ -123,7 +123,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_0lq9cg0" name="NRN" sourceRef="ExclusiveGateway_1j2nbeb" targetRef="CallActivity_0ttmlei">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${MarkupDecision == "NRN"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:callActivity id="CallActivity_151mthq" name="QA Response" calledElement="STAGE">
+    <bpmn:callActivity id="QAResponse_CallActivity" name="QA Response" calledElement="STAGE">
       <bpmn:extensionElements>
         <camunda:in source="QAResponseUUID" target="StageUUID" />
         <camunda:in sourceExpression="DCU_BASE_QA_RESPONSE" target="StageWorkFlow" />
@@ -139,7 +139,7 @@
       <bpmn:incoming>SequenceFlow_06rxrum</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1gic80p</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:callActivity id="CallActivity_0pmeblj" name="Private Office Sign Off" calledElement="STAGE">
+    <bpmn:callActivity id="POSignOff_CallActivity" name="Private Office Sign Off" calledElement="STAGE">
       <bpmn:extensionElements>
         <camunda:in source="PrivateOfficeUUID" target="StageUUID" />
         <camunda:in sourceExpression="DCU_DTEN_PRIVATE_OFFICE" target="StageWorkFlow" />
@@ -163,11 +163,11 @@
       <bpmn:outgoing>SequenceFlow_0y1hwz5</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_094as2e</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1gic80p" sourceRef="CallActivity_151mthq" targetRef="ServiceTask_0vdobae" />
-    <bpmn:sequenceFlow id="SequenceFlow_0y1hwz5" name="ACCEPT, MODIFY" sourceRef="ExclusiveGateway_1asbwik" targetRef="CallActivity_0pmeblj">
+    <bpmn:sequenceFlow id="SequenceFlow_1gic80p" sourceRef="QAResponse_CallActivity" targetRef="ServiceTask_0vdobae" />
+    <bpmn:sequenceFlow id="SequenceFlow_0y1hwz5" name="ACCEPT, MODIFY" sourceRef="ExclusiveGateway_1asbwik" targetRef="POSignOff_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QAResponseDecision == "ACCEPT" || QAResponseDecision == "MODIFY"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_094as2e" name="REJECT" sourceRef="ExclusiveGateway_1asbwik" targetRef="CallActivity_1ket68y">
+    <bpmn:sequenceFlow id="SequenceFlow_094as2e" name="REJECT" sourceRef="ExclusiveGateway_1asbwik" targetRef="InitialDraft_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QAResponseDecision == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_0uh5jth">
@@ -175,7 +175,7 @@
       <bpmn:outgoing>SequenceFlow_1tlbpjq</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0ln7eru</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1tlbpjq" name="REJECT" sourceRef="ExclusiveGateway_0uh5jth" targetRef="CallActivity_1ket68y">
+    <bpmn:sequenceFlow id="SequenceFlow_1tlbpjq" name="REJECT" sourceRef="ExclusiveGateway_0uh5jth" targetRef="InitialDraft_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PrivateOfficeDecision == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0ln7eru" name="ACCEPT" sourceRef="ExclusiveGateway_0uh5jth" targetRef="CallActivity_1rowgu5">
@@ -202,7 +202,7 @@
       <bpmn:outgoing>SequenceFlow_0hrswjv</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="SequenceFlow_1p4ijz3" sourceRef="CallActivity_1rowgu5" targetRef="ExclusiveGateway_19ar4c1" />
-    <bpmn:sequenceFlow id="SequenceFlow_1fy5blc" name="REJECT" sourceRef="ExclusiveGateway_19ar4c1" targetRef="CallActivity_0pmeblj">
+    <bpmn:sequenceFlow id="SequenceFlow_1fy5blc" name="REJECT" sourceRef="ExclusiveGateway_19ar4c1" targetRef="POSignOff_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DispatchDecision == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1bi7lza" sourceRef="CallActivity_0ttmlei" targetRef="ExclusiveGateway_0aomnup" />
@@ -212,7 +212,7 @@
       <bpmn:outgoing>SequenceFlow_0tcxf89</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="SequenceFlow_1h7ckog" sourceRef="Task_0wqz5qj" targetRef="ExclusiveGateway_1dfo58w" />
-    <bpmn:sequenceFlow id="SequenceFlow_1ii85y3" sourceRef="ExclusiveGateway_0aomnup" targetRef="Task_1grynar">
+    <bpmn:sequenceFlow id="SequenceFlow_1ii85y3" sourceRef="ExclusiveGateway_0aomnup" targetRef="MarkUp_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${NoReplyNeededConfirmation == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0tcxf89" sourceRef="ExclusiveGateway_0aomnup" targetRef="ServiceTask_0c47qfa">
@@ -223,7 +223,7 @@
       <bpmn:outgoing>SequenceFlow_08od3ei</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_06rxrum</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_08od3ei" name="Offline QA" sourceRef="ExclusiveGateway_1ycmh2d" targetRef="CallActivity_0pmeblj">
+    <bpmn:sequenceFlow id="SequenceFlow_08od3ei" name="Offline QA" sourceRef="ExclusiveGateway_1ycmh2d" targetRef="POSignOff_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${OfflineQA == "TRUE"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_1dfo58w">
@@ -231,7 +231,7 @@
       <bpmn:outgoing>SequenceFlow_0br3a39</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_18o5t1m</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_0br3a39" sourceRef="ExclusiveGateway_1dfo58w" targetRef="Task_1grynar">
+    <bpmn:sequenceFlow id="SequenceFlow_0br3a39" sourceRef="ExclusiveGateway_1dfo58w" targetRef="MarkUp_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TransferConfirmation == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_18o5t1m" sourceRef="ExclusiveGateway_1dfo58w" targetRef="ServiceTask_0c47qfa">
@@ -243,8 +243,8 @@
     <bpmn:sequenceFlow id="SequenceFlow_0hrswjv" name="ACCEPT" sourceRef="ExclusiveGateway_19ar4c1" targetRef="ServiceTask_0c47qfa">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DispatchDecision == "ACCEPT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0u1n7ex" sourceRef="CallActivity_0pmeblj" targetRef="ExclusiveGateway_0uh5jth" />
-    <bpmn:sequenceFlow id="SequenceFlow_06rxrum" sourceRef="ExclusiveGateway_1ycmh2d" targetRef="CallActivity_151mthq">
+    <bpmn:sequenceFlow id="SequenceFlow_0u1n7ex" sourceRef="POSignOff_CallActivity" targetRef="ExclusiveGateway_0uh5jth" />
+    <bpmn:sequenceFlow id="SequenceFlow_06rxrum" sourceRef="ExclusiveGateway_1ycmh2d" targetRef="QAResponse_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${OfflineQA == "FALSE"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="ServiceTask_0c47qfa" name="Complete Case" camunda:expression="${bpmnService.completeCase(execution.processBusinessKey)}">
@@ -317,7 +317,7 @@
           <dc:Bounds x="2058" y="595" width="90" height="20" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="CallActivity_0atg31v_di" bpmnElement="Task_1grynar">
+      <bpmndi:BPMNShape id="CallActivity_0atg31v_di" bpmnElement="MarkUp_CallActivity">
         <dc:Bounds x="593" y="177" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CallActivity_03ex0iv_di" bpmnElement="Task_0wqz5qj">
@@ -333,7 +333,7 @@
           <dc:Bounds x="1528" y="595" width="90" height="20" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="CallActivity_1ket68y_di" bpmnElement="CallActivity_1ket68y">
+      <bpmndi:BPMNShape id="CallActivity_1ket68y_di" bpmnElement="InitialDraft_CallActivity">
         <dc:Bounds x="1539" y="177" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1wtjsxs_di" bpmnElement="ExclusiveGateway_1wtjsxs" isMarkerVisible="true">
@@ -369,10 +369,10 @@
           <dc:Bounds x="1040" y="251" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="CallActivity_151mthq_di" bpmnElement="CallActivity_151mthq">
+      <bpmndi:BPMNShape id="CallActivity_151mthq_di" bpmnElement="QAResponse_CallActivity">
         <dc:Bounds x="2147" y="177" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="CallActivity_0pmeblj_di" bpmnElement="CallActivity_0pmeblj">
+      <bpmndi:BPMNShape id="CallActivity_0pmeblj_di" bpmnElement="POSignOff_CallActivity">
         <dc:Bounds x="2634" y="177" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1asbwik_di" bpmnElement="ExclusiveGateway_1asbwik" isMarkerVisible="true">

--- a/src/main/resources/processes/DCU_MIN.bpmn
+++ b/src/main/resources/processes/DCU_MIN.bpmn
@@ -18,11 +18,11 @@
     <bpmn:sequenceFlow id="SequenceFlow_058p133" name="OGD" sourceRef="ExclusiveGateway_1j2nbeb" targetRef="Task_0wqz5qj">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${MarkupDecision == "OGD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_04i3gn3" name="FAQ OR MARKUP" sourceRef="ExclusiveGateway_1j2nbeb" targetRef="CallActivity_1ket68y">
+    <bpmn:sequenceFlow id="SequenceFlow_04i3gn3" name="FAQ OR MARKUP" sourceRef="ExclusiveGateway_1j2nbeb" targetRef="InitialDraft_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${MarkupDecision == "FAQ" || MarkupDecision == "PR"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1kbehe7" sourceRef="Task_1grynar" targetRef="ExclusiveGateway_1j2nbeb" />
-    <bpmn:callActivity id="Task_1grynar" name="Mark Up" calledElement="STAGE">
+    <bpmn:sequenceFlow id="SequenceFlow_1kbehe7" sourceRef="MarkUp_CallActivity" targetRef="ExclusiveGateway_1j2nbeb" />
+    <bpmn:callActivity id="MarkUp_CallActivity" name="Mark Up" calledElement="STAGE">
       <bpmn:extensionElements>
         <camunda:in source="MarkupUUID" target="StageUUID" />
         <camunda:in sourceExpression="DCU_MIN_MARKUP" target="StageWorkFlow" />
@@ -77,8 +77,8 @@
       <bpmn:incoming>SequenceFlow_0842fwm</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_18mb2fq</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:sequenceFlow id="SequenceFlow_18mb2fq" sourceRef="CallActivity_0sc1113" targetRef="Task_1grynar" />
-    <bpmn:callActivity id="CallActivity_1ket68y" name="Initial Draft" calledElement="STAGE">
+    <bpmn:sequenceFlow id="SequenceFlow_18mb2fq" sourceRef="CallActivity_0sc1113" targetRef="MarkUp_CallActivity" />
+    <bpmn:callActivity id="InitialDraft_CallActivity" name="Initial Draft" calledElement="STAGE">
       <bpmn:extensionElements>
         <camunda:in source="InitialDraftUUID" target="StageUUID" />
         <camunda:in sourceExpression="DCU_MIN_INITIAL_DRAFT" target="StageWorkFlow" />
@@ -104,8 +104,8 @@
       <bpmn:outgoing>SequenceFlow_0occ9ef</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0hodmse</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1no0ocj" sourceRef="CallActivity_1ket68y" targetRef="ExclusiveGateway_1wtjsxs" />
-    <bpmn:sequenceFlow id="SequenceFlow_0occ9ef" name="REJECT" sourceRef="ExclusiveGateway_1wtjsxs" targetRef="Task_1grynar">
+    <bpmn:sequenceFlow id="SequenceFlow_1no0ocj" sourceRef="InitialDraft_CallActivity" targetRef="ExclusiveGateway_1wtjsxs" />
+    <bpmn:sequenceFlow id="SequenceFlow_0occ9ef" name="REJECT" sourceRef="ExclusiveGateway_1wtjsxs" targetRef="MarkUp_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${InitialDraftDecision == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:callActivity id="CallActivity_0ttmlei" name="No Reply Needed Confirmation" calledElement="STAGE">
@@ -128,7 +128,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_0hodmse" name="ACCEPT" sourceRef="ExclusiveGateway_1wtjsxs" targetRef="ExclusiveGateway_0m2d0yc">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${InitialDraftDecision == "ACCEPT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:callActivity id="CallActivity_151mthq" name="QA Response" calledElement="STAGE">
+    <bpmn:callActivity id="QAResponse_CallActivity" name="QA Response" calledElement="STAGE">
       <bpmn:extensionElements>
         <camunda:in source="QAResponseUUID" target="StageUUID" />
         <camunda:in sourceExpression="DCU_BASE_QA_RESPONSE" target="StageWorkFlow" />
@@ -144,7 +144,7 @@
       <bpmn:incoming>SequenceFlow_17blyfx</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1gic80p</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:callActivity id="CallActivity_0pmeblj" name="Private Office Sign Off" calledElement="STAGE">
+    <bpmn:callActivity id="POSignOff_CallActivity" name="Private Office Sign Off" calledElement="STAGE">
       <bpmn:extensionElements>
         <camunda:in source="PrivateOfficeUUID" target="StageUUID" />
         <camunda:in sourceExpression="DCU_MIN_PRIVATE_OFFICE" target="StageWorkFlow" />
@@ -170,11 +170,11 @@
       <bpmn:outgoing>SequenceFlow_0y1hwz5</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_094as2e</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1gic80p" sourceRef="CallActivity_151mthq" targetRef="ServiceTask_0agee0y" />
-    <bpmn:sequenceFlow id="SequenceFlow_0y1hwz5" name="ACCEPT, MODIFY" sourceRef="ExclusiveGateway_1asbwik" targetRef="CallActivity_0pmeblj">
+    <bpmn:sequenceFlow id="SequenceFlow_1gic80p" sourceRef="QAResponse_CallActivity" targetRef="ServiceTask_0agee0y" />
+    <bpmn:sequenceFlow id="SequenceFlow_0y1hwz5" name="ACCEPT, MODIFY" sourceRef="ExclusiveGateway_1asbwik" targetRef="POSignOff_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QAResponseDecision == "ACCEPT" || QAResponseDecision == "MODIFY"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_094as2e" name="REJECT" sourceRef="ExclusiveGateway_1asbwik" targetRef="CallActivity_1ket68y">
+    <bpmn:sequenceFlow id="SequenceFlow_094as2e" name="REJECT" sourceRef="ExclusiveGateway_1asbwik" targetRef="InitialDraft_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QAResponseDecision == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_0uh5jth">
@@ -183,11 +183,11 @@
       <bpmn:outgoing>SequenceFlow_0ln7eru</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1yygtaq</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1dvsqnt" sourceRef="CallActivity_0pmeblj" targetRef="ExclusiveGateway_0uh5jth" />
-    <bpmn:sequenceFlow id="SequenceFlow_1tlbpjq" name="REJECT" sourceRef="ExclusiveGateway_0uh5jth" targetRef="CallActivity_1ket68y">
+    <bpmn:sequenceFlow id="SequenceFlow_1dvsqnt" sourceRef="POSignOff_CallActivity" targetRef="ExclusiveGateway_0uh5jth" />
+    <bpmn:sequenceFlow id="SequenceFlow_1tlbpjq" name="REJECT" sourceRef="ExclusiveGateway_0uh5jth" targetRef="InitialDraft_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PrivateOfficeDecision == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:callActivity id="CallActivity_1syv7pu" name="Minister Sign Off" calledElement="STAGE">
+    <bpmn:callActivity id="MinisterSignOff_CallActivity" name="Minister Sign Off" calledElement="STAGE">
       <bpmn:extensionElements>
         <camunda:in source="MinisterSignOffUUID" target="StageUUID" />
         <camunda:in sourceExpression="DCU_MIN_MINISTER_SIGN_OFF" target="StageWorkFlow" />
@@ -203,7 +203,7 @@
       <bpmn:incoming>SequenceFlow_0ln7eru</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_19kv4zf</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:sequenceFlow id="SequenceFlow_0ln7eru" name="ACCEPT" sourceRef="ExclusiveGateway_0uh5jth" targetRef="CallActivity_1syv7pu">
+    <bpmn:sequenceFlow id="SequenceFlow_0ln7eru" name="ACCEPT" sourceRef="ExclusiveGateway_0uh5jth" targetRef="MinisterSignOff_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PrivateOfficeDecision == "ACCEPT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:callActivity id="CallActivity_1rowgu5" name="Dispatch" calledElement="STAGE">
@@ -221,7 +221,7 @@
       <bpmn:incoming>SequenceFlow_0gdfx58</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1p4ijz3</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:sequenceFlow id="SequenceFlow_19kv4zf" sourceRef="CallActivity_1syv7pu" targetRef="ExclusiveGateway_1mq7rz0" />
+    <bpmn:sequenceFlow id="SequenceFlow_19kv4zf" sourceRef="MinisterSignOff_CallActivity" targetRef="ExclusiveGateway_1mq7rz0" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_19ar4c1">
       <bpmn:incoming>SequenceFlow_1p4ijz3</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0hrswjv</bpmn:outgoing>
@@ -231,7 +231,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_0hrswjv" name="ACCEPT" sourceRef="ExclusiveGateway_19ar4c1" targetRef="ExclusiveGateway_03dipct">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DispatchDecision == "ACCEPT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1fy5blc" name="REJECT" sourceRef="ExclusiveGateway_19ar4c1" targetRef="CallActivity_0pmeblj">
+    <bpmn:sequenceFlow id="SequenceFlow_1fy5blc" name="REJECT" sourceRef="ExclusiveGateway_19ar4c1" targetRef="POSignOff_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DispatchDecision == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_1mq7rz0">
@@ -240,7 +240,7 @@
       <bpmn:outgoing>SequenceFlow_0gdfx58</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1gnfbua</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_042tt22" name="REJECT" sourceRef="ExclusiveGateway_1mq7rz0" targetRef="CallActivity_1ket68y">
+    <bpmn:sequenceFlow id="SequenceFlow_042tt22" name="REJECT" sourceRef="ExclusiveGateway_1mq7rz0" targetRef="InitialDraft_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${MinisterSignOffDecision == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0gdfx58" name="ACCEPT" sourceRef="ExclusiveGateway_1mq7rz0" targetRef="CallActivity_1rowgu5">
@@ -253,7 +253,7 @@
       <bpmn:outgoing>SequenceFlow_0tcxf89</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="SequenceFlow_1h7ckog" sourceRef="Task_0wqz5qj" targetRef="ExclusiveGateway_1dfo58w" />
-    <bpmn:sequenceFlow id="SequenceFlow_1ii85y3" sourceRef="ExclusiveGateway_0aomnup" targetRef="Task_1grynar">
+    <bpmn:sequenceFlow id="SequenceFlow_1ii85y3" sourceRef="ExclusiveGateway_0aomnup" targetRef="MarkUp_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${NoReplyNeededConfirmation == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0tcxf89" sourceRef="ExclusiveGateway_0aomnup" targetRef="Task_0aiawho">
@@ -275,10 +275,10 @@
       <bpmn:outgoing>SequenceFlow_17blyfx</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_08od3ei</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_17blyfx" sourceRef="ExclusiveGateway_1ycmh2d" targetRef="CallActivity_151mthq">
+    <bpmn:sequenceFlow id="SequenceFlow_17blyfx" sourceRef="ExclusiveGateway_1ycmh2d" targetRef="QAResponse_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${OfflineQA == "FALSE"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_08od3ei" name="Offline QA" sourceRef="ExclusiveGateway_1ycmh2d" targetRef="CallActivity_0pmeblj">
+    <bpmn:sequenceFlow id="SequenceFlow_08od3ei" name="Offline QA" sourceRef="ExclusiveGateway_1ycmh2d" targetRef="POSignOff_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${OfflineQA == "TRUE"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_03dipct">
@@ -306,7 +306,7 @@
       <bpmn:incoming>SequenceFlow_0y4nfck</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_163tdrh</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:sequenceFlow id="SequenceFlow_1yygtaq" name="CHANGE" sourceRef="ExclusiveGateway_0uh5jth" targetRef="CallActivity_0pmeblj">
+    <bpmn:sequenceFlow id="SequenceFlow_1yygtaq" name="CHANGE" sourceRef="ExclusiveGateway_0uh5jth" targetRef="POSignOff_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PrivateOfficeDecision == "CHANGE"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="ExclusiveGateway_1dfo58w">
@@ -314,7 +314,7 @@
       <bpmn:outgoing>SequenceFlow_0br3a39</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_18o5t1m</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_0br3a39" sourceRef="ExclusiveGateway_1dfo58w" targetRef="Task_1grynar">
+    <bpmn:sequenceFlow id="SequenceFlow_0br3a39" sourceRef="ExclusiveGateway_1dfo58w" targetRef="MarkUp_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TransferConfirmation == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_18o5t1m" sourceRef="ExclusiveGateway_1dfo58w" targetRef="Task_0aiawho">
@@ -342,7 +342,7 @@
       <bpmn:outgoing>SequenceFlow_0dbzkcf</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_0dbzkcf" sourceRef="ServiceTask_0agee0y" targetRef="ExclusiveGateway_1asbwik" />
-    <bpmn:sequenceFlow id="SequenceFlow_1gnfbua" name="NOT_APPLICABLE" sourceRef="ExclusiveGateway_1mq7rz0" targetRef="CallActivity_0pmeblj">
+    <bpmn:sequenceFlow id="SequenceFlow_1gnfbua" name="NOT_APPLICABLE" sourceRef="ExclusiveGateway_1mq7rz0" targetRef="POSignOff_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${MinisterSignOffDecision == "NOT_APPLICABLE"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
   </bpmn:process>
@@ -395,7 +395,7 @@
           <dc:Bounds x="2058" y="595" width="90" height="20" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="CallActivity_0atg31v_di" bpmnElement="Task_1grynar">
+      <bpmndi:BPMNShape id="CallActivity_0atg31v_di" bpmnElement="MarkUp_CallActivity">
         <dc:Bounds x="499" y="401" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CallActivity_03ex0iv_di" bpmnElement="Task_0wqz5qj">
@@ -411,7 +411,7 @@
           <dc:Bounds x="1528" y="595" width="90" height="20" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="CallActivity_1ket68y_di" bpmnElement="CallActivity_1ket68y">
+      <bpmndi:BPMNShape id="CallActivity_1ket68y_di" bpmnElement="InitialDraft_CallActivity">
         <dc:Bounds x="1257" y="401" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1wtjsxs_di" bpmnElement="ExclusiveGateway_1wtjsxs" isMarkerVisible="true">
@@ -454,10 +454,10 @@
           <dc:Bounds x="1508" y="409" width="45" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="CallActivity_151mthq_di" bpmnElement="CallActivity_151mthq">
+      <bpmndi:BPMNShape id="CallActivity_151mthq_di" bpmnElement="QAResponse_CallActivity">
         <dc:Bounds x="1955" y="401" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="CallActivity_0pmeblj_di" bpmnElement="CallActivity_0pmeblj">
+      <bpmndi:BPMNShape id="CallActivity_0pmeblj_di" bpmnElement="POSignOff_CallActivity">
         <dc:Bounds x="2377" y="401" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1asbwik_di" bpmnElement="ExclusiveGateway_1asbwik" isMarkerVisible="true">
@@ -511,7 +511,7 @@
           <dc:Bounds x="2607" y="513" width="43" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="CallActivity_1syv7pu_di" bpmnElement="CallActivity_1syv7pu">
+      <bpmndi:BPMNShape id="CallActivity_1syv7pu_di" bpmnElement="MinisterSignOff_CallActivity">
         <dc:Bounds x="2731" y="401" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNEdge id="SequenceFlow_0ln7eru_di" bpmnElement="SequenceFlow_0ln7eru">

--- a/src/main/resources/processes/DCU_MIN.bpmn
+++ b/src/main/resources/processes/DCU_MIN.bpmn
@@ -36,6 +36,8 @@
         <camunda:out source="DraftingTeamUUID" target="DraftingTeamUUID" />
         <camunda:out source="POTeamUUID" target="POTeamUUID" />
         <camunda:in source="&#34;&#34;" target="DraftingTeamUUID" />
+        <camunda:out source="OverrideDraftingTeamUUID" target="OverrideDraftingTeamUUID" />
+        <camunda:out source="OverridePOTeamUUID" target="OverridePOTeamUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0occ9ef</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1ii85y3</bpmn:incoming>
@@ -88,7 +90,7 @@
         <camunda:out source="OfflineQA" target="OfflineQA" />
         <camunda:in sourceExpression="DCU_MIN_INITIAL_DRAFT" target="StageType" />
         <camunda:out sourceExpression="${execution.getVariable(&#34;InitialDraftDecision&#34;) == &#34;REJECT&#34; ?  &#34;INITIAL_DRAFT_REJECT&#34; : execution.getVariable(&#34;OfflineQA&#34;) == &#34;TRUE&#34; ? &#34;ALLOCATE_PRIVATE_OFFICE&#34; : &#34;ALLOCATE_TEAM&#34; }" target="EmailType" />
-        <camunda:in source="DraftingTeamUUID" target="AllocationTeamUUID" />
+        <camunda:in sourceExpression="${execution.getVariable(&#34;OverrideDraftingTeamUUID&#34;) == null ? execution.getVariable(&#34;DraftingTeamUUID&#34;) : execution.getVariable(&#34;OverrideDraftingTeamUUID&#34;) }" target="AllocationTeamUUID" />
         <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_04i3gn3</bpmn:incoming>
@@ -137,7 +139,7 @@
         <camunda:in sourceExpression="DCU_MIN_QA_RESPONSE" target="StageType" />
         <camunda:out sourceExpression="${execution.getVariable(QAResponseDecision) == &#34;REJECT&#34; ?  &#34;QA_REJECT&#34; : &#34;ALLOCATE_TEAM&#34;}" target="EmailType" />
         <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
-        <camunda:in source="DraftingTeamUUID" target="AllocationTeamUUID" />
+        <camunda:in sourceExpression="${execution.getVariable(&#34;OverrideDraftingTeamUUID&#34;) == null ? execution.getVariable(&#34;DraftingTeamUUID&#34;) : execution.getVariable(&#34;OverrideDraftingTeamUUID&#34;) }" target="AllocationTeamUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_17blyfx</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1gic80p</bpmn:outgoing>
@@ -153,7 +155,7 @@
         <camunda:in sourceExpression="DCU_MIN_PRIVATE_OFFICE" target="StageType" />
         <camunda:out sourceExpression="${execution.getVariable(PrivateOfficeDecision) == &#34;REJECT&#34; ? &#34;PRIVATE_OFFICE_REJECT&#34; : &#34;ALLOCATE_TEAM&#34;}" target="EmailType" />
         <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
-        <camunda:in sourceExpression="${execution.getVariable(&#34;PrivateOfficeOverridePOTeamUUID&#34;) == null ? execution.getVariable(&#34;POTeamUUID&#34;) : execution.getVariable(&#34;PrivateOfficeOverridePOTeamUUID&#34;) }" target="AllocationTeamUUID" />
+        <camunda:in sourceExpression="${execution.getVariable(&#34;PrivateOfficeOverridePOTeamUUID&#34;) == null ? (execution.getVariable(&#34;OverridePOTeamUUID&#34;) == null ? execution.getVariable(&#34;POTeamUUID&#34;) : execution.getVariable(&#34;OverridePOTeamUUID&#34;)) : execution.getVariable(&#34;PrivateOfficeOverridePOTeamUUID&#34;) }" target="AllocationTeamUUID" />
         <camunda:out source="PrivateOfficeOverridePOTeamUUID" target="PrivateOfficeOverridePOTeamUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0y1hwz5</bpmn:incoming>
@@ -196,7 +198,7 @@
         <camunda:in sourceExpression="DCU_MIN_MINISTER_SIGN_OFF" target="StageType" />
         <camunda:out sourceExpression="${execution.getVariable(MinisterSignOffDecision) == &#34;REJECT&#34; ?  &#34;MINISTER_REJECT&#34; : &#34;ALLOCATE_TEAM&#34;}" target="EmailType" />
         <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
-        <camunda:in sourceExpression="${execution.getVariable(&#34;PrivateOfficeOverridePOTeamUUID&#34;) == null ? execution.getVariable(&#34;POTeamUUID&#34;) : execution.getVariable(&#34;PrivateOfficeOverridePOTeamUUID&#34;) }" target="AllocationTeamUUID" />
+        <camunda:in sourceExpression="${execution.getVariable(&#34;PrivateOfficeOverridePOTeamUUID&#34;) == null ? (execution.getVariable(&#34;OverridePOTeamUUID&#34;) == null ? execution.getVariable(&#34;POTeamUUID&#34;) : execution.getVariable(&#34;OverridePOTeamUUID&#34;)) : execution.getVariable(&#34;PrivateOfficeOverridePOTeamUUID&#34;) }" target="AllocationTeamUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0ln7eru</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_19kv4zf</bpmn:outgoing>

--- a/src/main/resources/processes/DCU_TRO.bpmn
+++ b/src/main/resources/processes/DCU_TRO.bpmn
@@ -18,11 +18,11 @@
     <bpmn:sequenceFlow id="SequenceFlow_058p133" name="OGD" sourceRef="ExclusiveGateway_1j2nbeb" targetRef="Task_0wqz5qj">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${MarkupDecision == "OGD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_04i3gn3" name="FAQ OR MARKUP" sourceRef="ExclusiveGateway_1j2nbeb" targetRef="CallActivity_1ket68y">
+    <bpmn:sequenceFlow id="SequenceFlow_04i3gn3" name="FAQ OR MARKUP" sourceRef="ExclusiveGateway_1j2nbeb" targetRef="InitialDraft_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${MarkupDecision == "FAQ" || MarkupDecision == "PR"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1kbehe7" sourceRef="Task_1grynar" targetRef="ExclusiveGateway_1j2nbeb" />
-    <bpmn:callActivity id="Task_1grynar" name="Mark Up" calledElement="STAGE">
+    <bpmn:sequenceFlow id="SequenceFlow_1kbehe7" sourceRef="MarkUp_CallActivity" targetRef="ExclusiveGateway_1j2nbeb" />
+    <bpmn:callActivity id="MarkUp_CallActivity" name="Mark Up" calledElement="STAGE">
       <bpmn:extensionElements>
         <camunda:in source="MarkupUUID" target="StageUUID" />
         <camunda:in sourceExpression="DCU_TRO_MARKUP" target="StageWorkFlow" />
@@ -75,8 +75,8 @@
       <bpmn:incoming>SequenceFlow_1bme8vz</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_18mb2fq</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:sequenceFlow id="SequenceFlow_18mb2fq" sourceRef="CallActivity_0sc1113" targetRef="Task_1grynar" />
-    <bpmn:callActivity id="CallActivity_1ket68y" name="Initial Draft" calledElement="STAGE">
+    <bpmn:sequenceFlow id="SequenceFlow_18mb2fq" sourceRef="CallActivity_0sc1113" targetRef="MarkUp_CallActivity" />
+    <bpmn:callActivity id="InitialDraft_CallActivity" name="Initial Draft" calledElement="STAGE">
       <bpmn:extensionElements>
         <camunda:in source="InitialDraftUUID" target="StageUUID" />
         <camunda:in sourceExpression="DCU_TRO_INITIAL_DRAFT" target="StageWorkFlow" />
@@ -101,8 +101,8 @@
       <bpmn:outgoing>SequenceFlow_0occ9ef</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0hodmse</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1no0ocj" sourceRef="CallActivity_1ket68y" targetRef="ExclusiveGateway_1wtjsxs" />
-    <bpmn:sequenceFlow id="SequenceFlow_0occ9ef" name="REJECT" sourceRef="ExclusiveGateway_1wtjsxs" targetRef="Task_1grynar">
+    <bpmn:sequenceFlow id="SequenceFlow_1no0ocj" sourceRef="InitialDraft_CallActivity" targetRef="ExclusiveGateway_1wtjsxs" />
+    <bpmn:sequenceFlow id="SequenceFlow_0occ9ef" name="REJECT" sourceRef="ExclusiveGateway_1wtjsxs" targetRef="MarkUp_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${InitialDraftDecision == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:callActivity id="CallActivity_0ttmlei" name="No Reply Needed Confirmation" calledElement="STAGE">
@@ -125,7 +125,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_0hodmse" name="ACCEPT" sourceRef="ExclusiveGateway_1wtjsxs" targetRef="ExclusiveGateway_0m2d0yc">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${InitialDraftDecision == "ACCEPT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:callActivity id="CallActivity_151mthq" name="QA Response" calledElement="STAGE">
+    <bpmn:callActivity id="QAResponse_CallActivity" name="QA Response" calledElement="STAGE">
       <bpmn:extensionElements>
         <camunda:in source="QAResponseUUID" target="StageUUID" />
         <camunda:in sourceExpression="DCU_BASE_QA_RESPONSE" target="StageWorkFlow" />
@@ -146,11 +146,11 @@
       <bpmn:outgoing>SequenceFlow_094as2e</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0y1hwz5</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1gic80p" sourceRef="CallActivity_151mthq" targetRef="ServiceTask_1qngsdc" />
-    <bpmn:sequenceFlow id="SequenceFlow_094as2e" name="REJECT" sourceRef="ExclusiveGateway_1asbwik" targetRef="CallActivity_1ket68y">
+    <bpmn:sequenceFlow id="SequenceFlow_1gic80p" sourceRef="QAResponse_CallActivity" targetRef="ServiceTask_1qngsdc" />
+    <bpmn:sequenceFlow id="SequenceFlow_094as2e" name="REJECT" sourceRef="ExclusiveGateway_1asbwik" targetRef="InitialDraft_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QAResponseDecision == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:callActivity id="CallActivity_1rowgu5" name="Dispatch" calledElement="STAGE">
+    <bpmn:callActivity id="Dispatch_CallActivity" name="Dispatch" calledElement="STAGE">
       <bpmn:extensionElements>
         <camunda:in source="DispatchUUID" target="StageUUID" />
         <camunda:in sourceExpression="DCU_BASE_DISPATCH" target="StageWorkFlow" />
@@ -172,11 +172,11 @@
       <bpmn:outgoing>SequenceFlow_0hrswjv</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1fy5blc</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1p4ijz3" sourceRef="CallActivity_1rowgu5" targetRef="ExclusiveGateway_19ar4c1" />
+    <bpmn:sequenceFlow id="SequenceFlow_1p4ijz3" sourceRef="Dispatch_CallActivity" targetRef="ExclusiveGateway_19ar4c1" />
     <bpmn:sequenceFlow id="SequenceFlow_0hrswjv" name="ACCEPT" sourceRef="ExclusiveGateway_19ar4c1" targetRef="ExclusiveGateway_03dipct">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DispatchDecision == "ACCEPT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1fy5blc" name="REJECT" sourceRef="ExclusiveGateway_19ar4c1" targetRef="CallActivity_1ket68y">
+    <bpmn:sequenceFlow id="SequenceFlow_1fy5blc" name="REJECT" sourceRef="ExclusiveGateway_19ar4c1" targetRef="InitialDraft_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DispatchDecision == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1bi7lza" sourceRef="CallActivity_0ttmlei" targetRef="ExclusiveGateway_0aomnup" />
@@ -186,7 +186,7 @@
       <bpmn:outgoing>SequenceFlow_0tcxf89</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="SequenceFlow_1h7ckog" sourceRef="Task_0wqz5qj" targetRef="ExclusiveGateway_1dfo58w" />
-    <bpmn:sequenceFlow id="SequenceFlow_1ii85y3" sourceRef="ExclusiveGateway_0aomnup" targetRef="Task_1grynar">
+    <bpmn:sequenceFlow id="SequenceFlow_1ii85y3" sourceRef="ExclusiveGateway_0aomnup" targetRef="MarkUp_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${NoReplyNeededConfirmation == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0tcxf89" sourceRef="ExclusiveGateway_0aomnup" targetRef="ServiceTask_057lbol">
@@ -233,13 +233,13 @@
       <bpmn:outgoing>SequenceFlow_0br3a39</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_18o5t1m</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_0br3a39" sourceRef="ExclusiveGateway_1dfo58w" targetRef="Task_1grynar">
+    <bpmn:sequenceFlow id="SequenceFlow_0br3a39" sourceRef="ExclusiveGateway_1dfo58w" targetRef="MarkUp_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TransferConfirmation == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_18o5t1m" sourceRef="ExclusiveGateway_1dfo58w" targetRef="ServiceTask_057lbol">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TransferConfirmation == "ACCEPT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0y1hwz5" name="ACCEPT, MODIFY" sourceRef="ExclusiveGateway_1asbwik" targetRef="CallActivity_1rowgu5">
+    <bpmn:sequenceFlow id="SequenceFlow_0y1hwz5" name="ACCEPT, MODIFY" sourceRef="ExclusiveGateway_1asbwik" targetRef="Dispatch_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QAResponseDecision == "ACCEPT" || QAResponseDecision == "MODIFY"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="ServiceTask_057lbol" name="Complete Case" camunda:expression="${bpmnService.completeCase(execution.processBusinessKey)}">
@@ -256,10 +256,10 @@
       <bpmn:outgoing>SequenceFlow_1vwmzfr</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0eskleb</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1vwmzfr" sourceRef="ExclusiveGateway_04nwh4d" targetRef="CallActivity_151mthq">
+    <bpmn:sequenceFlow id="SequenceFlow_1vwmzfr" sourceRef="ExclusiveGateway_04nwh4d" targetRef="QAResponse_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${OfflineQA == "FALSE"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0eskleb" name="Offline QA" sourceRef="ExclusiveGateway_04nwh4d" targetRef="CallActivity_1rowgu5">
+    <bpmn:sequenceFlow id="SequenceFlow_0eskleb" name="Offline QA" sourceRef="ExclusiveGateway_04nwh4d" targetRef="Dispatch_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${OfflineQA == "TRUE"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1bme8vz" name="REJ" sourceRef="ExclusiveGateway_1j2nbeb" targetRef="CallActivity_0sc1113">
@@ -325,7 +325,7 @@
           <dc:Bounds x="2058" y="595" width="90" height="20" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="CallActivity_0atg31v_di" bpmnElement="Task_1grynar">
+      <bpmndi:BPMNShape id="CallActivity_0atg31v_di" bpmnElement="MarkUp_CallActivity">
         <dc:Bounds x="570" y="338" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CallActivity_03ex0iv_di" bpmnElement="Task_0wqz5qj">
@@ -341,7 +341,7 @@
           <dc:Bounds x="1528" y="595" width="90" height="20" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="CallActivity_1ket68y_di" bpmnElement="CallActivity_1ket68y">
+      <bpmndi:BPMNShape id="CallActivity_1ket68y_di" bpmnElement="InitialDraft_CallActivity">
         <dc:Bounds x="1183" y="338" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1wtjsxs_di" bpmnElement="ExclusiveGateway_1wtjsxs" isMarkerVisible="true">
@@ -384,7 +384,7 @@
           <dc:Bounds x="1388" y="354" width="45" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="CallActivity_151mthq_di" bpmnElement="CallActivity_151mthq">
+      <bpmndi:BPMNShape id="CallActivity_151mthq_di" bpmnElement="QAResponse_CallActivity">
         <dc:Bounds x="1821" y="338" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1asbwik_di" bpmnElement="ExclusiveGateway_1asbwik" isMarkerVisible="true">
@@ -409,7 +409,7 @@
           <dc:Bounds x="2492" y="428" width="43" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="CallActivity_1rowgu5_di" bpmnElement="CallActivity_1rowgu5">
+      <bpmndi:BPMNShape id="CallActivity_1rowgu5_di" bpmnElement="Dispatch_CallActivity">
         <dc:Bounds x="2340" y="338" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_19ar4c1_di" bpmnElement="ExclusiveGateway_19ar4c1" isMarkerVisible="true">

--- a/src/main/resources/processes/DCU_TRO.bpmn
+++ b/src/main/resources/processes/DCU_TRO.bpmn
@@ -35,6 +35,7 @@
         <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
         <camunda:out source="DraftingTeamUUID" target="DraftingTeamUUID" />
         <camunda:in source="&#34;&#34;" target="DraftingTeamUUID" />
+        <camunda:out source="OverrideDraftingTeamUUID" target="OverrideDraftingTeamUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_18mb2fq</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1ii85y3</bpmn:incoming>
@@ -87,7 +88,7 @@
         <camunda:out source="OfflineQA" target="OfflineQA" />
         <camunda:in sourceExpression="DCU_TRO_INITIAL_DRAFT" target="StageType" />
         <camunda:out sourceExpression="${execution.getVariable(&#34;InitialDraftDecision&#34;) == &#34;REJECT&#34; ?  &#34;INITIAL_DRAFT_REJECT&#34; : execution.getVariable(&#34;OfflineQA&#34;) == &#34;TRUE&#34; ? &#34;ALLOCATE_PRIVATE_OFFICE&#34; : &#34;ALLOCATE_TEAM&#34; }" target="EmailType" />
-        <camunda:in source="DraftingTeamUUID" target="AllocationTeamUUID" />
+        <camunda:in sourceExpression="${execution.getVariable(&#34;OverrideDraftingTeamUUID&#34;) == null ? execution.getVariable(&#34;DraftingTeamUUID&#34;) : execution.getVariable(&#34;OverrideDraftingTeamUUID&#34;) }" target="AllocationTeamUUID" />
         <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_04i3gn3</bpmn:incoming>
@@ -135,7 +136,7 @@
         <camunda:in sourceExpression="DCU_TRO_QA_RESPONSE" target="StageType" />
         <camunda:out sourceExpression="${execution.getVariable(QAResponseDecision) == &#34;REJECT&#34; ?  &#34;QA_REJECT&#34; : &#34;ALLOCATE_TEAM&#34;}" target="EmailType" />
         <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
-        <camunda:in source="DraftingTeamUUID" target="AllocationTeamUUID" />
+        <camunda:in sourceExpression="${execution.getVariable(&#34;OverrideDraftingTeamUUID&#34;) == null ? execution.getVariable(&#34;DraftingTeamUUID&#34;) : execution.getVariable(&#34;OverrideDraftingTeamUUID&#34;) }" target="AllocationTeamUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1vwmzfr</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1gic80p</bpmn:outgoing>
@@ -160,7 +161,7 @@
         <camunda:in sourceExpression="DCU_TRO_DISPATCH" target="StageType" />
         <camunda:out sourceExpression="${execution.getVariable(DispatchDecision) == &#34;REJECT&#34; ?  &#34;DISPATCH_REJECT&#34; : &#34;ALLOCATE_TEAM&#34;}" target="EmailType" />
         <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
-        <camunda:in source="DraftingTeamUUID" target="AllocationTeamUUID" />
+        <camunda:in sourceExpression="${execution.getVariable(&#34;OverrideDraftingTeamUUID&#34;) == null ? execution.getVariable(&#34;DraftingTeamUUID&#34;) : execution.getVariable(&#34;OverrideDraftingTeamUUID&#34;) }" target="AllocationTeamUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0y1hwz5</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0eskleb</bpmn:incoming>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/DCU_MIN.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/DCU_MIN.java
@@ -34,8 +34,8 @@ import static uk.gov.digital.ho.hocs.workflow.util.CallActivityMockWrapper.whenA
 public class DCU_MIN {
 
     public static final String DISPATCH = "CallActivity_1rowgu5";
-    public static final String PO_SIGN_OFF = "CallActivity_0pmeblj";
-    public static final String INITIAL_DRAFT = "CallActivity_1ket68y";
+    public static final String PO_SIGN_OFF = "POSignOff_CallActivity";
+    public static final String INITIAL_DRAFT = "InitialDraft_CallActivity";
     @Rule
     @ClassRule
     public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/DCU_MIN_DTEN_TRO_CallActivityVariables.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/DCU_MIN_DTEN_TRO_CallActivityVariables.java
@@ -1,0 +1,115 @@
+package uk.gov.digital.ho.hocs.workflow.processes;
+
+import org.junit.Test;
+
+import static uk.gov.digital.ho.hocs.workflow.util.CallActivityTestUtil.callActivity;
+
+public class DCU_MIN_DTEN_TRO_CallActivityVariables {
+
+    public static final String DCU_MIN_BPMN = "processes/DCU_MIN.bpmn";
+    public static final String DCU_DTEN_BPMN = "processes/DCU_DTEN.bpmn";
+    public static final String DCU_TRO_BPMN = "processes/DCU_TRO.bpmn";
+    public static final String DRAFT_OVERRIDE_EXPRESSION = "${execution.getVariable(\"OverrideDraftingTeamUUID\") == null ? execution.getVariable(\"DraftingTeamUUID\") : execution.getVariable(\"OverrideDraftingTeamUUID\") }";
+    public static final String PO_OVERRIDE_EXPRESSION = "${execution.getVariable(\"PrivateOfficeOverridePOTeamUUID\") == null ? (execution.getVariable(\"OverridePOTeamUUID\") == null ? execution.getVariable(\"POTeamUUID\") : execution.getVariable(\"OverridePOTeamUUID\")) : execution.getVariable(\"PrivateOfficeOverridePOTeamUUID\") }";
+
+    @Test
+    public void MIN_MarkUpHasOverrideVariables() {
+        callActivity("MarkUp_CallActivity", DCU_MIN_BPMN)
+                .containsInputVariable("\"\"", "DraftingTeamUUID")
+                .containsOutputVariable("DraftingTeamUUID", "DraftingTeamUUID")
+                .containsOutputVariable("POTeamUUID", "POTeamUUID")
+                .containsOutputVariable("OverrideDraftingTeamUUID", "OverrideDraftingTeamUUID")
+                .containsOutputVariable("OverridePOTeamUUID", "OverridePOTeamUUID")
+                .assertVariables();
+    }
+
+    @Test
+    public void DTEN_MarkUpHasOverrideVariables() {
+        callActivity("MarkUp_CallActivity", DCU_DTEN_BPMN)
+                .containsInputVariable("\"\"", "DraftingTeamUUID")
+                .containsOutputVariable("DraftingTeamUUID", "DraftingTeamUUID")
+                .containsOutputVariable("POTeamUUID", "POTeamUUID")
+                .containsOutputVariable("OverrideDraftingTeamUUID", "OverrideDraftingTeamUUID")
+                .containsOutputVariable("OverridePOTeamUUID", "OverridePOTeamUUID")
+                .assertVariables();
+    }
+
+    @Test
+    public void TRO_MarkUpHasOverrideVariables() {
+        callActivity("MarkUp_CallActivity", DCU_TRO_BPMN)
+                .containsInputVariable("\"\"", "DraftingTeamUUID")
+                .containsOutputVariable("DraftingTeamUUID", "DraftingTeamUUID")
+                .containsOutputVariable("OverrideDraftingTeamUUID", "OverrideDraftingTeamUUID")
+                .assertVariables();
+    }
+
+    @Test
+    public void MIN_InitialDraftHasOverrideVariables() {
+        callActivity("InitialDraft_CallActivity", DCU_MIN_BPMN)
+                .containsInputVariable(DRAFT_OVERRIDE_EXPRESSION, "AllocationTeamUUID")
+                .assertVariables();
+    }
+
+    @Test
+    public void DTEN_InitialDraftHasOverrideVariables() {
+        callActivity("InitialDraft_CallActivity", DCU_DTEN_BPMN)
+                .containsInputVariable(DRAFT_OVERRIDE_EXPRESSION, "AllocationTeamUUID")
+                .assertVariables();
+    }
+
+    @Test
+    public void TRO_InitialDraftHasOverrideVariables() {
+        callActivity("InitialDraft_CallActivity", DCU_TRO_BPMN)
+                .containsInputVariable(DRAFT_OVERRIDE_EXPRESSION, "AllocationTeamUUID")
+                .assertVariables();
+    }
+
+    @Test
+    public void MIN_QAResponseHasOverrideVariables() {
+        callActivity("QAResponse_CallActivity", DCU_MIN_BPMN)
+                .containsInputVariable(DRAFT_OVERRIDE_EXPRESSION, "AllocationTeamUUID")
+                .assertVariables();
+    }
+
+    @Test
+    public void DTEN_QAResponseHasOverrideVariables() {
+        callActivity("QAResponse_CallActivity", DCU_DTEN_BPMN)
+                .containsInputVariable(DRAFT_OVERRIDE_EXPRESSION, "AllocationTeamUUID")
+                .assertVariables();
+    }
+
+    @Test
+    public void TRO_QAResponseHasOverrideVariables() {
+        callActivity("QAResponse_CallActivity", DCU_TRO_BPMN)
+                .containsInputVariable(DRAFT_OVERRIDE_EXPRESSION, "AllocationTeamUUID")
+                .assertVariables();
+    }
+
+    @Test
+    public void MIN_POSignOffHasOverrideVariables() {
+        callActivity("POSignOff_CallActivity", DCU_MIN_BPMN)
+                .containsInputVariable(PO_OVERRIDE_EXPRESSION, "AllocationTeamUUID")
+                .assertVariables();
+    }
+
+    @Test
+    public void DTEN_POSignOffHasOverrideVariables() {
+        callActivity("POSignOff_CallActivity", DCU_DTEN_BPMN)
+                .containsInputVariable(PO_OVERRIDE_EXPRESSION, "AllocationTeamUUID")
+                .assertVariables();
+    }
+
+    @Test
+    public void MIN_MinisterSignOffHasOverrideVariables() {
+        callActivity("MinisterSignOff_CallActivity", DCU_MIN_BPMN)
+                .containsInputVariable(PO_OVERRIDE_EXPRESSION, "AllocationTeamUUID")
+                .assertVariables();
+    }
+
+    @Test
+    public void TRO_DispatchHasOverrideVariables() {
+        callActivity("Dispatch_CallActivity", DCU_TRO_BPMN)
+                .containsInputVariable(DRAFT_OVERRIDE_EXPRESSION, "AllocationTeamUUID")
+                .assertVariables();
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/util/CallActivityTestUtil.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/util/CallActivityTestUtil.java
@@ -1,0 +1,73 @@
+package uk.gov.digital.ho.hocs.workflow.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.camunda.bpm.model.bpmn.Bpmn;
+import org.camunda.bpm.model.bpmn.BpmnModelInstance;
+import org.camunda.bpm.model.bpmn.instance.CallActivity;
+import org.camunda.bpm.model.bpmn.instance.ExtensionElements;
+import org.camunda.bpm.model.bpmn.instance.camunda.CamundaIn;
+import org.camunda.bpm.model.bpmn.instance.camunda.CamundaOut;
+import org.camunda.bpm.model.xml.instance.ModelElementInstance;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
+
+@Slf4j
+public class CallActivityTestUtil {
+    private final String callActivityId;
+    private final List<CallActivityVariable> expectedInputVariables = new ArrayList<>();
+    private final List<CallActivityVariable> expectedOutputVariables = new ArrayList<>();
+    private final String bpmnFile;
+
+    private CallActivityTestUtil(String callActivityId, String bpmnFile) {
+        this.callActivityId = callActivityId;
+        this.bpmnFile = bpmnFile;
+    }
+
+    public static CallActivityTestUtil callActivity(String callActivityId, String bpmnFile) {
+        return new CallActivityTestUtil(callActivityId, bpmnFile);
+    }
+
+    public CallActivityTestUtil containsInputVariable(String source, String target) {
+        expectedInputVariables.add(new CallActivityVariable(source, target));
+        return this;
+    }
+
+    public CallActivityTestUtil containsOutputVariable(String source, String target) {
+        expectedOutputVariables.add(new CallActivityVariable(source, target));
+        return this;
+    }
+
+    public void assertVariables() {
+        BpmnModelInstance modelInstance = Bpmn.readModelFromStream(getClass().getClassLoader().getResourceAsStream(bpmnFile));
+
+        CallActivity callActivity = modelInstance.getModelElementById(callActivityId);
+        ExtensionElements extensionElements = callActivity.getExtensionElements();
+
+        List<CamundaIn> camundaIns = extensionElements.getElementsQuery().filterByType(CamundaIn.class).list();
+        List<CallActivityVariable> actualInputVariables = new ArrayList<>();
+        for (ModelElementInstance element : camundaIns) {
+            actualInputVariables.add(new CallActivityVariable(element.getAttributeValue("source"), element.getAttributeValue("target")));
+            actualInputVariables.add(new CallActivityVariable(element.getAttributeValue("sourceExpression"), element.getAttributeValue("target")));
+        }
+
+        List<CamundaOut> camundaOuts = extensionElements.getElementsQuery().filterByType(CamundaOut.class).list();
+        List<CallActivityVariable> actualOutputVariables = new ArrayList<>();
+        for (ModelElementInstance element : camundaOuts) {
+            actualOutputVariables.add(new CallActivityVariable(element.getAttributeValue("source"), element.getAttributeValue("target")));
+            actualOutputVariables.add(new CallActivityVariable(element.getAttributeValue("sourceExpression"), element.getAttributeValue("target")));
+        }
+
+        for (CallActivityVariable expectedInputVariable : expectedInputVariables) {
+            String message = "Expected Input : " + expectedInputVariables + " \nActual Input : " + actualInputVariables;
+            assertTrue(message, actualInputVariables.contains(expectedInputVariable));
+        }
+
+        for (CallActivityVariable expectedOutputVariable : expectedOutputVariables) {
+            String message = "Expected Output : " + expectedOutputVariables + " \nActual Output : " + actualOutputVariables;
+            assertTrue(message, actualOutputVariables.contains(expectedOutputVariable));
+        }
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/util/CallActivityVariable.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/util/CallActivityVariable.java
@@ -1,0 +1,12 @@
+package uk.gov.digital.ho.hocs.workflow.util;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor()
+@EqualsAndHashCode
+@ToString
+public class CallActivityVariable {
+    private final String source;
+    private final String target;
+}


### PR DESCRIPTION
Changes to take into account any overridden drafting or po team, when associating with work stacks. 
Added a new test approach for Call activity variable checking. 