### PR TITLE
HOCS-2449 clear business area on leaving transfer stage

### DIFF
--- a/src/main/resources/processes/MPAM_TRANSFER.bpmn
+++ b/src/main/resources/processes/MPAM_TRANSFER.bpmn
@@ -46,13 +46,13 @@
     <bpmn:sequenceFlow id="Flow_152qw0a" name="Transfer Accepted" sourceRef="Gateway_1kvs6l2" targetRef="EndEvent_MpamTransfer">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TransferOutcome == 'TransferAccepted'}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1nthk5l" name="Transfer Rejected" sourceRef="Gateway_1kvs6l2" targetRef="Activity_18fmvw3">
+    <bpmn:sequenceFlow id="Flow_1nthk5l" name="Transfer Rejected" sourceRef="Gateway_1kvs6l2" targetRef="Activity_0isctk7">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TransferOutcome == 'TransferRejected'}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_18k8e5m" sourceRef="Activity_0isuqez" targetRef="EndEvent_MpamTransfer" />
     <bpmn:serviceTask id="Activity_18fmvw3" name="User Input" camunda:expression="MPAM_UPDATE_BUS_AREA_ON_TRANSFER_EXIT" camunda:resultVariable="screen">
       <bpmn:incoming>Flow_00y55ab</bpmn:incoming>
-      <bpmn:incoming>Flow_1nthk5l</bpmn:incoming>
+      <bpmn:incoming>Flow_06u1kxo</bpmn:incoming>
       <bpmn:outgoing>Flow_1uhs1tg</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:userTask id="Validate_UserInput_RejectUpdateBusinessArea" name="Validate User Input">
@@ -76,7 +76,7 @@
       <bpmn:incoming>Flow_1f7xchk</bpmn:incoming>
       <bpmn:outgoing>Flow_0gg9t91</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1f7xchk" sourceRef="Gateway_1kvs6l2" targetRef="Activity_1ogqztp">
+    <bpmn:sequenceFlow id="Flow_1f7xchk" name="Update Deadline Date" sourceRef="Gateway_1kvs6l2" targetRef="Activity_1ogqztp">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TransferOutcome == 'SaveDeadline'}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0gg9t91" sourceRef="Activity_1ogqztp" targetRef="EndEvent_MpamTransfer" />
@@ -91,9 +91,24 @@
     <bpmn:sequenceFlow id="Flow_0c5aec8" sourceRef="Gateway_01sw7ug" targetRef="Activity_15jdyd3">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION != "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="Activity_0isctk7" name="Clear Business Area" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;BusArea&#34;)}">
+      <bpmn:incoming>Flow_1nthk5l</bpmn:incoming>
+      <bpmn:outgoing>Flow_06u1kxo</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_06u1kxo" sourceRef="Activity_0isctk7" targetRef="Activity_18fmvw3" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_TRANSFER">
+      <bpmndi:BPMNEdge id="Flow_0c5aec8_di" bpmnElement="Flow_0c5aec8">
+        <di:waypoint x="1100" y="145" />
+        <di:waypoint x="1100" y="80" />
+        <di:waypoint x="450" y="80" />
+        <di:waypoint x="450" y="247" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1opz3eb_di" bpmnElement="Flow_1opz3eb">
+        <di:waypoint x="1100" y="195" />
+        <di:waypoint x="1100" y="262" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0gg9t91_di" bpmnElement="Flow_0gg9t91">
         <di:waypoint x="1000" y="570" />
         <di:waypoint x="1186" y="570" />
@@ -104,24 +119,27 @@
         <di:waypoint x="750" y="465" />
         <di:waypoint x="750" y="570" />
         <di:waypoint x="900" y="570" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="726" y="515" width="82" height="27" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1dbhlsq_di" bpmnElement="Flow_1dbhlsq">
         <di:waypoint x="1125" y="287" />
         <di:waypoint x="1200" y="287" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1qmoefm_di" bpmnElement="Flow_1qmoefm">
-        <di:waypoint x="950" y="170" />
+        <di:waypoint x="1030" y="170" />
         <di:waypoint x="1075" y="170" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1uhs1tg_di" bpmnElement="Flow_1uhs1tg">
-        <di:waypoint x="900" y="247" />
-        <di:waypoint x="900" y="210" />
+        <di:waypoint x="980" y="247" />
+        <di:waypoint x="980" y="210" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_00y55ab_di" bpmnElement="Flow_00y55ab">
         <di:waypoint x="1075" y="287" />
-        <di:waypoint x="950" y="287" />
+        <di:waypoint x="1030" y="287" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1008" y="263" width="24" height="14" />
+          <dc:Bounds x="1043" y="263" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_18k8e5m_di" bpmnElement="Flow_18k8e5m">
@@ -133,7 +151,7 @@
       <bpmndi:BPMNEdge id="Flow_1nthk5l_di" bpmnElement="Flow_1nthk5l">
         <di:waypoint x="750" y="415" />
         <di:waypoint x="750" y="287" />
-        <di:waypoint x="850" y="287" />
+        <di:waypoint x="790" y="287" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="722" y="350" width="88" height="14" />
         </bpmndi:BPMNLabel>
@@ -172,15 +190,9 @@
         <di:waypoint x="215" y="287" />
         <di:waypoint x="400" y="287" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1opz3eb_di" bpmnElement="Flow_1opz3eb">
-        <di:waypoint x="1100" y="195" />
-        <di:waypoint x="1100" y="262" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0c5aec8_di" bpmnElement="Flow_0c5aec8">
-        <di:waypoint x="1100" y="145" />
-        <di:waypoint x="1100" y="80" />
-        <di:waypoint x="450" y="80" />
-        <di:waypoint x="450" y="247" />
+      <bpmndi:BPMNEdge id="Flow_06u1kxo_di" bpmnElement="Flow_06u1kxo">
+        <di:waypoint x="890" y="287" />
+        <di:waypoint x="930" y="287" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="269" width="36" height="36" />
@@ -221,17 +233,20 @@
       <bpmndi:BPMNShape id="Activity_1ogqztp_di" bpmnElement="Activity_1ogqztp">
         <dc:Bounds x="900" y="530" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_18fmvw3_di" bpmnElement="Activity_18fmvw3">
-        <dc:Bounds x="850" y="247" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0380gol_di" bpmnElement="Validate_UserInput_RejectUpdateBusinessArea">
-        <dc:Bounds x="850" y="130" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_01sw7ug_di" bpmnElement="Gateway_01sw7ug" isMarkerVisible="true">
         <dc:Bounds x="1075" y="145" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1135" y="163" width="50" height="14" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_18fmvw3_di" bpmnElement="Activity_18fmvw3">
+        <dc:Bounds x="930" y="247" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0380gol_di" bpmnElement="Validate_UserInput_RejectUpdateBusinessArea">
+        <dc:Bounds x="930" y="130" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0isctk7_di" bpmnElement="Activity_0isctk7">
+        <dc:Bounds x="790" y="247" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
This bug was caused by Ministerial Response and Urgency fields being made conditional by ticket 2394. The fix is to clear business area on leaving the transfer stage this will redisplay the missing fields.

Process tests for this functionality and other paths have been added, we now have 93% test coverage on the transfer stage.