### PR TITLE
HOCS-2539 : add top level bpmn digram for FOI

### DIFF
--- a/src/main/resources/processes/FOI.bpmn
+++ b/src/main/resources/processes/FOI.bpmn
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+  <bpmn:process id="FOI" isExecutable="true">
+    <bpmn:startEvent id="FOI_START" name="Start Case">
+      <bpmn:outgoing>SequenceFlow_1pepep6</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="FOI_END" name="End Case">
+      <bpmn:incoming>Flow_0cz5i2m</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1pepep6" sourceRef="FOI_START" targetRef="Activity_1d2ue6g" />
+    <bpmn:serviceTask id="Activity_1d2ue6g" name="Complete Case" camunda:expression="${bpmnService.completeCase(execution.processBusinessKey)}">
+      <bpmn:incoming>SequenceFlow_1pepep6</bpmn:incoming>
+      <bpmn:outgoing>Flow_0cz5i2m</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0cz5i2m" sourceRef="Activity_1d2ue6g" targetRef="FOI_END" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="FOI">
+      <bpmndi:BPMNEdge id="Flow_0cz5i2m_di" bpmnElement="Flow_0cz5i2m">
+        <di:waypoint x="1080" y="118" />
+        <di:waypoint x="1272" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1pepep6_di" bpmnElement="SequenceFlow_1pepep6">
+        <di:waypoint x="200" y="118" />
+        <di:waypoint x="980" y="118" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1102.5" y="595" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="FOI_START">
+        <dc:Bounds x="164" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="156" y="146" width="52" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1y4bj2w_di" bpmnElement="FOI_END">
+        <dc:Bounds x="1272" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1318" y="111" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d2ue6g_di" bpmnElement="Activity_1d2ue6g">
+        <dc:Bounds x="980" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI.java
@@ -1,0 +1,61 @@
+package uk.gov.digital.ho.hocs.workflow.processes;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.camunda.bpm.scenario.ProcessScenario;
+import org.camunda.bpm.scenario.Scenario;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.withVariables;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+@Deployment(resources = "processes/FOI.bpmn")
+public class FOI {
+
+    @Rule
+    @ClassRule
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
+            .assertClassCoverageAtLeast(1.0)
+            .build();
+
+    @Rule
+    public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+    @Mock
+    BpmnService bpmnService;
+    @Mock
+    private ProcessScenario FOIProcess;
+
+    @Before
+    public void defaultScenario() {
+
+        Mocks.register("bpmnService", bpmnService);
+
+    }
+
+    @Test
+    public void happyPath() {
+
+        Scenario.run(FOIProcess)
+                .startByKey("FOI")
+                .execute();
+
+        verify(FOIProcess)
+                .hasCompleted("Activity_1d2ue6g");
+
+        verify(bpmnService).completeCase(any());
+
+    }
+
+}


### PR DESCRIPTION
This ticket adds the initial top level bpmn digram for FOI workflow. It does nothing but close a created case. Further stages shall be added to this diagram.
A process test is also included.