### PR TITLE
Support 'Form Key' as a source for screen names

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/client/camundaclient/CamundaClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/client/camundaclient/CamundaClient.java
@@ -60,6 +60,19 @@ public class CamundaClient {
 
 
     public String getStageScreenName(UUID stageUUID) {
+        String formKeyScreenName = getFormKeyForCurrentTask(stageUUID);
+        return formKeyScreenName != null ? formKeyScreenName : getStageScreenNameFromProcessVariable(stageUUID);
+    }
+
+    public String getFormKeyForCurrentTask(UUID stageUUID) {
+        Task task = taskService.createTaskQuery()
+            .processInstanceBusinessKey(stageUUID.toString())
+            .initializeFormKeys()
+            .singleResult();
+        return task != null ? task.getFormKey() : null;
+    }
+
+    public String getStageScreenNameFromProcessVariable(UUID stageUUID) {
         String screenName = getPropertyByBusinessKey(stageUUID, "screen");
         log.info("Got current stage for bpmn Stage: '{}' Screen: '{}'", stageUUID, screenName, value(EVENT, CURRENT_STAGE_RETRIEVED));
         return screenName == null || screenName.equals("null") ? "FINISH" : screenName;

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/client/camundaclient/CamundaClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/client/camundaclient/CamundaClientTest.java
@@ -1,0 +1,138 @@
+package uk.gov.digital.ho.hocs.workflow.client.camundaclient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+import org.camunda.bpm.engine.RuntimeService;
+import org.camunda.bpm.engine.TaskService;
+import org.camunda.bpm.engine.runtime.ProcessInstance;
+import org.camunda.bpm.engine.runtime.ProcessInstanceQuery;
+import org.camunda.bpm.engine.runtime.VariableInstance;
+import org.camunda.bpm.engine.runtime.VariableInstanceQuery;
+import org.camunda.bpm.engine.task.Task;
+import org.camunda.bpm.engine.task.TaskQuery;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class CamundaClientTest {
+
+  private CamundaClient camundaClient;
+
+  @Mock
+  private TaskService taskService;
+
+  @Mock
+  private TaskQuery taskQuery;
+
+  @Mock
+  private Task task;
+
+  @Mock
+  private RuntimeService runtimeService;
+
+  @Mock
+  private ProcessInstance processInstance;
+
+  @Mock
+  private ProcessInstanceQuery processInstanceQuery;
+
+  @Mock
+  private VariableInstance variableInstance;
+
+  @Mock
+  private VariableInstanceQuery variableInstanceQuery;
+
+  private final UUID stageUUID = UUID.randomUUID();
+
+  private final String FORM_KEY_SCREEN_NAME = "ABC_DEF";
+
+  private final String PROCESS_VARIABLE_SCREEN_NAME = "SCREEN_NAME_2";
+
+  private final String FINISH = "FINISH";
+
+  private final String PROCESS_INSTANCE_ID = "1234";
+
+  private final String SCREEN_PROCESS_VARIABLE = "screen";
+
+  @Before
+  public void setUp() {
+    camundaClient = new CamundaClient(runtimeService, taskService);
+    when(taskService.createTaskQuery()).thenReturn(taskQuery);
+    when(taskQuery.processInstanceBusinessKey(any())).thenReturn(taskQuery);
+    when(taskQuery.initializeFormKeys()).thenReturn(taskQuery);
+    when(runtimeService.createProcessInstanceQuery()).thenReturn(processInstanceQuery);
+    when(processInstanceQuery.processInstanceBusinessKey(stageUUID.toString())).thenReturn(processInstanceQuery);
+    when(processInstanceQuery.singleResult()).thenReturn(processInstance);
+    when(processInstance.getProcessInstanceId()).thenReturn(PROCESS_INSTANCE_ID);
+    when(runtimeService.createVariableInstanceQuery()).thenReturn(variableInstanceQuery);
+    when(variableInstanceQuery.processInstanceIdIn(PROCESS_INSTANCE_ID)).thenReturn(variableInstanceQuery);
+    when(variableInstanceQuery.variableName(SCREEN_PROCESS_VARIABLE)).thenReturn(variableInstanceQuery);
+  }
+
+  @Test
+  public void screenNameTakenFromTaskFormKeyIfPresent() {
+
+    //given
+    when(taskQuery.singleResult()).thenReturn(task);
+    when(task.getFormKey()).thenReturn(FORM_KEY_SCREEN_NAME);
+
+    //when
+    String screenName = camundaClient.getStageScreenName(stageUUID);
+
+    //then
+    assertThat(screenName).isEqualTo(FORM_KEY_SCREEN_NAME);
+  }
+
+  @Test
+  public void screenNameTakenFromProcessVariableIfTaskNotFound() {
+
+    //given
+    when(taskQuery.singleResult()).thenReturn(null);
+    when(variableInstanceQuery.singleResult()).thenReturn(variableInstance);
+    when(variableInstance.getValue()).thenReturn(PROCESS_VARIABLE_SCREEN_NAME);
+
+    //when
+    String screenName = camundaClient.getStageScreenName(stageUUID);
+
+    //then
+    assertThat(screenName).isEqualTo(PROCESS_VARIABLE_SCREEN_NAME);
+  }
+
+
+  @Test
+  public void screenNameTakenFromProcessVariableIfTaskFoundWithoutFormKey() {
+
+    //given
+    when(task.getFormKey()).thenReturn(null);
+    when(taskQuery.singleResult()).thenReturn(task);
+    when(variableInstanceQuery.singleResult()).thenReturn(variableInstance);
+    when(variableInstance.getValue()).thenReturn(PROCESS_VARIABLE_SCREEN_NAME);
+
+    //when
+    String screenName = camundaClient.getStageScreenName(stageUUID);
+
+    //then
+    assertThat(screenName).isEqualTo(PROCESS_VARIABLE_SCREEN_NAME);
+  }
+
+  @Test
+  public void finishIfFormKeyNotPresentAndProcessVariableNull() {
+
+    //given
+    when(taskQuery.singleResult()).thenReturn(null);
+    when(variableInstanceQuery.singleResult()).thenReturn(variableInstance);
+    when(variableInstance.getValue()).thenReturn(null);
+
+    //when
+    String screenName = camundaClient.getStageScreenName(stageUUID);
+
+    //then
+    assertThat(screenName).isEqualTo(FINISH);
+  }
+}


### PR DESCRIPTION
New feature where Camunda's User Task's form key can be used to store the screen names.
See https://collaboration.homeoffice.gov.uk/display/HOCS/Camunda+Improvements#CamundaImprovements-Usingformkeytostoretheformnames

If a Form Key is specified for a user task it will be used as the source for the screen name.
Otherwise the existing behaviour of looking for the screen name in the process variable is maintained.