### PR TITLE
HOCS-2747: fix draft put on campaign

### DIFF
--- a/src/main/resources/processes/MPAM_DRAFT_ESCALATE.bpmn
+++ b/src/main/resources/processes/MPAM_DRAFT_ESCALATE.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_089rb4g" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_089rb4g" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
   <bpmn:process id="MPAM_DRAFT_ESCALATE" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_1672f4h</bpmn:outgoing>
@@ -259,12 +259,12 @@
     <bpmn:sequenceFlow id="SequenceFlow_015lfkg" sourceRef="ExclusiveGateway_1f6i48q" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_17fdowe" name="Request Campaign" camunda:expression="MPAM_CAMPAIGN_REQUEST" camunda:resultVariable="screen">
+    <bpmn:serviceTask id="ServiceTask_RequestCampaignInput" name="Request Campaign Input" camunda:expression="MPAM_CAMPAIGN_REQUEST" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_02lqild</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0sl5bjs</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_198enjr</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_1k8qqbf" name="Request Campaign">
+    <bpmn:userTask id="UserTask_RequestCampaign" name="Request Campaign">
       <bpmn:incoming>SequenceFlow_198enjr</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_15wnd9y</bpmn:outgoing>
     </bpmn:userTask>
@@ -278,32 +278,32 @@
       <bpmn:outgoing>SequenceFlow_02lqild</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_11me2lb</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="ServiceTask_1cdshpt" name="Update Team for Campaign" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_CAMPAIGN&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
+    <bpmn:serviceTask id="ServiceTask_UpdateTeamForCampaign" name="Update Team for Campaign" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_CAMPAIGN&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
       <bpmn:incoming>SequenceFlow_11me2lb</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1p4l1xt</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="ServiceTask_0vgq27c" name="Clear CampaignType" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;CampaignType&#34;)}">
+    <bpmn:serviceTask id="ServiceTask_ClearCampaignType" name="Clear CampaignType" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;CampaignType&#34;)}">
       <bpmn:incoming>SequenceFlow_0n6j6o3</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0sl5bjs</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_02lqild" sourceRef="ExclusiveGateway_0pln2uu" targetRef="ServiceTask_17fdowe">
+    <bpmn:sequenceFlow id="SequenceFlow_02lqild" sourceRef="ExclusiveGateway_0pln2uu" targetRef="ServiceTask_RequestCampaignInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0sl5bjs" sourceRef="ServiceTask_0vgq27c" targetRef="ServiceTask_17fdowe" />
-    <bpmn:sequenceFlow id="SequenceFlow_198enjr" sourceRef="ServiceTask_17fdowe" targetRef="UserTask_1k8qqbf" />
-    <bpmn:sequenceFlow id="SequenceFlow_15wnd9y" sourceRef="UserTask_1k8qqbf" targetRef="ExclusiveGateway_14kgmzf" />
+    <bpmn:sequenceFlow id="SequenceFlow_0sl5bjs" sourceRef="ServiceTask_ClearCampaignType" targetRef="ServiceTask_RequestCampaignInput" />
+    <bpmn:sequenceFlow id="SequenceFlow_198enjr" sourceRef="ServiceTask_RequestCampaignInput" targetRef="UserTask_RequestCampaign" />
+    <bpmn:sequenceFlow id="SequenceFlow_15wnd9y" sourceRef="UserTask_RequestCampaign" targetRef="ExclusiveGateway_14kgmzf" />
     <bpmn:sequenceFlow id="SequenceFlow_0uqy7ip" sourceRef="ExclusiveGateway_14kgmzf" targetRef="ExclusiveGateway_0pln2uu">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_11me2lb" sourceRef="ExclusiveGateway_0pln2uu" targetRef="ServiceTask_1cdshpt">
+    <bpmn:sequenceFlow id="SequenceFlow_11me2lb" sourceRef="ExclusiveGateway_0pln2uu" targetRef="ServiceTask_UpdateTeamForCampaign">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1p4l1xt" sourceRef="ServiceTask_1cdshpt" targetRef="EndEvent_MpamDraftEscalate" />
+    <bpmn:sequenceFlow id="SequenceFlow_1p4l1xt" sourceRef="ServiceTask_UpdateTeamForCampaign" targetRef="EndEvent_MpamDraftEscalate" />
     <bpmn:sequenceFlow id="SequenceFlow_1pjkuph" sourceRef="ExclusiveGateway_14kgmzf" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0n6j6o3" name="PutOnCampaign" sourceRef="ExclusiveGateway_12jft8z" targetRef="ServiceTask_0vgq27c">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus == "RequestContribution"}</bpmn:conditionExpression>
+    <bpmn:sequenceFlow id="SequenceFlow_0n6j6o3" name="PutOnCampaign" sourceRef="ExclusiveGateway_12jft8z" targetRef="ServiceTask_ClearCampaignType">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DraftStatus == "PutOnCampaign"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1vdgiyk" sourceRef="ServiceTask_1qunav1" targetRef="Service_SaveRefTypeChangeCaseNote" />
     <bpmn:serviceTask id="Service_SaveRefTypeChangeCaseNote" name="Save Ref Type Change Case Note" camunda:expression="${bpmnService.createCaseConversionNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_TriageChangeCaseType&#34;))}">
@@ -394,6 +394,10 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_DRAFT_ESCALATE">
+      <bpmndi:BPMNEdge id="Flow_1mjl8s5_di" bpmnElement="Flow_1mjl8s5">
+        <di:waypoint x="944" y="166" />
+        <di:waypoint x="1061" y="166" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0uinegz_di" bpmnElement="Flow_0uinegz">
         <di:waypoint x="1111" y="166" />
         <di:waypoint x="1777" y="166" />
@@ -740,10 +744,6 @@
           <dc:Bounds x="583" y="911" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1mjl8s5_di" bpmnElement="Flow_1mjl8s5">
-        <di:waypoint x="944" y="166" />
-        <di:waypoint x="1061" y="166" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="914" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -861,10 +861,10 @@
           <dc:Bounds x="630" y="1088" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_17fdowe_di" bpmnElement="ServiceTask_17fdowe">
+      <bpmndi:BPMNShape id="ServiceTask_17fdowe_di" bpmnElement="ServiceTask_RequestCampaignInput">
         <dc:Bounds x="844" y="608" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_1k8qqbf_di" bpmnElement="UserTask_1k8qqbf">
+      <bpmndi:BPMNShape id="UserTask_1k8qqbf_di" bpmnElement="UserTask_RequestCampaign">
         <dc:Bounds x="844" y="444" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_14kgmzf_di" bpmnElement="ExclusiveGateway_14kgmzf" isMarkerVisible="true">
@@ -876,10 +876,10 @@
       <bpmndi:BPMNShape id="ExclusiveGateway_0pln2uu_di" bpmnElement="ExclusiveGateway_0pln2uu" isMarkerVisible="true">
         <dc:Bounds x="1072" y="459" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1cdshpt_di" bpmnElement="ServiceTask_1cdshpt">
+      <bpmndi:BPMNShape id="ServiceTask_1cdshpt_di" bpmnElement="ServiceTask_UpdateTeamForCampaign">
         <dc:Bounds x="1313" y="444" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0vgq27c_di" bpmnElement="ServiceTask_0vgq27c">
+      <bpmndi:BPMNShape id="ServiceTask_0vgq27c_di" bpmnElement="ServiceTask_ClearCampaignType">
         <dc:Bounds x="844" y="719" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_195k9jy_di" bpmnElement="Service_SaveRefTypeChangeCaseNote">

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMDraftEscalate.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMDraftEscalate.java
@@ -97,6 +97,33 @@ public class MPAMDraftEscalate extends MPAMCommonTests {
     }
 
     @Test
+    public void whenPutOnCampaign_thenPutOnCampaign() {
+        when(processScenario.waitsAtUserTask("Validate_UserInput"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "FORWARD",
+                        "valid", true,
+                        "DraftStatus", "PutOnCampaign")));
+
+        when(processScenario.waitsAtUserTask("UserTask_RequestCampaign"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "FORWARD",
+                        "valid", false)))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "FORWARD",
+                        "valid", true)));
+
+        Scenario.run(processScenario)
+                .startByKey("MPAM_DRAFT_ESCALATE")
+                .execute();
+
+        verify(processScenario).hasCompleted("ServiceTask_ClearCampaignType");
+        verify(processScenario, times(2)).hasCompleted("ServiceTask_RequestCampaignInput");
+        verify(processScenario, times(2)).hasCompleted("UserTask_RequestCampaign");
+        verify(processScenario).hasCompleted("ServiceTask_UpdateTeamForCampaign");
+        verify(processScenario).hasFinished("EndEvent_MpamDraftEscalate");
+    }
+
+    @Test
     public void whenOfficialChangedToMinisterial_thenMinisterialValuesAreNotCleared() {
 
         when(processScenario.waitsAtUserTask("Validate_UserInput"))


### PR DESCRIPTION
A regression was introduced in HOCS-2311 that stopped the PutOnCampaign DraftStatus to no longer work. This change reverts a partial unintended change and adds test to stop this happening again.