### PR TITLE
HOCS-2885 Automatically deploy to gamma on push

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -104,6 +104,25 @@ steps:
         - push
         - promote
 
+  - name: deploy to gamma
+    image: quay.io/ukhomeofficedigital/kd:v1.16.0
+    commands:
+      - cd kube-hocs-workflow
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: cs-gamma
+      KUBE_TOKEN:
+        from_secret: hocs_workflow_hocs_gamma
+      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      VERSION: build_${DRONE_BUILD_NUMBER}
+    when:
+      branch:
+        - epic/foi-mvp
+      event:
+        - push
+    depends_on:
+      - clone kube repo
+
   - name: deploy to cs-dev
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     commands:


### PR DESCRIPTION
This adds a step to Drone that fires on push to the FOI epic branch,
which triggers a deployment to the hocs-gamma environment.

Previously we were deploying manually to hocs-gamma, and using a fixed
branch-based tag, which was causing inconsistencies and confusion. Here
we deploy a tag based on the Drone build number, which is easier to
track. If we wanted, we could deploy using the SHA hash for a similar
effect.