### PR TITLE
HOCS-2739: moving WCS team update case

### DIFF
--- a/src/main/resources/processes/WCS.bpmn
+++ b/src/main/resources/processes/WCS.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0wg7ans" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.2">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0wg7ans" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
   <bpmn:process id="WCS" isExecutable="true">
     <bpmn:startEvent id="StartEvent_WCS" name="Start claim">
       <bpmn:outgoing>SequenceFlow_16fw7qq</bpmn:outgoing>
@@ -913,6 +913,592 @@
   <bpmn:message id="Message_1yeo1cb" name="CLOSED" />
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="WCS">
+      <bpmndi:BPMNEdge id="SequenceFlow_1m9c1wb_di" bpmnElement="SequenceFlow_1m9c1wb">
+        <di:waypoint x="1395" y="2204" />
+        <di:waypoint x="3836" y="2204" />
+        <di:waypoint x="3836" y="540" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1416" y="2177" width="57" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ii6vw3_di" bpmnElement="SequenceFlow_0ii6vw3">
+        <di:waypoint x="1206" y="2204" />
+        <di:waypoint x="1345" y="2204" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0lfimbn_di" bpmnElement="SequenceFlow_0lfimbn">
+        <di:waypoint x="1370" y="2229" />
+        <di:waypoint x="1370" y="2426" />
+        <di:waypoint x="305" y="2426" />
+        <di:waypoint x="305" y="540" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1381" y="2266" width="84" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sbspon_di" bpmnElement="SequenceFlow_1sbspon">
+        <di:waypoint x="462" y="2344" />
+        <di:waypoint x="1156" y="2344" />
+        <di:waypoint x="1156" y="2244" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="482" y="2362" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0uj5elh_di" bpmnElement="SequenceFlow_0uj5elh">
+        <di:waypoint x="462" y="2065" />
+        <di:waypoint x="1156" y="2065" />
+        <di:waypoint x="1156" y="2164" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="481" y="2040" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ny5uz4_di" bpmnElement="SequenceFlow_1ny5uz4">
+        <di:waypoint x="1206" y="1568" />
+        <di:waypoint x="1345" y="1568" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0sohasi_di" bpmnElement="SequenceFlow_0sohasi">
+        <di:waypoint x="1395" y="1568" />
+        <di:waypoint x="3836" y="1568" />
+        <di:waypoint x="3836" y="540" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1429" y="1541" width="57" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1spfvi1_di" bpmnElement="SequenceFlow_1spfvi1">
+        <di:waypoint x="1370" y="1593" />
+        <di:waypoint x="1370" y="1769" />
+        <di:waypoint x="610" y="1769" />
+        <di:waypoint x="610" y="741" />
+        <di:waypoint x="840" y="741" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1396" y="1644" width="81" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_05wjkhx_di" bpmnElement="SequenceFlow_05wjkhx">
+        <di:waypoint x="915" y="1691" />
+        <di:waypoint x="1156" y="1691" />
+        <di:waypoint x="1156" y="1608" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="924" y="1709" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0szvowd_di" bpmnElement="SequenceFlow_0szvowd">
+        <di:waypoint x="915" y="1436" />
+        <di:waypoint x="1156" y="1436" />
+        <di:waypoint x="1156" y="1528" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="926" y="1416" width="37" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ccjpkn_di" bpmnElement="SequenceFlow_0ccjpkn">
+        <di:waypoint x="1075" y="744" />
+        <di:waypoint x="1156" y="741" />
+        <di:waypoint x="1156" y="1319" />
+        <di:waypoint x="940" y="1319" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1pio0fm_di" bpmnElement="SequenceFlow_1pio0fm">
+        <di:waypoint x="865" y="1691" />
+        <di:waypoint x="611" y="1691" />
+        <di:waypoint x="611" y="741" />
+        <di:waypoint x="840" y="741" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="764" y="1709" width="81" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1tk5v1l_di" bpmnElement="SequenceFlow_1tk5v1l">
+        <di:waypoint x="890" y="1608" />
+        <di:waypoint x="890" y="1666" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1nymkwa_di" bpmnElement="SequenceFlow_1nymkwa">
+        <di:waypoint x="890" y="1461" />
+        <di:waypoint x="890" y="1528" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="906" y="1494" width="74" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0bhyhgr_di" bpmnElement="SequenceFlow_0bhyhgr">
+        <di:waypoint x="890" y="1359" />
+        <di:waypoint x="890" y="1411" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sd65eg_di" bpmnElement="SequenceFlow_1sd65eg">
+        <di:waypoint x="774" y="500" />
+        <di:waypoint x="1003" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="798" y="513" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ccneyt_di" bpmnElement="SequenceFlow_0ccneyt">
+        <di:waypoint x="749" y="525" />
+        <di:waypoint x="749" y="741" />
+        <di:waypoint x="840" y="741" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="661" y="548" width="81" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_07qeroh_di" bpmnElement="SequenceFlow_07qeroh">
+        <di:waypoint x="437" y="2244" />
+        <di:waypoint x="437" y="2319" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0wcus5v_di" bpmnElement="SequenceFlow_0wcus5v">
+        <di:waypoint x="437" y="2090" />
+        <di:waypoint x="437" y="2164" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="448" y="2124" width="74" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0knicym_di" bpmnElement="SequenceFlow_0knicym">
+        <di:waypoint x="412" y="2344" />
+        <di:waypoint x="305" y="2344" />
+        <di:waypoint x="305" y="540" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="322" y="2360" width="84" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1cyl5pp_di" bpmnElement="SequenceFlow_1cyl5pp">
+        <di:waypoint x="437" y="1951" />
+        <di:waypoint x="437" y="2040" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0a7fniw_di" bpmnElement="SequenceFlow_0a7fniw">
+        <di:waypoint x="3771" y="411" />
+        <di:waypoint x="3771" y="436" />
+        <di:waypoint x="3690" y="436" />
+        <di:waypoint x="3690" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1jwq5no_di" bpmnElement="SequenceFlow_1jwq5no">
+        <di:waypoint x="3690" y="411" />
+        <di:waypoint x="3690" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_18x7zmj_di" bpmnElement="SequenceFlow_18x7zmj">
+        <di:waypoint x="3439" y="411" />
+        <di:waypoint x="3439" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0v85g4v_di" bpmnElement="SequenceFlow_0v85g4v">
+        <di:waypoint x="2676" y="947" />
+        <di:waypoint x="2711" y="947" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ds1lfr_di" bpmnElement="SequenceFlow_0ds1lfr">
+        <di:waypoint x="2676" y="729" />
+        <di:waypoint x="2711" y="729" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1w5mz3m_di" bpmnElement="SequenceFlow_1w5mz3m">
+        <di:waypoint x="3029" y="411" />
+        <di:waypoint x="3029" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_10jpg8q_di" bpmnElement="SequenceFlow_10jpg8q">
+        <di:waypoint x="3189" y="411" />
+        <di:waypoint x="3189" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_07v08od_di" bpmnElement="SequenceFlow_07v08od">
+        <di:waypoint x="2510" y="708" />
+        <di:waypoint x="2510" y="620" />
+        <di:waypoint x="2559" y="620" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ezvho6_di" bpmnElement="SequenceFlow_1ezvho6">
+        <di:waypoint x="2609" y="411" />
+        <di:waypoint x="2609" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ph216h_di" bpmnElement="SequenceFlow_1ph216h">
+        <di:waypoint x="2353" y="411" />
+        <di:waypoint x="2353" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0oebgkx_di" bpmnElement="SequenceFlow_0oebgkx">
+        <di:waypoint x="2078" y="393" />
+        <di:waypoint x="2122" y="393" />
+        <di:waypoint x="2122" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1180qcf_di" bpmnElement="SequenceFlow_1180qcf">
+        <di:waypoint x="1882" y="411" />
+        <di:waypoint x="1882" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1kzo8ut_di" bpmnElement="SequenceFlow_1kzo8ut">
+        <di:waypoint x="1573" y="422" />
+        <di:waypoint x="1573" y="439" />
+        <di:waypoint x="1633" y="439" />
+        <di:waypoint x="1633" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1o01txw_di" bpmnElement="SequenceFlow_1o01txw">
+        <di:waypoint x="1573" y="628" />
+        <di:waypoint x="1573" y="645" />
+        <di:waypoint x="1516" y="645" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_11vx77p_di" bpmnElement="SequenceFlow_11vx77p">
+        <di:waypoint x="1053" y="1012" />
+        <di:waypoint x="1053" y="969" />
+        <di:waypoint x="940" y="969" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0kk16je_di" bpmnElement="SequenceFlow_0kk16je">
+        <di:waypoint x="805" y="636" />
+        <di:waypoint x="805" y="669" />
+        <di:waypoint x="890" y="669" />
+        <di:waypoint x="890" y="701" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0lnw468_di" bpmnElement="SequenceFlow_0lnw468">
+        <di:waypoint x="227" y="393" />
+        <di:waypoint x="227" y="425" />
+        <di:waypoint x="305" y="425" />
+        <di:waypoint x="305" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0fcl578_di" bpmnElement="SequenceFlow_0fcl578">
+        <di:waypoint x="1218" y="422" />
+        <di:waypoint x="1218" y="441" />
+        <di:waypoint x="1275" y="441" />
+        <di:waypoint x="1275" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_13j60n4_di" bpmnElement="SequenceFlow_13j60n4">
+        <di:waypoint x="994" y="422" />
+        <di:waypoint x="994" y="437" />
+        <di:waypoint x="1053" y="437" />
+        <di:waypoint x="1053" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1dhlqqh_di" bpmnElement="SequenceFlow_1dhlqqh">
+        <di:waypoint x="3079" y="500" />
+        <di:waypoint x="3139" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0kth4oz_di" bpmnElement="SequenceFlow_0kth4oz">
+        <di:waypoint x="1053" y="341" />
+        <di:waypoint x="1053" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1057" y="348" width="76" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0yhk55u_di" bpmnElement="SequenceFlow_0yhk55u">
+        <di:waypoint x="1028" y="316" />
+        <di:waypoint x="915" y="316" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1g6deoe_di" bpmnElement="SequenceFlow_1g6deoe">
+        <di:waypoint x="1466" y="475" />
+        <di:waypoint x="1466" y="316" />
+        <di:waypoint x="1078" y="316" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1430" y="298" width="71" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1t6o8wi_di" bpmnElement="SequenceFlow_1t6o8wi">
+        <di:waypoint x="865" y="316" />
+        <di:waypoint x="305" y="316" />
+        <di:waypoint x="305" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="713" y="322" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ptr3tz_di" bpmnElement="SequenceFlow_1ptr3tz">
+        <di:waypoint x="890" y="341" />
+        <di:waypoint x="890" y="701" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="895" y="349" width="88" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0rvbnzc_di" bpmnElement="SequenceFlow_0rvbnzc">
+        <di:waypoint x="865" y="849" />
+        <di:waypoint x="783" y="849" />
+        <di:waypoint x="783" y="1216" />
+        <di:waypoint x="3835" y="1216" />
+        <di:waypoint x="3836" y="540" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="803" y="872" width="68" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1f81u7n_di" bpmnElement="SequenceFlow_1f81u7n">
+        <di:waypoint x="890" y="824" />
+        <di:waypoint x="890" y="781" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1snix26_di" bpmnElement="SequenceFlow_1snix26">
+        <di:waypoint x="890" y="929" />
+        <di:waypoint x="890" y="874" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0xboc5q_di" bpmnElement="SequenceFlow_0xboc5q">
+        <di:waypoint x="1053" y="766" />
+        <di:waypoint x="1053" y="969" />
+        <di:waypoint x="940" y="969" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1057" y="777" width="23" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0srhj4e_di" bpmnElement="SequenceFlow_0srhj4e">
+        <di:waypoint x="1416" y="645" />
+        <di:waypoint x="1303" y="645" />
+        <di:waypoint x="1303" y="540" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0uuixch_di" bpmnElement="SequenceFlow_0uuixch">
+        <di:waypoint x="1466" y="525" />
+        <di:waypoint x="1466" y="605" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1471" y="540" width="23" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0birlna_di" bpmnElement="SequenceFlow_0birlna">
+        <di:waypoint x="1491" y="500" />
+        <di:waypoint x="1583" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1498" y="484" width="16" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hsqqfh_di" bpmnElement="SequenceFlow_0hsqqfh">
+        <di:waypoint x="2761" y="1076" />
+        <di:waypoint x="2761" y="1123" />
+        <di:waypoint x="3836" y="1123" />
+        <di:waypoint x="3836" y="543" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2812" y="1100" width="32" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1hx3609_di" bpmnElement="SequenceFlow_1hx3609">
+        <di:waypoint x="2786" y="1051" />
+        <di:waypoint x="3029" y="1051" />
+        <di:waypoint x="3029" y="540" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2818" y="1031" width="34" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1c5wrex_di" bpmnElement="SequenceFlow_1c5wrex">
+        <di:waypoint x="2761" y="987" />
+        <di:waypoint x="2761" y="1026" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0yikm73_di" bpmnElement="SequenceFlow_0yikm73">
+        <di:waypoint x="2761" y="863" />
+        <di:waypoint x="2761" y="907" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2767" y="873" width="62" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_137sj52_di" bpmnElement="SequenceFlow_137sj52">
+        <di:waypoint x="2775" y="851" />
+        <di:waypoint x="3029" y="851" />
+        <di:waypoint x="3029" y="540" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2933" y="834" width="34" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0rtgc8e_di" bpmnElement="SequenceFlow_0rtgc8e">
+        <di:waypoint x="2774" y="512" />
+        <di:waypoint x="2864" y="618" />
+        <di:waypoint x="3836" y="618" />
+        <di:waypoint x="3836" y="540" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2819" y="554" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_120ptwd_di" bpmnElement="SequenceFlow_120ptwd">
+        <di:waypoint x="2659" y="589" />
+        <di:waypoint x="2748" y="512" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1phw7gc_di" bpmnElement="SequenceFlow_1phw7gc">
+        <di:waypoint x="2259" y="497" />
+        <di:waypoint x="2259" y="82" />
+        <di:waypoint x="1275" y="82" />
+        <di:waypoint x="1275" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2263" y="430" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_01um849_di" bpmnElement="SequenceFlow_01um849">
+        <di:waypoint x="1782" y="500" />
+        <di:waypoint x="1832" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1778" y="485" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_14uxgrl_di" bpmnElement="SequenceFlow_14uxgrl">
+        <di:waypoint x="2761" y="525" />
+        <di:waypoint x="2761" y="623" />
+        <di:waypoint x="2761" y="688" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2767" y="611" width="32" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1qr0q1k_di" bpmnElement="SequenceFlow_1qr0q1k">
+        <di:waypoint x="3315" y="475" />
+        <di:waypoint x="3315" y="81" />
+        <di:waypoint x="1275" y="81" />
+        <di:waypoint x="1275" y="458" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3320" y="430" width="44" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1kcygny_di" bpmnElement="SequenceFlow_1kcygny">
+        <di:waypoint x="3340" y="500" />
+        <di:waypoint x="3389" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3344" y="482" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0v025qm_di" bpmnElement="SequenceFlow_0v025qm">
+        <di:waypoint x="2786" y="500" />
+        <di:waypoint x="2979" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2793" y="481" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_16uaskl_di" bpmnElement="SequenceFlow_16uaskl">
+        <di:waypoint x="2480" y="475" />
+        <di:waypoint x="2480" y="316" />
+        <di:waypoint x="2122" y="316" />
+        <di:waypoint x="2122" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2488" y="430" width="44" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1i28bcj_di" bpmnElement="SequenceFlow_1i28bcj">
+        <di:waypoint x="2237" y="475" />
+        <di:waypoint x="2237" y="172" />
+        <di:waypoint x="1633" y="172" />
+        <di:waypoint x="1633" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2212" y="430" width="16" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_19w7kbp_di" bpmnElement="SequenceFlow_19w7kbp">
+        <di:waypoint x="2005" y="475" />
+        <di:waypoint x="2005" y="172" />
+        <di:waypoint x="1633" y="172" />
+        <di:waypoint x="1633" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1983" y="430" width="16" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1kp1ctp_di" bpmnElement="SequenceFlow_1kp1ctp">
+        <di:waypoint x="2262" y="500" />
+        <di:waypoint x="2303" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2266" y="483" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1pgbmc2_di" bpmnElement="SequenceFlow_1pgbmc2">
+        <di:waypoint x="2030" y="500" />
+        <di:waypoint x="2072" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2031" y="483" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1yejt76_di" bpmnElement="SequenceFlow_1yejt76">
+        <di:waypoint x="3239" y="500" />
+        <di:waypoint x="3290" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_11d1sfn_di" bpmnElement="SequenceFlow_11d1sfn">
+        <di:waypoint x="2659" y="500" />
+        <di:waypoint x="2736" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_08bc3k3_di" bpmnElement="SequenceFlow_08bc3k3">
+        <di:waypoint x="2505" y="500" />
+        <di:waypoint x="2559" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2514" y="480" width="25" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1yb9nwq_di" bpmnElement="SequenceFlow_1yb9nwq">
+        <di:waypoint x="2480" y="525" />
+        <di:waypoint x="2480" y="620" />
+        <di:waypoint x="2559" y="620" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2485" y="540" width="13" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1t6vfhz_di" bpmnElement="SequenceFlow_1t6vfhz">
+        <di:waypoint x="3489" y="500" />
+        <di:waypoint x="3541" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1finuzu_di" bpmnElement="SequenceFlow_1finuzu">
+        <di:waypoint x="2403" y="500" />
+        <di:waypoint x="2455" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_15wnmo1_di" bpmnElement="SequenceFlow_15wnmo1">
+        <di:waypoint x="2172" y="500" />
+        <di:waypoint x="2212" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0euf7ft_di" bpmnElement="SequenceFlow_0euf7ft">
+        <di:waypoint x="437" y="525" />
+        <di:waypoint x="437" y="1871" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="241" y="580" width="62" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0dvt6hi_di" bpmnElement="SequenceFlow_0dvt6hi">
+        <di:waypoint x="462" y="500" />
+        <di:waypoint x="724" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="346" y="438" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1o932mp_di" bpmnElement="SequenceFlow_1o932mp">
+        <di:waypoint x="3740" y="500" />
+        <di:waypoint x="3786" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1nmrn6j_di" bpmnElement="SequenceFlow_1nmrn6j">
+        <di:waypoint x="3566" y="475" />
+        <di:waypoint x="3566" y="81" />
+        <di:waypoint x="1275" y="81" />
+        <di:waypoint x="1275" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3571" y="430" width="34" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0114w7o_di" bpmnElement="SequenceFlow_0114w7o">
+        <di:waypoint x="3591" y="500" />
+        <di:waypoint x="3640" y="500" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3594" y="479" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_13g9keh_di" bpmnElement="SequenceFlow_13g9keh">
+        <di:waypoint x="2786" y="838" />
+        <di:waypoint x="2879" y="838" />
+        <di:waypoint x="2879" y="81" />
+        <di:waypoint x="1275" y="81" />
+        <di:waypoint x="1275" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2886" y="779" width="75" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_02gz6hu_di" bpmnElement="SequenceFlow_02gz6hu">
+        <di:waypoint x="2761" y="768" />
+        <di:waypoint x="2761" y="813" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1crb1b1_di" bpmnElement="SequenceFlow_1crb1b1">
+        <di:waypoint x="1757" y="525" />
+        <di:waypoint x="1757" y="741" />
+        <di:waypoint x="1275" y="741" />
+        <di:waypoint x="1275" y="541" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1612" y="535" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1yll54x_di" bpmnElement="SequenceFlow_1yll54x">
+        <di:waypoint x="1053" y="716" />
+        <di:waypoint x="1053" y="540" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1056" y="689" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0u8ottx_di" bpmnElement="SequenceFlow_0u8ottx">
+        <di:waypoint x="3886" y="500" />
+        <di:waypoint x="3940" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_072j964_di" bpmnElement="SequenceFlow_072j964">
+        <di:waypoint x="940" y="741" />
+        <di:waypoint x="1028" y="741" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1n1h926_di" bpmnElement="SequenceFlow_1n1h926">
+        <di:waypoint x="1932" y="500" />
+        <di:waypoint x="1980" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0rut5wh_di" bpmnElement="SequenceFlow_0rut5wh">
+        <di:waypoint x="1683" y="500" />
+        <di:waypoint x="1732" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1wqc35k_di" bpmnElement="SequenceFlow_1wqc35k">
+        <di:waypoint x="1325" y="500" />
+        <di:waypoint x="1441" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_02wpfty_di" bpmnElement="SequenceFlow_02wpfty">
+        <di:waypoint x="1103" y="500" />
+        <di:waypoint x="1225" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1p2dvke_di" bpmnElement="SequenceFlow_1p2dvke">
+        <di:waypoint x="355" y="500" />
+        <di:waypoint x="412" y="500" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_16fw7qq_di" bpmnElement="SequenceFlow_16fw7qq">
+        <di:waypoint x="199" y="500" />
+        <di:waypoint x="255" y="500" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_WCS">
         <dc:Bounds x="163" y="482" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -922,14 +1508,6 @@
       <bpmndi:BPMNShape id="CallActivity_0itv8jg_di" bpmnElement="CallActivity_0itv8jg">
         <dc:Bounds x="255" y="460" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_16fw7qq_di" bpmnElement="SequenceFlow_16fw7qq">
-        <di:waypoint x="199" y="500" />
-        <di:waypoint x="255" y="500" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1p2dvke_di" bpmnElement="SequenceFlow_1p2dvke">
-        <di:waypoint x="355" y="500" />
-        <di:waypoint x="412" y="500" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ServiceTask_1bk24p1_di" bpmnElement="ServiceTask_1bk24p1">
         <dc:Bounds x="3786" y="460" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -939,31 +1517,15 @@
       <bpmndi:BPMNShape id="CallActivity_0yoi4tq_di" bpmnElement="CallActivity_0yoi4tq">
         <dc:Bounds x="1003" y="460" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_02wpfty_di" bpmnElement="SequenceFlow_02wpfty">
-        <di:waypoint x="1103" y="500" />
-        <di:waypoint x="1225" y="500" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_0su7o0r_di" bpmnElement="CallActivity_0su7o0r">
         <dc:Bounds x="1225" y="460" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1wqc35k_di" bpmnElement="SequenceFlow_1wqc35k">
-        <di:waypoint x="1325" y="500" />
-        <di:waypoint x="1441" y="500" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_0dhyvig_di" bpmnElement="CallActivity_0dhyvig">
         <dc:Bounds x="1583" y="460" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0rut5wh_di" bpmnElement="SequenceFlow_0rut5wh">
-        <di:waypoint x="1683" y="500" />
-        <di:waypoint x="1732" y="500" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_1wqd2d8_di" bpmnElement="CallActivity_1wqd2d8">
         <dc:Bounds x="1832" y="460" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1n1h926_di" bpmnElement="SequenceFlow_1n1h926">
-        <di:waypoint x="1932" y="500" />
-        <di:waypoint x="1980" y="500" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_15z8s52_di" bpmnElement="ExclusiveGateway_15z8s52" isMarkerVisible="true">
         <dc:Bounds x="724" y="475" width="50" height="50" />
         <bpmndi:BPMNLabel>
@@ -976,42 +1538,18 @@
           <dc:Bounds x="970" y="704" width="57" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_072j964_di" bpmnElement="SequenceFlow_072j964">
-        <di:waypoint x="940" y="741" />
-        <di:waypoint x="1028" y="741" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="EndEvent_0w4cna4_di" bpmnElement="EndEvent_WCS">
         <dc:Bounds x="3940" y="482" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="3986" y="493" width="51" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0u8ottx_di" bpmnElement="SequenceFlow_0u8ottx">
-        <di:waypoint x="3886" y="500" />
-        <di:waypoint x="3940" y="500" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1yll54x_di" bpmnElement="SequenceFlow_1yll54x">
-        <di:waypoint x="1053" y="716" />
-        <di:waypoint x="1053" y="540" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1056" y="689" width="18" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_0w6yut4_di" bpmnElement="ExclusiveGateway_0w6yut4" isMarkerVisible="true">
         <dc:Bounds x="1732" y="475" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1733" y="459" width="48" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1crb1b1_di" bpmnElement="SequenceFlow_1crb1b1">
-        <di:waypoint x="1757" y="525" />
-        <di:waypoint x="1757" y="741" />
-        <di:waypoint x="1275" y="741" />
-        <di:waypoint x="1275" y="541" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1612" y="535" width="15" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_0viljw4_di" bpmnElement="CallActivity_0viljw4">
         <dc:Bounds x="2711" y="688" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -1021,298 +1559,78 @@
           <dc:Bounds x="2682" y="831" width="52" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_02gz6hu_di" bpmnElement="SequenceFlow_02gz6hu">
-        <di:waypoint x="2761" y="768" />
-        <di:waypoint x="2761" y="813" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_13g9keh_di" bpmnElement="SequenceFlow_13g9keh">
-        <di:waypoint x="2786" y="838" />
-        <di:waypoint x="2879" y="838" />
-        <di:waypoint x="2879" y="81" />
-        <di:waypoint x="1275" y="81" />
-        <di:waypoint x="1275" y="460" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2886" y="779" width="75" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_0hvivwl_di" bpmnElement="ExclusiveGateway_0hvivwl" isMarkerVisible="true">
         <dc:Bounds x="3541" y="475" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="3527" y="535" width="79" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0114w7o_di" bpmnElement="SequenceFlow_0114w7o">
-        <di:waypoint x="3591" y="500" />
-        <di:waypoint x="3640" y="500" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3594" y="479" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1nmrn6j_di" bpmnElement="SequenceFlow_1nmrn6j">
-        <di:waypoint x="3566" y="475" />
-        <di:waypoint x="3566" y="81" />
-        <di:waypoint x="1275" y="81" />
-        <di:waypoint x="1275" y="460" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3571" y="430" width="34" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_1dj23uw_di" bpmnElement="CallActivity_1dj23uw">
         <dc:Bounds x="3640" y="460" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1o932mp_di" bpmnElement="SequenceFlow_1o932mp">
-        <di:waypoint x="3740" y="500" />
-        <di:waypoint x="3786" y="500" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_108qbsg_di" bpmnElement="ExclusiveGateway_108qbsg" isMarkerVisible="true">
         <dc:Bounds x="412" y="475" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="408.5" y="437.5" width="57" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0dvt6hi_di" bpmnElement="SequenceFlow_0dvt6hi">
-        <di:waypoint x="462" y="500" />
-        <di:waypoint x="724" y="500" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="346" y="438" width="18" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0euf7ft_di" bpmnElement="SequenceFlow_0euf7ft">
-        <di:waypoint x="437" y="525" />
-        <di:waypoint x="437" y="1871" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="241" y="580" width="62" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_1pvz39b_di" bpmnElement="CallActivity_1pvz39b">
         <dc:Bounds x="2072" y="460" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_15wnmo1_di" bpmnElement="SequenceFlow_15wnmo1">
-        <di:waypoint x="2172" y="500" />
-        <di:waypoint x="2212" y="500" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_0jz2nzv_di" bpmnElement="CallActivity_0jz2nzv">
         <dc:Bounds x="2303" y="460" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1finuzu_di" bpmnElement="SequenceFlow_1finuzu">
-        <di:waypoint x="2403" y="500" />
-        <di:waypoint x="2455" y="500" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_0mr0e18_di" bpmnElement="CallActivity_0mr0e18">
         <dc:Bounds x="2559" y="580" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1t6vfhz_di" bpmnElement="SequenceFlow_1t6vfhz">
-        <di:waypoint x="3489" y="500" />
-        <di:waypoint x="3541" y="500" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_09eyouz_di" bpmnElement="ExclusiveGateway_09eyouz" isMarkerVisible="true">
         <dc:Bounds x="2455" y="475" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="2414" y="527" width="60" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1yb9nwq_di" bpmnElement="SequenceFlow_1yb9nwq">
-        <di:waypoint x="2480" y="525" />
-        <di:waypoint x="2480" y="620" />
-        <di:waypoint x="2559" y="620" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2485" y="540" width="13" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_0rqybuc_di" bpmnElement="CallActivity_0rqybuc">
         <dc:Bounds x="2559" y="460" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_08bc3k3_di" bpmnElement="SequenceFlow_08bc3k3">
-        <di:waypoint x="2505" y="500" />
-        <di:waypoint x="2559" y="500" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2514" y="480" width="25" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_0i15cif_di" bpmnElement="CallActivity_0i15cif">
         <dc:Bounds x="3139" y="460" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CallActivity_0bm3qs4_di" bpmnElement="CallActivity_0bm3qs4">
         <dc:Bounds x="3389" y="460" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_11d1sfn_di" bpmnElement="SequenceFlow_11d1sfn">
-        <di:waypoint x="2659" y="500" />
-        <di:waypoint x="2736" y="500" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1yejt76_di" bpmnElement="SequenceFlow_1yejt76">
-        <di:waypoint x="3239" y="500" />
-        <di:waypoint x="3290" y="500" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_1ujq11p_di" bpmnElement="ExclusiveGateway_1ujq11p" isMarkerVisible="true">
         <dc:Bounds x="1980" y="475" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1981" y="532" width="51" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1pgbmc2_di" bpmnElement="SequenceFlow_1pgbmc2">
-        <di:waypoint x="2030" y="500" />
-        <di:waypoint x="2072" y="500" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2031" y="483" width="25" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_0wq8f2b_di" bpmnElement="ExclusiveGateway_0wq8f2b" isMarkerVisible="true">
         <dc:Bounds x="2212" y="475" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="2200" y="532" width="77" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1kp1ctp_di" bpmnElement="SequenceFlow_1kp1ctp">
-        <di:waypoint x="2262" y="500" />
-        <di:waypoint x="2303" y="500" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2266" y="483" width="25" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_19w7kbp_di" bpmnElement="SequenceFlow_19w7kbp">
-        <di:waypoint x="2005" y="475" />
-        <di:waypoint x="2005" y="172" />
-        <di:waypoint x="1633" y="172" />
-        <di:waypoint x="1633" y="460" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1983" y="430" width="16" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1i28bcj_di" bpmnElement="SequenceFlow_1i28bcj">
-        <di:waypoint x="2237" y="475" />
-        <di:waypoint x="2237" y="172" />
-        <di:waypoint x="1633" y="172" />
-        <di:waypoint x="1633" y="460" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2212" y="430" width="16" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_16uaskl_di" bpmnElement="SequenceFlow_16uaskl">
-        <di:waypoint x="2480" y="475" />
-        <di:waypoint x="2480" y="316" />
-        <di:waypoint x="2122" y="316" />
-        <di:waypoint x="2122" y="460" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2488" y="430" width="44" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_05opatv_di" bpmnElement="ExclusiveGateway_05opatv" isMarkerVisible="true">
         <dc:Bounds x="2736" y="475" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="2094" y="436" width="38" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0v025qm_di" bpmnElement="SequenceFlow_0v025qm">
-        <di:waypoint x="2786" y="500" />
-        <di:waypoint x="2979" y="500" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2793" y="481" width="25" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_084vm5d_di" bpmnElement="ExclusiveGateway_084vm5d" isMarkerVisible="true">
         <dc:Bounds x="3290" y="475" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="3290" y="532" width="50" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1kcygny_di" bpmnElement="SequenceFlow_1kcygny">
-        <di:waypoint x="3340" y="500" />
-        <di:waypoint x="3389" y="500" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3344" y="482" width="25" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1qr0q1k_di" bpmnElement="SequenceFlow_1qr0q1k">
-        <di:waypoint x="3315" y="475" />
-        <di:waypoint x="3315" y="81" />
-        <di:waypoint x="1275" y="81" />
-        <di:waypoint x="1275" y="458" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3320" y="430" width="44" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_14uxgrl_di" bpmnElement="SequenceFlow_14uxgrl">
-        <di:waypoint x="2761" y="525" />
-        <di:waypoint x="2761" y="623" />
-        <di:waypoint x="2761" y="688" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2767" y="611" width="32" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_01um849_di" bpmnElement="SequenceFlow_01um849">
-        <di:waypoint x="1782" y="500" />
-        <di:waypoint x="1832" y="500" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1778" y="485" width="41" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1phw7gc_di" bpmnElement="SequenceFlow_1phw7gc">
-        <di:waypoint x="2259" y="497" />
-        <di:waypoint x="2259" y="82" />
-        <di:waypoint x="1275" y="82" />
-        <di:waypoint x="1275" y="460" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2263" y="430" width="41" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_120ptwd_di" bpmnElement="SequenceFlow_120ptwd">
-        <di:waypoint x="2659" y="589" />
-        <di:waypoint x="2748" y="512" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0rtgc8e_di" bpmnElement="SequenceFlow_0rtgc8e">
-        <di:waypoint x="2774" y="512" />
-        <di:waypoint x="2864" y="618" />
-        <di:waypoint x="3836" y="618" />
-        <di:waypoint x="3836" y="540" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2819" y="554" width="90" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_137sj52_di" bpmnElement="SequenceFlow_137sj52">
-        <di:waypoint x="2775" y="851" />
-        <di:waypoint x="3029" y="851" />
-        <di:waypoint x="3029" y="540" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2933" y="834" width="34" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_12y1rfs_di" bpmnElement="CallActivity_12y1rfs">
         <dc:Bounds x="2711" y="907" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0yikm73_di" bpmnElement="SequenceFlow_0yikm73">
-        <di:waypoint x="2761" y="863" />
-        <di:waypoint x="2761" y="907" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2767" y="873" width="62" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_15tids7_di" bpmnElement="ExclusiveGateway_15tids7" isMarkerVisible="true">
         <dc:Bounds x="2736" y="1026" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="2670" y="1044" width="61" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1c5wrex_di" bpmnElement="SequenceFlow_1c5wrex">
-        <di:waypoint x="2761" y="987" />
-        <di:waypoint x="2761" y="1026" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1hx3609_di" bpmnElement="SequenceFlow_1hx3609">
-        <di:waypoint x="2786" y="1051" />
-        <di:waypoint x="3029" y="1051" />
-        <di:waypoint x="3029" y="540" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2818" y="1031" width="34" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0hsqqfh_di" bpmnElement="SequenceFlow_0hsqqfh">
-        <di:waypoint x="2761" y="1076" />
-        <di:waypoint x="2761" y="1123" />
-        <di:waypoint x="3836" y="1123" />
-        <di:waypoint x="3836" y="543" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2812" y="1100" width="32" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_1ol5c3s_di" bpmnElement="CallActivity_1ol5c3s">
         <dc:Bounds x="1416" y="605" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -1322,247 +1640,102 @@
           <dc:Bounds x="1365" y="517" width="90" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0birlna_di" bpmnElement="SequenceFlow_0birlna">
-        <di:waypoint x="1491" y="500" />
-        <di:waypoint x="1583" y="500" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1498" y="484" width="16" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0uuixch_di" bpmnElement="SequenceFlow_0uuixch">
-        <di:waypoint x="1466" y="525" />
-        <di:waypoint x="1466" y="605" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1471" y="540" width="23" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0srhj4e_di" bpmnElement="SequenceFlow_0srhj4e">
-        <di:waypoint x="1416" y="645" />
-        <di:waypoint x="1303" y="645" />
-        <di:waypoint x="1303" y="540" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_19xba6r_di" bpmnElement="CallActivity_19xba6r">
         <dc:Bounds x="840" y="929" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0xboc5q_di" bpmnElement="SequenceFlow_0xboc5q">
-        <di:waypoint x="1053" y="766" />
-        <di:waypoint x="1053" y="969" />
-        <di:waypoint x="940" y="969" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1057" y="777" width="23" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_1fjl9sv_di" bpmnElement="ExclusiveGateway_1fjl9sv" isMarkerVisible="true">
         <dc:Bounds x="865" y="824" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="919" y="842" width="56" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1snix26_di" bpmnElement="SequenceFlow_1snix26">
-        <di:waypoint x="890" y="929" />
-        <di:waypoint x="890" y="874" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1f81u7n_di" bpmnElement="SequenceFlow_1f81u7n">
-        <di:waypoint x="890" y="824" />
-        <di:waypoint x="890" y="781" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0rvbnzc_di" bpmnElement="SequenceFlow_0rvbnzc">
-        <di:waypoint x="865" y="849" />
-        <di:waypoint x="783" y="849" />
-        <di:waypoint x="783" y="1216" />
-        <di:waypoint x="3835" y="1216" />
-        <di:waypoint x="3836" y="540" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="803" y="872" width="68" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1ptr3tz_di" bpmnElement="SequenceFlow_1ptr3tz">
-        <di:waypoint x="890" y="341" />
-        <di:waypoint x="890" y="701" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="895" y="349" width="88" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1t6o8wi_di" bpmnElement="SequenceFlow_1t6o8wi">
-        <di:waypoint x="865" y="316" />
-        <di:waypoint x="305" y="316" />
-        <di:waypoint x="305" y="460" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="713" y="322" width="86" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_0br8e7x_di" bpmnElement="ExclusiveGateway_0br8e7x" isMarkerVisible="true">
         <dc:Bounds x="865" y="291" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="845" y="275" width="90" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1g6deoe_di" bpmnElement="SequenceFlow_1g6deoe">
-        <di:waypoint x="1466" y="475" />
-        <di:waypoint x="1466" y="316" />
-        <di:waypoint x="1078" y="316" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1430" y="298" width="71" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_150jokh_di" bpmnElement="ExclusiveGateway_150jokh" isMarkerVisible="true">
         <dc:Bounds x="1028" y="291" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1008" y="275" width="90" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0yhk55u_di" bpmnElement="SequenceFlow_0yhk55u">
-        <di:waypoint x="1028" y="316" />
-        <di:waypoint x="915" y="316" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0kth4oz_di" bpmnElement="SequenceFlow_0kth4oz">
-        <di:waypoint x="1053" y="341" />
-        <di:waypoint x="1053" y="460" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1057" y="348" width="76" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_1oqn1vl_di" bpmnElement="CallActivity_1oqn1vl">
         <dc:Bounds x="2979" y="460" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1dhlqqh_di" bpmnElement="SequenceFlow_1dhlqqh">
-        <di:waypoint x="3079" y="500" />
-        <di:waypoint x="3139" y="500" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_0paicpr_di" bpmnElement="StartEvent_WCS_TRIAGE">
         <dc:Bounds x="976" y="386" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="965" y="368" width="58" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_13j60n4_di" bpmnElement="SequenceFlow_13j60n4">
-        <di:waypoint x="994" y="422" />
-        <di:waypoint x="994" y="437" />
-        <di:waypoint x="1053" y="437" />
-        <di:waypoint x="1053" y="460" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_0f1gcc4_di" bpmnElement="StartEvent_0f1gcc4">
         <dc:Bounds x="1200" y="386" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1180" y="368" width="76" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0fcl578_di" bpmnElement="SequenceFlow_0fcl578">
-        <di:waypoint x="1218" y="422" />
-        <di:waypoint x="1218" y="441" />
-        <di:waypoint x="1275" y="441" />
-        <di:waypoint x="1275" y="460" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_1pz8nz5_di" bpmnElement="StartEvent_1pz8nz5">
         <dc:Bounds x="209" y="357" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="184" y="341" width="85" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0lnw468_di" bpmnElement="SequenceFlow_0lnw468">
-        <di:waypoint x="227" y="393" />
-        <di:waypoint x="227" y="425" />
-        <di:waypoint x="305" y="425" />
-        <di:waypoint x="305" y="460" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_1krep6i_di" bpmnElement="StartEvent_1krep6i">
         <dc:Bounds x="787" y="600" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="770" y="582" width="70" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0kk16je_di" bpmnElement="SequenceFlow_0kk16je">
-        <di:waypoint x="805" y="636" />
-        <di:waypoint x="805" y="669" />
-        <di:waypoint x="890" y="669" />
-        <di:waypoint x="890" y="701" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_0ep9h9s_di" bpmnElement="StartEvent_0ep9h9s">
         <dc:Bounds x="1035" y="1012" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1009" y="1051" width="87" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_11vx77p_di" bpmnElement="SequenceFlow_11vx77p">
-        <di:waypoint x="1053" y="1012" />
-        <di:waypoint x="1053" y="969" />
-        <di:waypoint x="940" y="969" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_083ut27_di" bpmnElement="StartEvent_083ut27">
         <dc:Bounds x="1555" y="592" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1535" y="561" width="76" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1o01txw_di" bpmnElement="SequenceFlow_1o01txw">
-        <di:waypoint x="1573" y="628" />
-        <di:waypoint x="1573" y="645" />
-        <di:waypoint x="1516" y="645" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_18ge3lv_di" bpmnElement="StartEvent_18ge3lv">
         <dc:Bounds x="1555" y="386" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1552" y="369" width="43" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1kzo8ut_di" bpmnElement="SequenceFlow_1kzo8ut">
-        <di:waypoint x="1573" y="422" />
-        <di:waypoint x="1573" y="439" />
-        <di:waypoint x="1633" y="439" />
-        <di:waypoint x="1633" y="460" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_1avsxqe_di" bpmnElement="StartEvent_1avsxqe">
         <dc:Bounds x="1864" y="375" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1847" y="345" width="70" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1180qcf_di" bpmnElement="SequenceFlow_1180qcf">
-        <di:waypoint x="1882" y="411" />
-        <di:waypoint x="1882" y="460" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_08297th_di" bpmnElement="StartEvent_08297th">
         <dc:Bounds x="2042" y="375" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="2035" y="347" width="51" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0oebgkx_di" bpmnElement="SequenceFlow_0oebgkx">
-        <di:waypoint x="2078" y="393" />
-        <di:waypoint x="2122" y="393" />
-        <di:waypoint x="2122" y="460" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_0eawpgs_di" bpmnElement="StartEvent_0eawpgs">
         <dc:Bounds x="2335" y="375" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="2313" y="350" width="80" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1ph216h_di" bpmnElement="SequenceFlow_1ph216h">
-        <di:waypoint x="2353" y="411" />
-        <di:waypoint x="2353" y="460" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_0ewsk72_di" bpmnElement="StartEvent_0ewsk72">
         <dc:Bounds x="2591" y="375" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="2568" y="352" width="82" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1ezvho6_di" bpmnElement="SequenceFlow_1ezvho6">
-        <di:waypoint x="2609" y="411" />
-        <di:waypoint x="2609" y="460" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_0qw94pg_di" bpmnElement="StartEvent_0qw94pg">
         <dc:Bounds x="2492" y="708" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="2476" y="747" width="67" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_07v08od_di" bpmnElement="SequenceFlow_07v08od">
-        <di:waypoint x="2510" y="708" />
-        <di:waypoint x="2510" y="620" />
-        <di:waypoint x="2559" y="620" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_1kvodfh_di" bpmnElement="StartEvent_1kvodfh">
         <dc:Bounds x="3011" y="375" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -1575,263 +1748,90 @@
           <dc:Bounds x="3154" y="344" width="70" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_10jpg8q_di" bpmnElement="SequenceFlow_10jpg8q">
-        <di:waypoint x="3189" y="411" />
-        <di:waypoint x="3189" y="460" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1w5mz3m_di" bpmnElement="SequenceFlow_1w5mz3m">
-        <di:waypoint x="3029" y="411" />
-        <di:waypoint x="3029" y="460" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_17b415p_di" bpmnElement="StartEvent_17b415p">
         <dc:Bounds x="2640" y="710" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="2631" y="678" width="54" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0ds1lfr_di" bpmnElement="SequenceFlow_0ds1lfr">
-        <di:waypoint x="2676" y="729" />
-        <di:waypoint x="2711" y="729" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_137nu5g_di" bpmnElement="StartEvent_137nu5g">
         <dc:Bounds x="2640" y="929" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="2631" y="899" width="54" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0v85g4v_di" bpmnElement="SequenceFlow_0v85g4v">
-        <di:waypoint x="2676" y="947" />
-        <di:waypoint x="2711" y="947" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_0yzjtnn_di" bpmnElement="StartEvent_0yzjtnn">
         <dc:Bounds x="3421" y="375" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="3414" y="343" width="52" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_18x7zmj_di" bpmnElement="SequenceFlow_18x7zmj">
-        <di:waypoint x="3439" y="411" />
-        <di:waypoint x="3439" y="460" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_11rm3ai_di" bpmnElement="StartEvent_11rm3ai">
         <dc:Bounds x="3672" y="375" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="3653" y="342" width="74" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1jwq5no_di" bpmnElement="SequenceFlow_1jwq5no">
-        <di:waypoint x="3690" y="411" />
-        <di:waypoint x="3690" y="460" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="StartEvent_1r9whst_di" bpmnElement="StartEvent_1r9whst">
         <dc:Bounds x="3753" y="375" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="3741" y="342" width="61" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0a7fniw_di" bpmnElement="SequenceFlow_0a7fniw">
-        <di:waypoint x="3771" y="411" />
-        <di:waypoint x="3771" y="436" />
-        <di:waypoint x="3690" y="436" />
-        <di:waypoint x="3690" y="460" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_1n98uh5_di" bpmnElement="CallActivity_1n98uh5">
         <dc:Bounds x="840" y="1279" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="CallActivity_08rii2k_di" bpmnElement="CallActivity_08rii2k">
         <dc:Bounds x="387" y="1871" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1cyl5pp_di" bpmnElement="SequenceFlow_1cyl5pp">
-        <di:waypoint x="437" y="1951" />
-        <di:waypoint x="437" y="2040" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_1osbiem_di" bpmnElement="ExclusiveGateway_1osbiem" isMarkerVisible="true">
         <dc:Bounds x="412" y="2040" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="347" y="2031" width="79" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0knicym_di" bpmnElement="SequenceFlow_0knicym">
-        <di:waypoint x="412" y="2344" />
-        <di:waypoint x="305" y="2344" />
-        <di:waypoint x="305" y="540" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="322" y="2360" width="84" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_1ckc2th_di" bpmnElement="CallActivity_1ckc2th">
         <dc:Bounds x="387" y="2164" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0wcus5v_di" bpmnElement="SequenceFlow_0wcus5v">
-        <di:waypoint x="437" y="2090" />
-        <di:waypoint x="437" y="2164" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="448" y="2124" width="74" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_1prlsec_di" bpmnElement="ExclusiveGateway_1prlsec" isMarkerVisible="true">
         <dc:Bounds x="412" y="2319" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="334" y="2310" width="87" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_07qeroh_di" bpmnElement="SequenceFlow_07qeroh">
-        <di:waypoint x="437" y="2244" />
-        <di:waypoint x="437" y="2319" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0ccneyt_di" bpmnElement="SequenceFlow_0ccneyt">
-        <di:waypoint x="749" y="525" />
-        <di:waypoint x="749" y="741" />
-        <di:waypoint x="840" y="741" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="661" y="548" width="81" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1sd65eg_di" bpmnElement="SequenceFlow_1sd65eg">
-        <di:waypoint x="774" y="500" />
-        <di:waypoint x="1003" y="500" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="798" y="513" width="69" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_00rent3_di" bpmnElement="ExclusiveGateway_00rent3" isMarkerVisible="true">
         <dc:Bounds x="865" y="1411" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="803" y="1402" width="74" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0bhyhgr_di" bpmnElement="SequenceFlow_0bhyhgr">
-        <di:waypoint x="890" y="1359" />
-        <di:waypoint x="890" y="1411" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_0wxh0ne_di" bpmnElement="CallActivity_0wxh0ne">
         <dc:Bounds x="840" y="1528" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1nymkwa_di" bpmnElement="SequenceFlow_1nymkwa">
-        <di:waypoint x="890" y="1461" />
-        <di:waypoint x="890" y="1528" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="906" y="1494" width="74" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_029ksxv_di" bpmnElement="ExclusiveGateway_029ksxv" isMarkerVisible="true">
         <dc:Bounds x="865" y="1666" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="788" y="1657" width="85" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1tk5v1l_di" bpmnElement="SequenceFlow_1tk5v1l">
-        <di:waypoint x="890" y="1608" />
-        <di:waypoint x="890" y="1666" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1pio0fm_di" bpmnElement="SequenceFlow_1pio0fm">
-        <di:waypoint x="865" y="1691" />
-        <di:waypoint x="611" y="1691" />
-        <di:waypoint x="611" y="741" />
-        <di:waypoint x="840" y="741" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="764" y="1709" width="81" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0ccjpkn_di" bpmnElement="SequenceFlow_0ccjpkn">
-        <di:waypoint x="1075" y="744" />
-        <di:waypoint x="1156" y="741" />
-        <di:waypoint x="1156" y="1319" />
-        <di:waypoint x="940" y="1319" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_0021i19_di" bpmnElement="CallActivity_0021i19">
         <dc:Bounds x="1106" y="1528" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0szvowd_di" bpmnElement="SequenceFlow_0szvowd">
-        <di:waypoint x="915" y="1436" />
-        <di:waypoint x="1156" y="1436" />
-        <di:waypoint x="1156" y="1528" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="926" y="1416" width="37" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_05wjkhx_di" bpmnElement="SequenceFlow_05wjkhx">
-        <di:waypoint x="915" y="1691" />
-        <di:waypoint x="1156" y="1691" />
-        <di:waypoint x="1156" y="1608" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="924" y="1709" width="37" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_0tjst2n_di" bpmnElement="ExclusiveGateway_0tjst2n" isMarkerVisible="true">
         <dc:Bounds x="1345" y="1543" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1269" y="1534" width="89" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1spfvi1_di" bpmnElement="SequenceFlow_1spfvi1">
-        <di:waypoint x="1370" y="1593" />
-        <di:waypoint x="1370" y="1769" />
-        <di:waypoint x="610" y="1769" />
-        <di:waypoint x="610" y="741" />
-        <di:waypoint x="840" y="741" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1396" y="1644" width="81" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0sohasi_di" bpmnElement="SequenceFlow_0sohasi">
-        <di:waypoint x="1395" y="1568" />
-        <di:waypoint x="3836" y="1568" />
-        <di:waypoint x="3836" y="540" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1429" y="1541" width="57" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1ny5uz4_di" bpmnElement="SequenceFlow_1ny5uz4">
-        <di:waypoint x="1206" y="1568" />
-        <di:waypoint x="1345" y="1568" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="CallActivity_0a4wfy7_di" bpmnElement="CallActivity_0a4wfy7">
         <dc:Bounds x="1106" y="2164" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0uj5elh_di" bpmnElement="SequenceFlow_0uj5elh">
-        <di:waypoint x="462" y="2065" />
-        <di:waypoint x="1156" y="2065" />
-        <di:waypoint x="1156" y="2164" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="481" y="2040" width="37" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1sbspon_di" bpmnElement="SequenceFlow_1sbspon">
-        <di:waypoint x="462" y="2344" />
-        <di:waypoint x="1156" y="2344" />
-        <di:waypoint x="1156" y="2244" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="482" y="2362" width="37" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_0j7fp11_di" bpmnElement="ExclusiveGateway_0j7fp11" isMarkerVisible="true">
         <dc:Bounds x="1345" y="2179" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1271" y="2170" width="85" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0lfimbn_di" bpmnElement="SequenceFlow_0lfimbn">
-        <di:waypoint x="1370" y="2229" />
-        <di:waypoint x="1370" y="2426" />
-        <di:waypoint x="305" y="2426" />
-        <di:waypoint x="305" y="540" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1381" y="2266" width="84" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0ii6vw3_di" bpmnElement="SequenceFlow_0ii6vw3">
-        <di:waypoint x="1206" y="2204" />
-        <di:waypoint x="1345" y="2204" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1m9c1wb_di" bpmnElement="SequenceFlow_1m9c1wb">
-        <di:waypoint x="1395" y="2204" />
-        <di:waypoint x="3836" y="2204" />
-        <di:waypoint x="3836" y="540" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1416" y="2177" width="57" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/processes/WCS.bpmn
+++ b/src/main/resources/processes/WCS.bpmn
@@ -105,6 +105,7 @@
         <camunda:in source="CaseworkUserUUID" target="AllocatedUserUUID" />
         <camunda:in source="SendPaymentStatus" target="SendPaymentStatus" />
         <camunda:out source="LastUpdatedByUserUUID" target="LastUpdatedByUserUUID" />
+        <camunda:out source="CaseworkTeamUUID" target="CaseworkTeamUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0srhj4e</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0fcl578</bpmn:incoming>
@@ -503,6 +504,7 @@
         <camunda:in source="LastUpdatedByUserUUID" target="AllocatedUserUUID" />
         <camunda:out source="LastUpdatedByUserUUID" target="CaseworkUserUUID" />
         <camunda:out source="LastUpdatedByUserUUID" target="LastUpdatedByUserUUID" />
+        <camunda:out source="CaseworkTeamUUID" target="CaseworkTeamUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0uuixch</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1o01txw</bpmn:incoming>


### PR DESCRIPTION
As we are currently changing the internal representation of the data, 
we need to pull this out of the stage when we finish one. As we 
change it for the stage level we can assign the outer variable to the 
same.

Currently when a team is moved outside a workflow, the internal 
representation of the case is not update-able. This change adds an 
endpoint that allows for the updating of the data. This endpoint is 
protected by the `@Authorised` annotation for users with write 
permissions.