### PR TITLE
HOCS-2923: allow enquiry reason subject change

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/application/CamundaProcessEngineConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/application/CamundaProcessEngineConfiguration.java
@@ -45,8 +45,8 @@ public class CamundaProcessEngineConfiguration {
     config.setJobExecutorActivate(true);
     config.setMetricsEnabled(false);
 
-    // deploy all processes from folder 'processes'
-    Resource[] resources = resourceLoader.getResources("classpath:/processes/*");
+    // loops through and collates all bpmn files in the processes (sub-)folders
+    Resource[] resources = resourceLoader.getResources("classpath:/processes/**/*.bpmn");
     config.setDeploymentResources(resources);
 
     return config;

--- a/src/main/resources/processes/MPAM/MPAM_UPDATE_ENQUIRY_SUBJECT_REASON.bpmn
+++ b/src/main/resources/processes/MPAM/MPAM_UPDATE_ENQUIRY_SUBJECT_REASON.bpmn
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1gxgx6i" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+  <bpmn:process id="MPAM_UPDATE_ENQUIRY_SUBJECT_REASON" isExecutable="true">
+    <bpmn:startEvent id="MpamUpdateEnquirySubjectReason_StartEvent">
+      <bpmn:outgoing>Flow_1n47na7</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1n47na7" sourceRef="MpamUpdateEnquirySubjectReason_StartEvent" targetRef="MpamEnquirySubject_Activity" />
+    <bpmn:endEvent id="MpamUpdateEnquirySubjectReason_EndEvent">
+      <bpmn:incoming>Flow_1dkgjpa</bpmn:incoming>
+      <bpmn:incoming>Flow_1qnfu0k</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:userTask id="MpamEnquirySubject_Activity" name="MPAM Enquiry Subject Input" camunda:formKey="MPAM_ENQUIRY_SUBJECT">
+      <bpmn:incoming>Flow_11kdclp</bpmn:incoming>
+      <bpmn:incoming>Flow_1n47na7</bpmn:incoming>
+      <bpmn:outgoing>Flow_018x7sy</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_0ykr0ko">
+      <bpmn:incoming>Flow_0vnqtel</bpmn:incoming>
+      <bpmn:outgoing>Flow_11kdclp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1wjhktn</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_190pv43" name="Direction Check">
+      <bpmn:incoming>Flow_018x7sy</bpmn:incoming>
+      <bpmn:outgoing>Flow_0vnqtel</bpmn:outgoing>
+      <bpmn:outgoing>Flow_04lkhb6</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="MpamEnquiryReason_Activity" name="MPAM Enquiry Reason Input" camunda:formKey="MPAM_ENQUIRY_REASON">
+      <bpmn:incoming>Flow_17e9b7p</bpmn:incoming>
+      <bpmn:incoming>Flow_1wjhktn</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ot2qg5</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:exclusiveGateway id="Gateway_06eavsn">
+      <bpmn:incoming>Flow_09qem3v</bpmn:incoming>
+      <bpmn:outgoing>Flow_17e9b7p</bpmn:outgoing>
+      <bpmn:outgoing>Flow_02k5elb</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:exclusiveGateway id="Gateway_1ouon9a" name="Direction Check">
+      <bpmn:incoming>Flow_1ot2qg5</bpmn:incoming>
+      <bpmn:outgoing>Flow_09qem3v</bpmn:outgoing>
+      <bpmn:outgoing>Flow_04pe7xc</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:serviceTask id="UpdateEnquirySubjectReason_Activity" name="Update Enquiry Subject/Reason" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;EnquirySubject&#34;, execution.getVariable(&#34;tempEnquirySubject&#34;), &#34;EnquiryReason&#34;, execution.getVariable(&#34;tempEnquiryReason&#34;) )}">
+      <bpmn:incoming>Flow_02k5elb</bpmn:incoming>
+      <bpmn:outgoing>Flow_12msrbc</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_11kdclp" name="false" sourceRef="Gateway_0ykr0ko" targetRef="MpamEnquirySubject_Activity">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_018x7sy" sourceRef="MpamEnquirySubject_Activity" targetRef="Gateway_190pv43" />
+    <bpmn:sequenceFlow id="Flow_0vnqtel" name="FORWARD" sourceRef="Gateway_190pv43" targetRef="Gateway_0ykr0ko">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1wjhktn" sourceRef="Gateway_0ykr0ko" targetRef="MpamEnquiryReason_Activity">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_17e9b7p" name="false" sourceRef="Gateway_06eavsn" targetRef="MpamEnquiryReason_Activity">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1ot2qg5" sourceRef="MpamEnquiryReason_Activity" targetRef="Gateway_1ouon9a" />
+    <bpmn:sequenceFlow id="Flow_09qem3v" name="FORWARD" sourceRef="Gateway_1ouon9a" targetRef="Gateway_06eavsn">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_02k5elb" sourceRef="Gateway_06eavsn" targetRef="UpdateEnquirySubjectReason_Activity">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_04pe7xc" name="BACKWARD" sourceRef="Gateway_1ouon9a" targetRef="ClearTempEnquirySubjectReason_Activity">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_12msrbc" sourceRef="UpdateEnquirySubjectReason_Activity" targetRef="ClearTempEnquirySubjectReason_Activity" />
+    <bpmn:sequenceFlow id="Flow_04lkhb6" name="BACKWARD" sourceRef="Gateway_190pv43" targetRef="ClearTempEnquirySubject_Activity">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="ClearTempEnquirySubject_Activity" name="Clear Temp Enquiry Subject" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;tempEnquirySubject&#34;)}">
+      <bpmn:incoming>Flow_04lkhb6</bpmn:incoming>
+      <bpmn:outgoing>Flow_1dkgjpa</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1dkgjpa" sourceRef="ClearTempEnquirySubject_Activity" targetRef="MpamUpdateEnquirySubjectReason_EndEvent" />
+    <bpmn:serviceTask id="ClearTempEnquirySubjectReason_Activity" name="Clear Temp Enquiry Subject/Reason" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;tempEnquirySubject&#34;, &#34;tempEnquiryReason&#34; )}">
+      <bpmn:incoming>Flow_12msrbc</bpmn:incoming>
+      <bpmn:incoming>Flow_04pe7xc</bpmn:incoming>
+      <bpmn:outgoing>Flow_1qnfu0k</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1qnfu0k" sourceRef="ClearTempEnquirySubjectReason_Activity" targetRef="MpamUpdateEnquirySubjectReason_EndEvent" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_UPDATE_ENQUIRY_SUBJECT_REASON">
+      <bpmndi:BPMNEdge id="Flow_1n47na7_di" bpmnElement="Flow_1n47na7">
+        <di:waypoint x="483" y="118" />
+        <di:waypoint x="483" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11kdclp_di" bpmnElement="Flow_11kdclp">
+        <di:waypoint x="508" y="463" />
+        <di:waypoint x="637" y="463" />
+        <di:waypoint x="637" y="220" />
+        <di:waypoint x="533" y="220" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="560" y="445" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_018x7sy_di" bpmnElement="Flow_018x7sy">
+        <di:waypoint x="483" y="260" />
+        <di:waypoint x="483" y="324" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vnqtel_di" bpmnElement="Flow_0vnqtel">
+        <di:waypoint x="483" y="374" />
+        <di:waypoint x="483" y="438" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="415" y="389" width="57" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wjhktn_di" bpmnElement="Flow_1wjhktn">
+        <di:waypoint x="483" y="488" />
+        <di:waypoint x="483" y="530" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04lkhb6_di" bpmnElement="Flow_04lkhb6">
+        <di:waypoint x="458" y="349" />
+        <di:waypoint x="370" y="349" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="388" y="328" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17e9b7p_di" bpmnElement="Flow_17e9b7p">
+        <di:waypoint x="508" y="790" />
+        <di:waypoint x="640" y="790" />
+        <di:waypoint x="640" y="570" />
+        <di:waypoint x="533" y="570" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="562" y="773" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ot2qg5_di" bpmnElement="Flow_1ot2qg5">
+        <di:waypoint x="483" y="610" />
+        <di:waypoint x="483" y="665" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09qem3v_di" bpmnElement="Flow_09qem3v">
+        <di:waypoint x="483" y="715" />
+        <di:waypoint x="483" y="765" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="415" y="748" width="57" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02k5elb_di" bpmnElement="Flow_02k5elb">
+        <di:waypoint x="458" y="790" />
+        <di:waypoint x="230" y="790" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04pe7xc_di" bpmnElement="Flow_04pe7xc">
+        <di:waypoint x="458" y="690" />
+        <di:waypoint x="180" y="690" />
+        <di:waypoint x="180" y="580" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="339" y="673" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12msrbc_di" bpmnElement="Flow_12msrbc">
+        <di:waypoint x="180" y="750" />
+        <di:waypoint x="180" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dkgjpa_di" bpmnElement="Flow_1dkgjpa">
+        <di:waypoint x="270" y="349" />
+        <di:waypoint x="198" y="349" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qnfu0k_di" bpmnElement="Flow_1qnfu0k">
+        <di:waypoint x="180" y="500" />
+        <di:waypoint x="180" y="367" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0zvdw3s_di" bpmnElement="MpamEnquirySubject_Activity">
+        <dc:Bounds x="433" y="180" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ykr0ko_di" bpmnElement="Gateway_0ykr0ko" isMarkerVisible="true">
+        <dc:Bounds x="458" y="438" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_190pv43_di" bpmnElement="Gateway_190pv43" isMarkerVisible="true">
+        <dc:Bounds x="458" y="324" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="518" y="342" width="78" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0sn3zuo_di" bpmnElement="MpamEnquiryReason_Activity">
+        <dc:Bounds x="433" y="530" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1ouon9a_di" bpmnElement="Gateway_1ouon9a" isMarkerVisible="true">
+        <dc:Bounds x="458" y="665" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="518" y="683" width="78" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_06eavsn_di" bpmnElement="Gateway_06eavsn" isMarkerVisible="true">
+        <dc:Bounds x="458" y="765" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="MpamUpdateEnquirySubjectReason_StartEvent">
+        <dc:Bounds x="465" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14lgrh1_di" bpmnElement="MpamUpdateEnquirySubjectReason_EndEvent">
+        <dc:Bounds x="162" y="331" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_148wqse_di" bpmnElement="ClearTempEnquirySubject_Activity">
+        <dc:Bounds x="270" y="309" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1d9kyjk_di" bpmnElement="UpdateEnquirySubjectReason_Activity">
+        <dc:Bounds x="130" y="750" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1wmpn1s_di" bpmnElement="ClearTempEnquirySubjectReason_Activity">
+        <dc:Bounds x="130" y="500" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/MPAM_TRIAGE.bpmn
+++ b/src/main/resources/processes/MPAM_TRIAGE.bpmn
@@ -8,8 +8,6 @@
       <bpmn:incoming>SequenceFlow_06v8hsn</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1m917qi</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0x8dpmn</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_1sq5itz</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_1101m5b</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1bypsoj</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0j5xv9g</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0roihnf</bpmn:incoming>
@@ -17,6 +15,9 @@
       <bpmn:incoming>SequenceFlow_09fnnt9</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0sk755u</bpmn:incoming>
       <bpmn:incoming>Flow_1gxj9d4</bpmn:incoming>
+      <bpmn:incoming>Flow_183ayoj</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1sq5itz</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1101m5b</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_16wwh9z</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:userTask id="Validate_UserInput" name="Validate User Input">
@@ -83,90 +84,8 @@
     <bpmn:sequenceFlow id="SequenceFlow_080dqh7" name="FORWARD" sourceRef="ExclusiveGateway_08l5d8b" targetRef="ExclusiveGateway_13qjvzx">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_14o40c8" name="Enquiry Subject" camunda:expression="MPAM_ENQUIRY_SUBJECT" camunda:resultVariable="screen">
-      <bpmn:incoming>SequenceFlow_1stb0k6</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_1ijxxtj</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_1nf0zpm</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_1stb0k6" name="UpdateEnquirySubject" sourceRef="ExclusiveGateway_08l5d8b" targetRef="ServiceTask_14o40c8">
+    <bpmn:sequenceFlow id="SequenceFlow_1stb0k6" name="UpdateEnquirySubject" sourceRef="ExclusiveGateway_08l5d8b" targetRef="UpdateEnquiryReason_Activity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "UpdateEnquirySubject"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:userTask id="UserTask_1r69osa" name="Validate User Input">
-      <bpmn:incoming>SequenceFlow_1nf0zpm</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_068rpjw</bpmn:outgoing>
-    </bpmn:userTask>
-    <bpmn:sequenceFlow id="SequenceFlow_1nf0zpm" sourceRef="ServiceTask_14o40c8" targetRef="UserTask_1r69osa" />
-    <bpmn:exclusiveGateway id="ExclusiveGateway_00ge51l">
-      <bpmn:incoming>SequenceFlow_11990z3</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_1ijxxtj</bpmn:outgoing>
-      <bpmn:outgoing>SequenceFlow_0wvio0a</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_068rpjw" sourceRef="UserTask_1r69osa" targetRef="ExclusiveGateway_049krff" />
-    <bpmn:sequenceFlow id="SequenceFlow_1ijxxtj" name="false" sourceRef="ExclusiveGateway_00ge51l" targetRef="ServiceTask_14o40c8">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0wvio0a" sourceRef="ExclusiveGateway_00ge51l" targetRef="ServiceTask_1wl4mgd">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="ExclusiveGateway_049krff" name="Direction Check">
-      <bpmn:incoming>SequenceFlow_068rpjw</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_11990z3</bpmn:outgoing>
-      <bpmn:outgoing>SequenceFlow_0enh4xh</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_11990z3" name="FORWARD" sourceRef="ExclusiveGateway_049krff" targetRef="ExclusiveGateway_00ge51l">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_1wl4mgd" name="Enquiry Reason" camunda:expression="MPAM_ENQUIRY_REASON" camunda:resultVariable="screen">
-      <bpmn:incoming>SequenceFlow_0z80bhn</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_0wvio0a</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_0a2kz4o</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:userTask id="UserTask_0kelzuk" name="Validate User Input">
-      <bpmn:incoming>SequenceFlow_0a2kz4o</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_00xav5j</bpmn:outgoing>
-    </bpmn:userTask>
-    <bpmn:exclusiveGateway id="ExclusiveGateway_17q8hsm">
-      <bpmn:incoming>SequenceFlow_08xepts</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_0z80bhn</bpmn:outgoing>
-      <bpmn:outgoing>SequenceFlow_11zk0mc</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:exclusiveGateway id="ExclusiveGateway_1iftjr8" name="Direction Check">
-      <bpmn:incoming>SequenceFlow_00xav5j</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_08xepts</bpmn:outgoing>
-      <bpmn:outgoing>SequenceFlow_1enm75p</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_0z80bhn" name="false" sourceRef="ExclusiveGateway_17q8hsm" targetRef="ServiceTask_1wl4mgd">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0a2kz4o" sourceRef="ServiceTask_1wl4mgd" targetRef="UserTask_0kelzuk" />
-    <bpmn:sequenceFlow id="SequenceFlow_00xav5j" sourceRef="UserTask_0kelzuk" targetRef="ExclusiveGateway_1iftjr8" />
-    <bpmn:sequenceFlow id="SequenceFlow_08xepts" name="FORWARD" sourceRef="ExclusiveGateway_1iftjr8" targetRef="ExclusiveGateway_17q8hsm">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_11zk0mc" sourceRef="ExclusiveGateway_17q8hsm" targetRef="ServiceTask_12eh3q4">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_12eh3q4" name="Update Enquiry Subject/Reason" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;EnquirySubject&#34;, execution.getVariable(&#34;tempEnquirySubject&#34;), &#34;EnquiryReason&#34;, execution.getVariable(&#34;tempEnquiryReason&#34;) )}">
-      <bpmn:incoming>SequenceFlow_11zk0mc</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_0jpt0ej</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_0jpt0ej" sourceRef="ServiceTask_12eh3q4" targetRef="ServiceTask_060ccpx" />
-    <bpmn:serviceTask id="ServiceTask_060ccpx" name="Clear Temp Enquiry Subject/Reason" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;tempEnquirySubject&#34;, &#34;tempEnquiryReason&#34; )}">
-      <bpmn:incoming>SequenceFlow_0jpt0ej</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_1enm75p</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_1sq5itz</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_1sq5itz" sourceRef="ServiceTask_060ccpx" targetRef="Screen_UserInput" />
-    <bpmn:serviceTask id="ServiceTask_0hpe5ym" name="Clear Temp Enquiry Subject" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;tempEnquirySubject&#34;)}">
-      <bpmn:incoming>SequenceFlow_0enh4xh</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_1101m5b</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_1101m5b" sourceRef="ServiceTask_0hpe5ym" targetRef="Screen_UserInput" />
-    <bpmn:sequenceFlow id="SequenceFlow_1enm75p" name="BACKWARD" sourceRef="ExclusiveGateway_1iftjr8" targetRef="ServiceTask_060ccpx">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0enh4xh" name="BACKWARD" sourceRef="ExclusiveGateway_049krff" targetRef="ServiceTask_0hpe5ym">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="ServiceTask_1w1h0tl" name="Request Contribution Input" camunda:expression="MPAM_TRIAGE_REQUEST_CONTRIBUTION_INPUT" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_1lphuf4</bpmn:incoming>
@@ -571,6 +490,91 @@
       <bpmn:outgoing>SequenceFlow_10f25gy</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_10f25gy" sourceRef="Service_SetBusAreaStatusConfirm" targetRef="Gateway_071hwrm" />
+    <bpmn:sequenceFlow id="Flow_183ayoj" sourceRef="UpdateEnquiryReason_Activity" targetRef="Screen_UserInput" />
+    <bpmn:callActivity id="UpdateEnquiryReason_Activity" name="Update Enquiry Reason" calledElement="MPAM_UPDATE_ENQUIRY_SUBJECT_REASON">
+      <bpmn:extensionElements>
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in source="CaseUUID" target="CaseUUID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1stb0k6</bpmn:incoming>
+      <bpmn:outgoing>Flow_183ayoj</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:serviceTask id="ServiceTask_12eh3q4" name="Update Enquiry Subject/Reason" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;EnquirySubject&#34;, execution.getVariable(&#34;tempEnquirySubject&#34;), &#34;EnquiryReason&#34;, execution.getVariable(&#34;tempEnquiryReason&#34;) )}">
+      <bpmn:incoming>SequenceFlow_11zk0mc</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0jpt0ej</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0jpt0ej" sourceRef="ServiceTask_12eh3q4" targetRef="ServiceTask_060ccpx" />
+    <bpmn:serviceTask id="ServiceTask_060ccpx" name="Clear Temp Enquiry Subject/Reason" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;tempEnquirySubject&#34;, &#34;tempEnquiryReason&#34; )}">
+      <bpmn:incoming>SequenceFlow_0jpt0ej</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1enm75p</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1sq5itz</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1sq5itz" sourceRef="ServiceTask_060ccpx" targetRef="Screen_UserInput" />
+    <bpmn:exclusiveGateway id="ExclusiveGateway_17q8hsm">
+      <bpmn:incoming>SequenceFlow_08xepts</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_11zk0mc</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_0z80bhn</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_11zk0mc" sourceRef="ExclusiveGateway_17q8hsm" targetRef="ServiceTask_12eh3q4">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1iftjr8" name="Direction Check">
+      <bpmn:incoming>SequenceFlow_00xav5j</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1enm75p</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_08xepts</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_1enm75p" name="BACKWARD" sourceRef="ExclusiveGateway_1iftjr8" targetRef="ServiceTask_060ccpx">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_08xepts" name="FORWARD" sourceRef="ExclusiveGateway_1iftjr8" targetRef="ExclusiveGateway_17q8hsm">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_0z80bhn" name="false" sourceRef="ExclusiveGateway_17q8hsm" targetRef="ServiceTask_1wl4mgd">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:userTask id="UserTask_0kelzuk" name="Validate User Input">
+      <bpmn:incoming>SequenceFlow_0a2kz4o</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_00xav5j</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="SequenceFlow_00xav5j" sourceRef="UserTask_0kelzuk" targetRef="ExclusiveGateway_1iftjr8" />
+    <bpmn:serviceTask id="ServiceTask_1wl4mgd" name="Enquiry Reason" camunda:expression="MPAM_ENQUIRY_REASON" camunda:resultVariable="screen">
+      <bpmn:incoming>SequenceFlow_0z80bhn</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_0wvio0a</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0a2kz4o</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_0a2kz4o" sourceRef="ServiceTask_1wl4mgd" targetRef="UserTask_0kelzuk" />
+    <bpmn:serviceTask id="ServiceTask_0hpe5ym" name="Clear Temp Enquiry Subject" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;tempEnquirySubject&#34;)}">
+      <bpmn:incoming>SequenceFlow_0enh4xh</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1101m5b</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1101m5b" sourceRef="ServiceTask_0hpe5ym" targetRef="Screen_UserInput" />
+    <bpmn:exclusiveGateway id="ExclusiveGateway_00ge51l">
+      <bpmn:incoming>SequenceFlow_11990z3</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0wvio0a</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1ijxxtj</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_0wvio0a" sourceRef="ExclusiveGateway_00ge51l" targetRef="ServiceTask_1wl4mgd">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="ExclusiveGateway_049krff" name="Direction Check">
+      <bpmn:incoming>SequenceFlow_068rpjw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_0enh4xh</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_11990z3</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="SequenceFlow_0enh4xh" name="BACKWARD" sourceRef="ExclusiveGateway_049krff" targetRef="ServiceTask_0hpe5ym">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_11990z3" name="FORWARD" sourceRef="ExclusiveGateway_049krff" targetRef="ExclusiveGateway_00ge51l">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_1ijxxtj" name="false" sourceRef="ExclusiveGateway_00ge51l" targetRef="UserTask_1r69osa">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:userTask id="UserTask_1r69osa" name="Validate User Input">
+      <bpmn:incoming>SequenceFlow_1ijxxtj</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_068rpjw</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="SequenceFlow_068rpjw" sourceRef="UserTask_1r69osa" targetRef="ExclusiveGateway_049krff" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_TRIAGE">

--- a/src/main/resources/processes/MPAM_TRIAGE.bpmn
+++ b/src/main/resources/processes/MPAM_TRIAGE.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ixf2kb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.2">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ixf2kb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
   <bpmn:process id="MPAM_TRIAGE" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_0x8dpmn</bpmn:outgoing>
@@ -578,6 +578,32 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_TRIAGE">
+      <bpmndi:BPMNEdge id="SequenceFlow_10f25gy_di" bpmnElement="SequenceFlow_10f25gy">
+        <di:waypoint x="1400" y="873" />
+        <di:waypoint x="1445" y="873" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yaafex_di" bpmnElement="Flow_1yaafex">
+        <di:waypoint x="1920" y="760" />
+        <di:waypoint x="2210" y="760" />
+        <di:waypoint x="2336" y="651" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_090lt1t_di" bpmnElement="Flow_090lt1t">
+        <di:waypoint x="1470" y="848" />
+        <di:waypoint x="1470" y="760" />
+        <di:waypoint x="1497" y="760" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v6jf5j_di" bpmnElement="Flow_0v6jf5j">
+        <di:waypoint x="1495" y="873" />
+        <di:waypoint x="1546" y="873" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18ol1vj_di" bpmnElement="Flow_18ol1vj">
+        <di:waypoint x="1597" y="760" />
+        <di:waypoint x="1639" y="760" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1cwwl6a_di" bpmnElement="Flow_1cwwl6a">
+        <di:waypoint x="1739" y="760" />
+        <di:waypoint x="1820" y="760" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_05mveu5_di" bpmnElement="SequenceFlow_05mveu5">
         <di:waypoint x="2289" y="515" />
         <di:waypoint x="2349" y="515" />
@@ -1010,7 +1036,8 @@
         <di:waypoint x="967" y="2138" />
         <di:waypoint x="967" y="1823" />
         <di:waypoint x="610" y="1823" />
-        <di:waypoint x="610" y="1855" />
+        <di:waypoint x="610" y="1895" />
+        <di:waypoint x="763" y="1895" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="890" y="2120" width="24" height="14" />
         </bpmndi:BPMNLabel>
@@ -1019,15 +1046,11 @@
         <di:waypoint x="813" y="1935" />
         <di:waypoint x="813" y="1999" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1nf0zpm_di" bpmnElement="SequenceFlow_1nf0zpm">
-        <di:waypoint x="660" y="1895" />
-        <di:waypoint x="763" y="1895" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1stb0k6_di" bpmnElement="SequenceFlow_1stb0k6">
         <di:waypoint x="610" y="823" />
-        <di:waypoint x="610" y="1855" />
+        <di:waypoint x="610" y="1550" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="566" y="1782" width="87" height="27" />
+          <dc:Bounds x="626" y="1426" width="87" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_080dqh7_di" bpmnElement="SequenceFlow_080dqh7">
@@ -1095,27 +1118,11 @@
           <dc:Bounds x="598" y="535" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1cwwl6a_di" bpmnElement="Flow_1cwwl6a">
-        <di:waypoint x="1739" y="760" />
-        <di:waypoint x="1820" y="760" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_18ol1vj_di" bpmnElement="Flow_18ol1vj">
-        <di:waypoint x="1597" y="760" />
-        <di:waypoint x="1639" y="760" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0v6jf5j_di" bpmnElement="Flow_0v6jf5j">
-        <di:waypoint x="1495" y="873" />
-        <di:waypoint x="1546" y="873" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_090lt1t_di" bpmnElement="Flow_090lt1t">
-        <di:waypoint x="1470" y="848" />
-        <di:waypoint x="1470" y="760" />
-        <di:waypoint x="1497" y="760" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1yaafex_di" bpmnElement="Flow_1yaafex">
-        <di:waypoint x="1920" y="760" />
-        <di:waypoint x="2210" y="760" />
-        <di:waypoint x="2336" y="651" />
+      <bpmndi:BPMNEdge id="Flow_183ayoj_di" bpmnElement="Flow_183ayoj">
+        <di:waypoint x="560" y="1590" />
+        <di:waypoint x="320" y="1590" />
+        <di:waypoint x="320" y="580" />
+        <di:waypoint x="380" y="580" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="156" y="538" width="36" height="36" />
@@ -1155,9 +1162,6 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="517" y="769" width="78" height="14" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_14o40c8_di" bpmnElement="ServiceTask_14o40c8">
-        <dc:Bounds x="560" y="1855" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_1r69osa_di" bpmnElement="UserTask_1r69osa">
         <dc:Bounds x="763" y="1855" width="100" height="80" />
@@ -1372,10 +1376,9 @@
       <bpmndi:BPMNShape id="ServiceTask_0s2gjg1_di" bpmnElement="Service_SetBusAreaStatusConfirm">
         <dc:Bounds x="1300" y="833" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_10f25gy_di" bpmnElement="SequenceFlow_10f25gy">
-        <di:waypoint x="1400" y="873" />
-        <di:waypoint x="1445" y="873" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_00opwf9_di" bpmnElement="UpdateEnquiryReason_Activity">
+        <dc:Bounds x="560" y="1550" width="100" height="80" />
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/processes/MPAM_TRIAGE_ESCALATE.bpmn
+++ b/src/main/resources/processes/MPAM_TRIAGE_ESCALATE.bpmn
@@ -13,6 +13,7 @@
       <bpmn:incoming>SequenceFlow_1m70lbc</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_19l3zia</bpmn:incoming>
       <bpmn:incoming>Flow_01s6las</bpmn:incoming>
+      <bpmn:incoming>Flow_1vct2cg</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1l0z7z9</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:userTask id="Validate_UserInput" name="Validate User Input">
@@ -105,6 +106,7 @@
       <bpmn:outgoing>SequenceFlow_0ixi7ye</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0mflb41</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1e2t09x</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1dxk4p3</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="SequenceFlow_0ixi7ye" sourceRef="ExclusiveGateway_0o5wz31" targetRef="ExclusiveGateway_0qsaemy">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
@@ -403,6 +405,18 @@
     <bpmn:sequenceFlow id="Flow_01s6las" sourceRef="Gateway_0eqa8f5" targetRef="Screen_UserInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:callActivity id="Activity_0l0ilnw" name="Update Enquiry Reason" calledElement="MPAM_UPDATE_ENQUIRY_SUBJECT_REASON">
+      <bpmn:extensionElements>
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in source="CaseUUID" target="CaseUUID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1dxk4p3</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vct2cg</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_1dxk4p3" name="UpdateEnquirySubject" sourceRef="ExclusiveGateway_0o5wz31" targetRef="Activity_0l0ilnw">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "UpdateEnquirySubject"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1vct2cg" sourceRef="Activity_0l0ilnw" targetRef="Screen_UserInput" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_TRIAGE_ESCALATE">

--- a/src/main/resources/processes/MPAM_TRIAGE_ESCALATE.bpmn
+++ b/src/main/resources/processes/MPAM_TRIAGE_ESCALATE.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0vlcfuo" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0vlcfuo" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
   <bpmn:process id="MPAM_TRIAGE_ESCALATE" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_0ioswxl</bpmn:outgoing>
@@ -778,6 +778,19 @@
           <dc:Bounds x="568" y="606" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dxk4p3_di" bpmnElement="Flow_1dxk4p3">
+        <di:waypoint x="580" y="815" />
+        <di:waypoint x="580" y="2100" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="486" y="2036" width="87" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vct2cg_di" bpmnElement="Flow_1vct2cg">
+        <di:waypoint x="530" y="2140" />
+        <di:waypoint x="280" y="2140" />
+        <di:waypoint x="280" y="627" />
+        <di:waypoint x="350" y="627" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="609" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -957,6 +970,9 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="834" y="361" width="78" height="14" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0l0ilnw_di" bpmnElement="Activity_0l0ilnw">
+        <dc:Bounds x="530" y="2100" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMCommonTests.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMCommonTests.java
@@ -35,4 +35,22 @@ public class MPAMCommonTests {
         verify(processScenario).hasFinished(endEvent);
     }
 
+    void whenUpdateEnquirySubjectReason_thenShouldContinue(String mpamFlow, String coreVariable, String endEvent,
+                                                                     ProcessScenario processScenario, BpmnService bpmnService) {
+        when(processScenario.waitsAtUserTask("Validate_UserInput"))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "UpdateEnquirySubject")))
+                .thenReturn(task -> task.complete(withVariables(
+                    "valid", true,
+                    coreVariable, "TEST_COMPLETE",
+                        "DIRECTION", "FORWARD")));
+
+        Scenario.run(processScenario)
+                .startByKey(mpamFlow)
+                .execute();
+
+        verify(processScenario).hasFinished(endEvent);
+    }
+
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMTriage.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMTriage.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.hocs.workflow.processes;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.extension.mockito.ProcessExpressions;
 import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
 import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
 import org.camunda.bpm.scenario.ProcessScenario;
@@ -23,7 +24,10 @@ import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
-@Deployment(resources = "processes/MPAM_TRIAGE.bpmn")
+@Deployment(resources = {
+        "processes/MPAM_TRIAGE.bpmn",
+        "processes/MPAM/MPAM_UPDATE_ENQUIRY_SUBJECT_REASON.bpmn"
+})
 public class MPAMTriage extends MPAMCommonTests {
 
     @Rule
@@ -154,6 +158,15 @@ public class MPAMTriage extends MPAMCommonTests {
     public void whenTriageChangeBusinessArea_thenBusAreaStatusIsConfirmed() {
         whenChangeBusinessArea_thenBusAreaStatusIsConfirmed("MPAM_TRIAGE", "Service_UpdateTeamForTriage", "MPAM_TRIAGE", "EndEvent_MpamTriage",
                 processScenario, bpmnService);
+    }
+
+    @Test
+    public void whenTriageUpdateEnquiryReasonSubject_thenBusAreaStatusIsConfirmed() {
+        ProcessExpressions.registerCallActivityMock("MPAM_UPDATE_ENQUIRY_SUBJECT_REASON")
+                .deploy(rule);
+
+        whenUpdateEnquirySubjectReason_thenShouldContinue("MPAM_TRIAGE", "TriageOutcome",
+                "EndEvent_MpamTriage",  processScenario, bpmnService);
     }
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMTriageEscalate.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMTriageEscalate.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.hocs.workflow.processes;
 import org.camunda.bpm.engine.test.Deployment;
 import org.camunda.bpm.engine.test.ProcessEngineRule;
 import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.extension.mockito.ProcessExpressions;
 import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
 import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
 import org.camunda.bpm.scenario.ProcessScenario;
@@ -24,7 +25,10 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
-@Deployment(resources = "processes/MPAM_TRIAGE_ESCALATE.bpmn")
+@Deployment(resources = {
+        "processes/MPAM_TRIAGE_ESCALATE.bpmn",
+        "processes/MPAM/MPAM_UPDATE_ENQUIRY_SUBJECT_REASON.bpmn"
+})
 public class MPAMTriageEscalate extends MPAMCommonTests {
 
     @Rule
@@ -205,6 +209,17 @@ public class MPAMTriageEscalate extends MPAMCommonTests {
     public void whenTriageEscalatedChangeBusinessArea_thenBusAreaStatusIsConfirmed() {
         whenChangeBusinessArea_thenBusAreaStatusIsConfirmed("MPAM_TRIAGE_ESCALATE", "Service_UpdateTeamForTriage", "MPAM_TRIAGE", "EndEvent_MpamTriageEscalate",
                 processScenario, bpmnService);
+    }
+
+    @Test
+    public void whenTriageUpdateEnquiryReasonSubject_thenBusAreaStatusIsConfirmed() {
+        ProcessExpressions.registerCallActivityMock("MPAM_UPDATE_ENQUIRY_SUBJECT_REASON")
+                .deploy(rule);
+
+        whenUpdateEnquirySubjectReason_thenShouldContinue("MPAM_TRIAGE_ESCALATE", "TriageEscalateOutcome",
+                "EndEvent_MpamTriageEscalate",  processScenario, bpmnService);
+
+        verify(processScenario).hasCompleted("ServiceTask_0rvjsky");
     }
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/mpam/MPAMUpdateEnquirySubjectReason.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/mpam/MPAMUpdateEnquirySubjectReason.java
@@ -1,0 +1,158 @@
+package uk.gov.digital.ho.hocs.workflow.processes.mpam;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.extension.mockito.ProcessExpressions;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.camunda.bpm.scenario.ProcessScenario;
+import org.camunda.bpm.scenario.Scenario;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+import uk.gov.digital.ho.hocs.workflow.processes.MPAMCommonTests;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.withVariables;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+@Deployment(resources = "processes/MPAM/MPAM_UPDATE_ENQUIRY_SUBJECT_REASON.bpmn")
+public class MPAMUpdateEnquirySubjectReason {
+
+    private static final String MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_BPMN = "MPAM_UPDATE_ENQUIRY_SUBJECT_REASON";
+
+    private static final String MPAM_ENQUIRY_SUBJECT_ACTIVITY = "MpamEnquirySubject_Activity";
+    private static final String MPAM_ENQUIRY_REASON_ACTIVITY = "MpamEnquiryReason_Activity";
+    private static final String CLEAR_TEMP_ENQUIRY_SUBJECT_ACTIVITY = "ClearTempEnquirySubject_Activity";
+    private static final String CLEAR_TEMP_ENQUIRY_SUBJECT_REASON_ACTIVITY = "ClearTempEnquirySubjectReason_Activity";
+    private static final String UPDATE_ENQUIRY_SUBJECT_REASON_ACTIVITY = "UpdateEnquirySubjectReason_Activity";
+
+    private static final String MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_END_EVENT = "MpamUpdateEnquirySubjectReason_EndEvent";
+
+    @Rule
+    @ClassRule
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
+            .assertClassCoverageAtLeast(1d)
+            .build();
+
+    @Rule
+    public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+
+    @Mock
+    BpmnService bpmnService;
+
+    @Mock
+    private ProcessScenario processScenario;
+
+    @Before
+    public void setup() {
+        Mocks.register("bpmnService", bpmnService);
+    }
+
+    @Test
+    public void whenEnquirySubjectBackPressed_thenClearCalledAndEndEvent() {
+        when(processScenario.waitsAtUserTask(MPAM_ENQUIRY_SUBJECT_ACTIVITY))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "BACKWARD")));
+
+        Scenario.run(processScenario)
+                .startByKey(MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_BPMN)
+                .execute();
+
+        verify(processScenario).hasCompleted(MPAM_ENQUIRY_SUBJECT_ACTIVITY);
+        verify(processScenario).hasCompleted(CLEAR_TEMP_ENQUIRY_SUBJECT_ACTIVITY);
+        verify(processScenario).hasFinished(MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_END_EVENT);
+    }
+
+    @Test
+    public void whenEnquirySubjectSubmittedInvalid_thenReloadsActivity() {
+        when(processScenario.waitsAtUserTask(MPAM_ENQUIRY_SUBJECT_ACTIVITY))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "FORWARD",
+                        "valid", "false")))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "BACKWARD")));
+
+        Scenario.run(processScenario)
+                .startByKey(MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_BPMN)
+                .execute();
+
+        verify(processScenario, times(2)).hasCompleted(MPAM_ENQUIRY_SUBJECT_ACTIVITY);
+    }
+
+    @Test
+    public void whenEnquiryReasonBackPressed_thenClearCalledAndEndEvent() {
+        when(processScenario.waitsAtUserTask(MPAM_ENQUIRY_SUBJECT_ACTIVITY))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "FORWARD",
+                        "valid", "true")));
+
+        when(processScenario.waitsAtUserTask(MPAM_ENQUIRY_REASON_ACTIVITY))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "BACKWARD")));
+
+        Scenario.run(processScenario)
+                .startByKey(MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_BPMN)
+                .execute();
+
+        verify(processScenario).hasCompleted(MPAM_ENQUIRY_SUBJECT_ACTIVITY);
+        verify(processScenario).hasCompleted(MPAM_ENQUIRY_REASON_ACTIVITY);
+        verify(processScenario).hasCompleted(CLEAR_TEMP_ENQUIRY_SUBJECT_REASON_ACTIVITY);
+        verify(processScenario).hasFinished(MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_END_EVENT);
+    }
+
+    @Test
+    public void whenEnquiryReasonInvalidSubmitted_thenReloadActivity() {
+        when(processScenario.waitsAtUserTask(MPAM_ENQUIRY_SUBJECT_ACTIVITY))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "FORWARD",
+                        "valid", "true")));
+
+        when(processScenario.waitsAtUserTask(MPAM_ENQUIRY_REASON_ACTIVITY))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "FORWARD",
+                        "valid", "false")))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "BACKWARD")));
+
+        Scenario.run(processScenario)
+                .startByKey(MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_BPMN)
+                .execute();
+
+        verify(processScenario).hasCompleted(MPAM_ENQUIRY_SUBJECT_ACTIVITY);
+        verify(processScenario, times(2)).hasCompleted(MPAM_ENQUIRY_REASON_ACTIVITY);
+    }
+
+
+    @Test
+    public void happyPath() {
+        when(processScenario.waitsAtUserTask(MPAM_ENQUIRY_SUBJECT_ACTIVITY))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "FORWARD",
+                        "valid", "true")));
+
+        when(processScenario.waitsAtUserTask(MPAM_ENQUIRY_REASON_ACTIVITY))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "FORWARD",
+                        "valid", "true")));
+
+        Scenario.run(processScenario)
+                .startByKey(MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_BPMN)
+                .execute();
+
+        verify(processScenario).hasCompleted(MPAM_ENQUIRY_SUBJECT_ACTIVITY);
+        verify(processScenario).hasCompleted(MPAM_ENQUIRY_REASON_ACTIVITY);
+        verify(processScenario).hasCompleted(UPDATE_ENQUIRY_SUBJECT_REASON_ACTIVITY);
+        verify(processScenario).hasCompleted(CLEAR_TEMP_ENQUIRY_SUBJECT_REASON_ACTIVITY);
+        verify(processScenario).hasCompleted(MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_END_EVENT);
+    }
+
+}


### PR DESCRIPTION
This change encompasses the following changes: 

- Now load all bpmn files in the processes folder and any subfolder. Allowing for seperation of workflows under business unit.
- Pull out the Update Enquiry Subject and Reason from MPAM Triage and put into it's own workflow. This is then reused in the MPAM Triage Esclate.