### PR TITLE
HOCS-2915: wipe override draft team

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
@@ -173,6 +173,10 @@ public class BpmnService {
 
         log.info("Writing draft team with {}", draftingUUIDString);
         TeamDto draftingTeam = infoClient.getTeam(UUID.fromString(draftingUUIDString));
+
+        teamsForTopic.put("OverrideDraftingTeamUUID", "");
+        teamsForTopic.put("OverrideDraftingTeamName", "");
+
         teamsForTopic.put("DraftingTeamUUID", draftingTeam.getUuid().toString());
         teamsForTopic.put("DraftingTeamName", draftingTeam.getDisplayName());
 

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/BpmnServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/BpmnServiceTest.java
@@ -90,6 +90,8 @@ public class BpmnServiceTest {
         String teamName = "Team1";
         TeamDto team = new TeamDto(teamName, draftingString, true, new HashSet<>());
         Map<String, String> teamsForTopic = new HashMap<>();
+        teamsForTopic.put("OverrideDraftingTeamUUID", "");
+        teamsForTopic.put("OverrideDraftingTeamName", "");
         teamsForTopic.put("DraftingTeamUUID", draftingString.toString());
         teamsForTopic.put("DraftingTeamName", teamName);
 


### PR DESCRIPTION
When a case has an override team set and is then later changed to a 
`FAQ Response` this override team is not wiped. This leads to the 
case being placed in an incorrect team. This change wipes the value 
of the `OverrideDraftingTeamUUID` and 
`OverrideDraftingTeamName`.