### PR TITLE
HOCS-2975: add update case value endpoint

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowResource.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
 import uk.gov.digital.ho.hocs.workflow.api.dto.*;
 import uk.gov.digital.ho.hocs.workflow.application.RequestData;
 import uk.gov.digital.ho.hocs.workflow.security.AccessLevel;
@@ -24,9 +25,13 @@ class WorkflowResource {
 
     private WorkflowService workflowService;
 
+    private BpmnService bpmnService;
+
     @Autowired
-    public WorkflowResource(WorkflowService workflowService) {
+    public WorkflowResource(WorkflowService workflowService,
+                            BpmnService bpmnService) {
         this.workflowService = workflowService;
+        this.bpmnService = bpmnService;
     }
 
     @Authorised(accessLevel = AccessLevel.OWNER)
@@ -84,6 +89,14 @@ class WorkflowResource {
     public ResponseEntity<GetCaseDetailsResponse> getReadOnlyCaseDetails(@PathVariable UUID caseUUID) {
         GetCaseDetailsResponse response = workflowService.getReadOnlyCaseDetails(caseUUID);
         return ResponseEntity.ok(response);
+    }
+
+    @Authorised(accessLevel = AccessLevel.WRITE)
+    @PutMapping(value = "/case/{caseUUID}/stage/{stageUUID}/{variable}")
+    public ResponseEntity updateCaseValue(@PathVariable UUID caseUUID, @PathVariable UUID stageUUID,
+                        @PathVariable String variable, @RequestBody UpdateCaseValueRequest request) {
+        bpmnService.updateValue(caseUUID.toString(), stageUUID.toString(), variable, request.getValue());
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/api/dto/UpdateCaseValueRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/api/dto/UpdateCaseValueRequest.java
@@ -1,0 +1,19 @@
+package uk.gov.digital.ho.hocs.workflow.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class UpdateCaseValueRequest {
+
+    @JsonProperty("value")
+    private String value;
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowResourceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowResourceTest.java
@@ -6,6 +6,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.ResponseEntity;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
 import uk.gov.digital.ho.hocs.workflow.api.dto.*;
 import uk.gov.digital.ho.hocs.workflow.domain.model.forms.HocsCaseSchema;
 import uk.gov.digital.ho.hocs.workflow.domain.model.forms.HocsFormField;
@@ -23,11 +24,14 @@ public class WorkflowResourceTest {
     @Mock
     private WorkflowService workflowService;
 
+    @Mock
+    private BpmnService bpmnService;
+
     private WorkflowResource workflowResource;
 
     @Before
     public void beforeTest() {
-        workflowResource = new WorkflowResource(workflowService);
+        workflowResource = new WorkflowResource(workflowService, bpmnService);
     }
 
     @Test
@@ -218,6 +222,22 @@ public class WorkflowResourceTest {
 
         workflowResource.getReadOnlyCaseDetails(caseUUID);
 
+    }
+
+    @Test
+    public void updateCaseValue_shouldCallBpmnService() {
+        UUID caseUUID = UUID.randomUUID();
+        UUID stageUUID = UUID.randomUUID();
+        UpdateCaseValueRequest updateCaseValueRequest = new UpdateCaseValueRequest("TEST");
+
+        ResponseEntity result = workflowResource.updateCaseValue(caseUUID, stageUUID, "CaseworkTeamUUID", updateCaseValueRequest);
+
+        verify(bpmnService).updateValue(caseUUID.toString(), stageUUID.toString(), "CaseworkTeamUUID", updateCaseValueRequest.getValue());
+
+        assertThat(result).isNotNull();
+        assertThat(result.getStatusCodeValue()).isEqualTo(200);
+
+        verifyNoMoreInteractions(bpmnService);
     }
 
 


### PR DESCRIPTION
Currently when a team is moved outside a workflow, the internal 
representation of the case is not update-able. This change adds an 
endpoint that allows for the updating of the data. This endpoint is 
protected by the `@Authorised` annotation for users with write 
permissions.