### PR TITLE
HOCS-2762 remove on hold option

### DIFF
--- a/src/main/resources/processes/MTS.bpmn
+++ b/src/main/resources/processes/MTS.bpmn
@@ -19,47 +19,18 @@
         <camunda:out source="DataInputStatus" target="DataInputStatus" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_0tsx10b</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_1llf0ew</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_04q1t74</bpmn:outgoing>
+      <bpmn:outgoing>Flow_10f7vt3</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="SequenceFlow_0tsx10b" sourceRef="StartEvent_1" targetRef="CallActivity_14mwb9u" />
     <bpmn:endEvent id="EndEvent_0h34pj4" name="End Case">
       <bpmn:incoming>SequenceFlow_1tml3pn</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:serviceTask id="ServiceTask_1umfuu0" name="Complete Case" camunda:expression="${bpmnService.completeCase(execution.processBusinessKey)}">
-      <bpmn:incoming>SequenceFlow_0mtfju3</bpmn:incoming>
+      <bpmn:incoming>Flow_10f7vt3</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1tml3pn</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_1tml3pn" sourceRef="ServiceTask_1umfuu0" targetRef="EndEvent_0h34pj4" />
-    <bpmn:callActivity id="CallActivity_12tzv2l" name="On Hold" calledElement="STAGE">
-      <bpmn:extensionElements>
-        <camunda:in source="OnHoldUUID" target="StageUUID" />
-        <camunda:in sourceExpression="MTS_ON_HOLD" target="StageWorkFlow" />
-        <camunda:in businessKey="#{execution.processBusinessKey}" />
-        <camunda:in variables="all" />
-        <camunda:out source="StageUUID" target="OnHoldUUID" />
-        <camunda:out source="DateReceived" target="DateReceived" />
-        <camunda:in sourceExpression="MTS_ON_HOLD" target="StageType" />
-        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
-        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
-        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
-      </bpmn:extensionElements>
-      <bpmn:incoming>SequenceFlow_154al89</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_1llf0ew</bpmn:outgoing>
-    </bpmn:callActivity>
-    <bpmn:exclusiveGateway id="ExclusiveGateway_1ydhsrh">
-      <bpmn:incoming>SequenceFlow_04q1t74</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_154al89</bpmn:outgoing>
-      <bpmn:outgoing>SequenceFlow_0mtfju3</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_04q1t74" sourceRef="CallActivity_14mwb9u" targetRef="ExclusiveGateway_1ydhsrh" />
-    <bpmn:sequenceFlow id="SequenceFlow_154al89" sourceRef="ExclusiveGateway_1ydhsrh" targetRef="CallActivity_12tzv2l">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DataInputStatus == "On-Hold"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1llf0ew" sourceRef="CallActivity_12tzv2l" targetRef="CallActivity_14mwb9u" />
-    <bpmn:sequenceFlow id="SequenceFlow_0mtfju3" sourceRef="ExclusiveGateway_1ydhsrh" targetRef="ServiceTask_1umfuu0">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DataInputStatus == "Complete"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_10f7vt3" sourceRef="CallActivity_14mwb9u" targetRef="ServiceTask_1umfuu0" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MTS">

--- a/src/main/resources/processes/MTS.bpmn
+++ b/src/main/resources/processes/MTS.bpmn
@@ -34,6 +34,18 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MTS">
+      <bpmndi:BPMNEdge id="SequenceFlow_1tml3pn_di" bpmnElement="SequenceFlow_1tml3pn">
+        <di:waypoint x="590" y="99" />
+        <di:waypoint x="652" y="99" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0tsx10b_di" bpmnElement="SequenceFlow_0tsx10b">
+        <di:waypoint x="215" y="99" />
+        <di:waypoint x="309" y="99" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10f7vt3_di" bpmnElement="Flow_10f7vt3">
+        <di:waypoint x="409" y="99" />
+        <di:waypoint x="490" y="99" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="81" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -43,46 +55,15 @@
       <bpmndi:BPMNShape id="CallActivity_14mwb9u_di" bpmnElement="CallActivity_14mwb9u">
         <dc:Bounds x="309" y="59" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0tsx10b_di" bpmnElement="SequenceFlow_0tsx10b">
-        <di:waypoint x="215" y="99" />
-        <di:waypoint x="309" y="99" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_1umfuu0_di" bpmnElement="ServiceTask_1umfuu0">
+        <dc:Bounds x="490" y="59" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_0h34pj4">
-        <dc:Bounds x="992" y="81" width="36" height="36" />
+        <dc:Bounds x="652" y="81" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1037" y="92" width="49" height="14" />
+          <dc:Bounds x="697" y="92" width="49" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1umfuu0_di" bpmnElement="ServiceTask_1umfuu0">
-        <dc:Bounds x="797" y="59" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1tml3pn_di" bpmnElement="SequenceFlow_1tml3pn">
-        <di:waypoint x="897" y="99" />
-        <di:waypoint x="992" y="99" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="CallActivity_12tzv2l_di" bpmnElement="CallActivity_12tzv2l">
-        <dc:Bounds x="558" y="202" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1ydhsrh_di" bpmnElement="ExclusiveGateway_1ydhsrh" isMarkerVisible="true">
-        <dc:Bounds x="583" y="74" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_04q1t74_di" bpmnElement="SequenceFlow_04q1t74">
-        <di:waypoint x="409" y="99" />
-        <di:waypoint x="583" y="99" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_154al89_di" bpmnElement="SequenceFlow_154al89">
-        <di:waypoint x="608" y="124" />
-        <di:waypoint x="608" y="202" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1llf0ew_di" bpmnElement="SequenceFlow_1llf0ew">
-        <di:waypoint x="558" y="242" />
-        <di:waypoint x="359" y="242" />
-        <di:waypoint x="359" y="139" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0mtfju3_di" bpmnElement="SequenceFlow_0mtfju3">
-        <di:waypoint x="633" y="99" />
-        <di:waypoint x="797" y="99" />
-      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/processes/MTS_DATA_INPUT.bpmn
+++ b/src/main/resources/processes/MTS_DATA_INPUT.bpmn
@@ -6,7 +6,6 @@
     </bpmn:startEvent>
     <bpmn:serviceTask id="ServiceTask_1j88374" name="User Input" camunda:expression="MTS_DI_DETAILS" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_1ooqhw0</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_0nle2q6</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1yo7wrh</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0k2c1ig</bpmn:outgoing>
     </bpmn:serviceTask>
@@ -19,28 +18,17 @@
       <bpmn:outgoing>SequenceFlow_1ooqhw0</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0fvxoel</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:exclusiveGateway id="ExclusiveGateway_1gd6s5a" name="Pending?">
-      <bpmn:incoming>SequenceFlow_0fvxoel</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_0nle2q6</bpmn:outgoing>
-      <bpmn:outgoing>SequenceFlow_1nk9vk0</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="SequenceFlow_1ooqhw0" name="false" sourceRef="ExclusiveGateway_1rs7n2x" targetRef="ServiceTask_1j88374">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0nle2q6" sourceRef="ExclusiveGateway_1gd6s5a" targetRef="ServiceTask_1j88374">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DataInputStatus == "Pending"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_0k2c1ig" sourceRef="ServiceTask_1j88374" targetRef="UserTask_0uu8g19" />
     <bpmn:sequenceFlow id="SequenceFlow_0tmj2c4" sourceRef="UserTask_0uu8g19" targetRef="ExclusiveGateway_02rbjm4" />
-    <bpmn:sequenceFlow id="SequenceFlow_0fvxoel" sourceRef="ExclusiveGateway_1rs7n2x" targetRef="ExclusiveGateway_1gd6s5a">
+    <bpmn:sequenceFlow id="SequenceFlow_0fvxoel" sourceRef="ExclusiveGateway_1rs7n2x" targetRef="EndEvent_168q5al">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:endEvent id="EndEvent_168q5al">
-      <bpmn:incoming>SequenceFlow_1nk9vk0</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_0fvxoel</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_1nk9vk0" sourceRef="ExclusiveGateway_1gd6s5a" targetRef="EndEvent_168q5al">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DataInputStatus != "Pending"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
     <bpmn:serviceTask id="ServiceTask_1j8d7km" name="Set Primary Correspondent" camunda:expression="MTS_DI_CORRESPONDENTS" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_0j8lbo8</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_149rgmi</bpmn:incoming>

--- a/src/main/resources/processes/MTS_DATA_INPUT.bpmn
+++ b/src/main/resources/processes/MTS_DATA_INPUT.bpmn
@@ -72,6 +72,66 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MTS_DATA_INPUT">
+      <bpmndi:BPMNEdge id="SequenceFlow_10i25vz_di" bpmnElement="SequenceFlow_10i25vz">
+        <di:waypoint x="1211" y="389" />
+        <di:waypoint x="1211" y="465" />
+        <di:waypoint x="276" y="465" />
+        <di:waypoint x="276" y="121" />
+        <di:waypoint x="333" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1tzsa7b_di" bpmnElement="SequenceFlow_1tzsa7b">
+        <di:waypoint x="1211" y="339" />
+        <di:waypoint x="1211" y="309" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1yo7wrh_di" bpmnElement="SequenceFlow_1yo7wrh">
+        <di:waypoint x="766" y="201" />
+        <di:waypoint x="981" y="201" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_149rgmi_di" bpmnElement="SequenceFlow_149rgmi">
+        <di:waypoint x="215" y="121" />
+        <di:waypoint x="333" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1g2isf7_di" bpmnElement="SequenceFlow_1g2isf7">
+        <di:waypoint x="588" y="201" />
+        <di:waypoint x="666" y="201" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1nl5g6h_di" bpmnElement="SequenceFlow_1nl5g6h">
+        <di:waypoint x="433" y="290" />
+        <di:waypoint x="563" y="290" />
+        <di:waypoint x="563" y="226" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1alv81y_di" bpmnElement="SequenceFlow_1alv81y">
+        <di:waypoint x="383" y="161" />
+        <di:waypoint x="383" y="251" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0j8lbo8_di" bpmnElement="SequenceFlow_0j8lbo8">
+        <di:waypoint x="563" y="176" />
+        <di:waypoint x="563" y="121" />
+        <di:waypoint x="433" y="121" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="551" y="100.5" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0fvxoel_di" bpmnElement="SequenceFlow_0fvxoel">
+        <di:waypoint x="1236" y="284" />
+        <di:waypoint x="1332" y="284" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0tmj2c4_di" bpmnElement="SequenceFlow_0tmj2c4">
+        <di:waypoint x="1081" y="364" />
+        <di:waypoint x="1186" y="364" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0k2c1ig_di" bpmnElement="SequenceFlow_0k2c1ig">
+        <di:waypoint x="1031" y="241" />
+        <di:waypoint x="1031" y="324" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ooqhw0_di" bpmnElement="SequenceFlow_1ooqhw0">
+        <di:waypoint x="1211" y="259" />
+        <di:waypoint x="1211" y="201" />
+        <di:waypoint x="1081" y="201" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1199" y="180" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="103" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -84,44 +144,6 @@
       <bpmndi:BPMNShape id="ExclusiveGateway_1rs7n2x_di" bpmnElement="ExclusiveGateway_1rs7n2x" isMarkerVisible="true">
         <dc:Bounds x="1186" y="259" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1gd6s5a_di" bpmnElement="ExclusiveGateway_1gd6s5a" isMarkerVisible="true">
-        <dc:Bounds x="1296" y="259" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1298" y="316" width="47" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1ooqhw0_di" bpmnElement="SequenceFlow_1ooqhw0">
-        <di:waypoint x="1211" y="259" />
-        <di:waypoint x="1211" y="201" />
-        <di:waypoint x="1081" y="201" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1199" y="180" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0nle2q6_di" bpmnElement="SequenceFlow_0nle2q6">
-        <di:waypoint x="1321" y="259" />
-        <di:waypoint x="1321" y="201" />
-        <di:waypoint x="1081" y="201" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0k2c1ig_di" bpmnElement="SequenceFlow_0k2c1ig">
-        <di:waypoint x="1031" y="241" />
-        <di:waypoint x="1031" y="324" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0tmj2c4_di" bpmnElement="SequenceFlow_0tmj2c4">
-        <di:waypoint x="1081" y="364" />
-        <di:waypoint x="1186" y="364" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0fvxoel_di" bpmnElement="SequenceFlow_0fvxoel">
-        <di:waypoint x="1236" y="284" />
-        <di:waypoint x="1296" y="284" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="EndEvent_168q5al_di" bpmnElement="EndEvent_168q5al">
-        <dc:Bounds x="1494" y="266" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1nk9vk0_di" bpmnElement="SequenceFlow_1nk9vk0">
-        <di:waypoint x="1346" y="284" />
-        <di:waypoint x="1494" y="284" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ServiceTask_1j8d7km_di" bpmnElement="ServiceTask_1j8d7km">
         <dc:Bounds x="333" y="81" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -134,52 +156,15 @@
       <bpmndi:BPMNShape id="ServiceTask_1y5iqza_di" bpmnElement="ServiceTask_1y5iqza">
         <dc:Bounds x="666" y="161" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_0j8lbo8_di" bpmnElement="SequenceFlow_0j8lbo8">
-        <di:waypoint x="563" y="176" />
-        <di:waypoint x="563" y="121" />
-        <di:waypoint x="433" y="121" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="551" y="100.5" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1alv81y_di" bpmnElement="SequenceFlow_1alv81y">
-        <di:waypoint x="383" y="161" />
-        <di:waypoint x="383" y="251" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1nl5g6h_di" bpmnElement="SequenceFlow_1nl5g6h">
-        <di:waypoint x="433" y="290" />
-        <di:waypoint x="563" y="290" />
-        <di:waypoint x="563" y="226" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1g2isf7_di" bpmnElement="SequenceFlow_1g2isf7">
-        <di:waypoint x="588" y="201" />
-        <di:waypoint x="666" y="201" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_149rgmi_di" bpmnElement="SequenceFlow_149rgmi">
-        <di:waypoint x="215" y="121" />
-        <di:waypoint x="333" y="121" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1yo7wrh_di" bpmnElement="SequenceFlow_1yo7wrh">
-        <di:waypoint x="766" y="201" />
-        <di:waypoint x="981" y="201" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="ExclusiveGateway_02rbjm4_di" bpmnElement="ExclusiveGateway_02rbjm4" isMarkerVisible="true">
         <dc:Bounds x="1186" y="339" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1246" y="357" width="50" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="SequenceFlow_1tzsa7b_di" bpmnElement="SequenceFlow_1tzsa7b">
-        <di:waypoint x="1211" y="339" />
-        <di:waypoint x="1211" y="309" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_10i25vz_di" bpmnElement="SequenceFlow_10i25vz">
-        <di:waypoint x="1211" y="389" />
-        <di:waypoint x="1211" y="465" />
-        <di:waypoint x="276" y="465" />
-        <di:waypoint x="276" y="121" />
-        <di:waypoint x="333" y="121" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_168q5al_di" bpmnElement="EndEvent_168q5al">
+        <dc:Bounds x="1332" y="266" width="36" height="36" />
+      </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/mts/MTS.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/mts/MTS.java
@@ -1,0 +1,73 @@
+package uk.gov.digital.ho.hocs.workflow.processes.mts;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.extension.mockito.ProcessExpressions;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.camunda.bpm.scenario.ProcessScenario;
+import org.camunda.bpm.scenario.Scenario;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+import uk.gov.digital.ho.hocs.workflow.util.CallActivityReturnVariable;
+import uk.gov.digital.ho.hocs.workflow.util.ExecutionVariableSequence;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+@Deployment(resources = {
+        "processes/MTS.bpmn",
+        "processes/MTS_DATA_INPUT.bpmn",
+        "processes/STAGE.bpmn"
+})
+public class MTS {
+
+    public static final String DATA_INPUT_CALL_ACTIVITY = "CallActivity_14mwb9u";
+
+    public static final String COMPLETE_CASE_SERVICE_TASK = "ServiceTask_1umfuu0";
+
+    public static final String END_EVENT = "EndEvent_0h34pj4";
+
+    @Rule
+    @ClassRule
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
+            .build();
+
+    @Mock
+    BpmnService bpmnService;
+
+    @Mock
+    private ProcessScenario mtsProcess;
+
+    @Before
+    public void defaultScenario() {
+        Mocks.register("bpmnService", bpmnService);
+
+        ProcessExpressions.registerCallActivityMock("MTS_DATA_INPUT")
+                .deploy(rule);
+    }
+
+    @Test
+    public void happyPath() {
+        Scenario.run(mtsProcess)
+                .startByKey("MTS")
+                .execute();
+
+        verify(mtsProcess)
+                .hasCompleted(DATA_INPUT_CALL_ACTIVITY);
+
+        verify(mtsProcess)
+                .hasCompleted(COMPLETE_CASE_SERVICE_TASK);
+
+        verify(mtsProcess).hasFinished(END_EVENT);
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/mts/MTS_DATA_INPUT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/mts/MTS_DATA_INPUT.java
@@ -1,0 +1,146 @@
+package uk.gov.digital.ho.hocs.workflow.processes.mts;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.extension.mockito.ProcessExpressions;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.camunda.bpm.scenario.ProcessScenario;
+import org.camunda.bpm.scenario.Scenario;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.withVariables;
+import static org.mockito.Mockito.*;
+
+@RunWith(MockitoJUnitRunner.class)
+@Deployment(resources = "processes/MTS_DATA_INPUT.bpmn")
+public class MTS_DATA_INPUT {
+
+    public static final String SET_PRIMARY_CORRESPONDENT_SCREEN = "ServiceTask_1j8d7km";
+    public static final String SET_PRIMARY_CORRESPONDENT_USER_TASK = "UserTask_1bx67tn";
+
+    public static final String MTS_DI_DETAILS_SCREEN = "ServiceTask_1j88374";
+    public static final String MTS_DI_DETAILS_USER_TASK = "UserTask_0uu8g19";
+
+    public static final String UPDATE_PRIMARY_CORRESPONDENT_SERVICE_TASK = "ServiceTask_1y5iqza";
+
+    public static final String END_EVENT = "EndEvent_168q5al";
+
+    @Rule
+    @ClassRule
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
+            .build();
+
+    @Mock
+    BpmnService bpmnService;
+
+    @Mock
+    private ProcessScenario mtsProcess;
+
+    @Before
+    public void defaultScenario() {
+        Mocks.register("bpmnService", bpmnService);
+
+        when(mtsProcess.waitsAtUserTask(SET_PRIMARY_CORRESPONDENT_USER_TASK))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true)));
+
+        when(mtsProcess.waitsAtUserTask(MTS_DI_DETAILS_USER_TASK))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "FORWARD")));
+    }
+
+    @Test
+    public void happyPath() {
+        Scenario.run(mtsProcess)
+                .startByKey("MTS_DATA_INPUT")
+                .execute();
+
+        verify(mtsProcess)
+                .hasCompleted(SET_PRIMARY_CORRESPONDENT_SCREEN);
+        verify(mtsProcess)
+                .hasCompleted(UPDATE_PRIMARY_CORRESPONDENT_SERVICE_TASK);
+        verify(mtsProcess)
+                .hasCompleted(MTS_DI_DETAILS_SCREEN);
+
+        verify(mtsProcess).hasFinished(END_EVENT);
+    }
+
+    @Test
+    public void whenInvalidPrimaryCorrespondentScreen_RetriesScreen() {
+        when(mtsProcess.waitsAtUserTask(SET_PRIMARY_CORRESPONDENT_USER_TASK))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", false)))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true)));
+
+        Scenario.run(mtsProcess)
+                .startByKey("MTS_DATA_INPUT")
+                .execute();
+
+        verify(mtsProcess, times(2))
+                .hasCompleted(SET_PRIMARY_CORRESPONDENT_SCREEN);
+        verify(mtsProcess)
+                .hasCompleted(UPDATE_PRIMARY_CORRESPONDENT_SERVICE_TASK);
+        verify(mtsProcess)
+                .hasCompleted(MTS_DI_DETAILS_SCREEN);
+
+        verify(mtsProcess).hasFinished(END_EVENT);
+    }
+
+    @Test
+    public void whenInvalidDateInputScreen_RetriesScreen() {
+        when(mtsProcess.waitsAtUserTask(MTS_DI_DETAILS_USER_TASK))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", false,
+                        "DIRECTION", "FORWARD")))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "FORWARD")));
+
+        Scenario.run(mtsProcess)
+                .startByKey("MTS_DATA_INPUT")
+                .execute();
+
+        verify(mtsProcess)
+                .hasCompleted(SET_PRIMARY_CORRESPONDENT_SCREEN);
+        verify(mtsProcess)
+                .hasCompleted(UPDATE_PRIMARY_CORRESPONDENT_SERVICE_TASK);
+        verify(mtsProcess, times(2))
+                .hasCompleted(MTS_DI_DETAILS_SCREEN);
+
+        verify(mtsProcess).hasFinished(END_EVENT);
+    }
+
+    @Test
+    public void whenBackwardDateInputScreen_GoesBack() {
+        when(mtsProcess.waitsAtUserTask(MTS_DI_DETAILS_USER_TASK))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "BACKWARD")))
+                .thenReturn(task -> task.complete(withVariables(
+                        "valid", true,
+                        "DIRECTION", "FORWARD")));
+
+        Scenario.run(mtsProcess)
+                .startByKey("MTS_DATA_INPUT")
+                .execute();
+
+        verify(mtsProcess, times(2))
+                .hasCompleted(SET_PRIMARY_CORRESPONDENT_SCREEN);
+        verify(mtsProcess, times(2))
+                .hasCompleted(UPDATE_PRIMARY_CORRESPONDENT_SERVICE_TASK);
+        verify(mtsProcess, times(2))
+                .hasCompleted(MTS_DI_DETAILS_SCREEN);
+
+        verify(mtsProcess).hasFinished(END_EVENT);
+    }
+}


### PR DESCRIPTION
For new MTS cases we no longer want the ability to put the case on 
hold. This changes works in conjunction with the data change that 
results in action item no longer existing that can put a case on hold.

We no longer allow the user to save changes as pending, so new 
cases should not have this option available on the diagram.