### PR TITLE
HOCS-3064: improve allocation notes by adding additional information

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
@@ -328,7 +328,6 @@ public class BpmnService {
      * @param stageUUIDString
      * @param allocationNote the content of the allocation note
      * @param allocationNoteType The type of allocation note, usually REJECT or ALLOCATE
-     * @param oldTeamUUID The uuid of the team that created the allocation request
      * @param newTeamUUID The destination of the allocation
      * @param allocationStageUUID The stage at which the allocation request was made
      */
@@ -339,9 +338,9 @@ public class BpmnService {
         StageTypeDto stageTypeDto = infoClient.getAllStageTypes().stream().filter(st -> st.getType().equals(caseworkStageType)).findFirst().get();
         if (allocationNoteType.equals("ALLOCATE")){
             String newTeamName = infoClient.getTeam(UUID.fromString(newTeamUUID)).getDisplayName();
-            allocationNote = oldTeamName + " allocated case to " + newTeamName + " at " + stageTypeDto.getDisplayName() + " Stage: " + allocationNote;
+            allocationNote = oldTeamName + " allocated case to " + newTeamName + " at " + stageTypeDto.getDisplayName() + " stage: " + allocationNote;
         } else {
-            allocationNote = oldTeamName + " rejected case at " + stageTypeDto.getDisplayName() + "Stage: " + allocationNote;
+            allocationNote = oldTeamName + " rejected case at " + stageTypeDto.getDisplayName() + " stage: " + allocationNote;
         }
 
         log.debug("######## Save Allocation Note ########");

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
@@ -11,6 +11,7 @@ import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.CaseworkClient;
 import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.dto.GetCorrespondentResponse;
 import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.dto.GetCorrespondentsResponse;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.InfoClient;
+import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.StageTypeDto;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.TeamDto;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.UserDto;
 import uk.gov.digital.ho.hocs.workflow.domain.exception.ApplicationExceptions;
@@ -316,6 +317,33 @@ public class BpmnService {
     }
 
     public void updateAllocationNote(String caseUUIDString, String stageUUIDString, String allocationNote, String allocationNoteType) {
+        log.debug("######## Save Allocation Note ########");
+        caseworkClient.createCaseNote(UUID.fromString(caseUUIDString), allocationNoteType, allocationNote);
+        log.info("Adding Casenote to Case: {}", caseUUIDString);
+    }
+
+    /**
+     *
+     * @param caseUUIDString The UUID string for the case that is being updated
+     * @param stageUUIDString
+     * @param allocationNote the content of the allocation note
+     * @param allocationNoteType The type of allocation note, usually REJECT or ALLOCATE
+     * @param oldTeamUUID The uuid of the team that created the allocation request
+     * @param newTeamUUID The destination of the allocation
+     * @param allocationStageUUID The stage at which the allocation request was made
+     */
+    public void updateAllocationNoteWithDetails(String caseUUIDString, String stageUUIDString, String allocationNote, String allocationNoteType,
+                                                String newTeamUUID, String allocationStageUUID ) {
+        String oldTeamName =  infoClient.getTeam(caseworkClient.getStageTeam(UUID.fromString(caseUUIDString), UUID.fromString(allocationStageUUID))).getDisplayName();
+        String caseworkStageType = caseworkClient.getStageType(UUID.fromString(caseUUIDString), UUID.fromString(allocationStageUUID));
+        StageTypeDto stageTypeDto = infoClient.getAllStageTypes().stream().filter(st -> st.getType().equals(caseworkStageType)).findFirst().get();
+        if (allocationNoteType.equals("ALLOCATE")){
+            String newTeamName = infoClient.getTeam(UUID.fromString(newTeamUUID)).getDisplayName();
+            allocationNote = oldTeamName + " allocated case to " + newTeamName + " at " + stageTypeDto.getDisplayName() + " Stage: " + allocationNote;
+        } else {
+            allocationNote = oldTeamName + " rejected case at " + stageTypeDto.getDisplayName() + "Stage: " + allocationNote;
+        }
+
         log.debug("######## Save Allocation Note ########");
         caseworkClient.createCaseNote(UUID.fromString(caseUUIDString), allocationNoteType, allocationNote);
         log.info("Adding Casenote to Case: {}", caseUUIDString);

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/client/caseworkclient/CaseworkClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/client/caseworkclient/CaseworkClient.java
@@ -151,6 +151,12 @@ public class CaseworkClient {
         return response;
     }
 
+    public String getStageType(UUID caseUUID, UUID stageUUID) {
+        String response = restHelper.get(serviceBaseURL, String.format("/case/%s/stage/%s/type", caseUUID, stageUUID), String.class);
+        log.info("Got Stage Type: {} for Case: {}", stageUUID, caseUUID);
+        return response;
+    }
+
     public GetAllStagesForCaseResponse getAllStagesForCase(UUID caseUUID) {
         GetAllStagesForCaseResponse response = restHelper.get(
                 serviceBaseURL, String.format("/stage/case/%s", caseUUID), GetAllStagesForCaseResponse.class

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/client/infoclient/InfoClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/client/infoclient/InfoClient.java
@@ -14,6 +14,7 @@ import uk.gov.digital.ho.hocs.workflow.api.dto.CaseDataType;
 import uk.gov.digital.ho.hocs.workflow.api.dto.SchemaDto;
 import uk.gov.digital.ho.hocs.workflow.application.RestHelper;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.CaseDetailsFieldDto;
+import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.StageTypeDto;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.TeamDto;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.UserDto;
 
@@ -69,6 +70,21 @@ public class InfoClient {
         });
         log.info("Got {} teams", teams.size(), value(EVENT, INFO_CLIENT_GET_TEAMS_SUCCESS));
         return teams;
+    }
+
+    @Cacheable(value = "InfoClientGetStageType", unless = "#result == null", key = "#stageTypeUUID")
+    public StageTypeDto getStageType(UUID stageTypeUUID) {
+        StageTypeDto response = restHelper.get(serviceBaseURL, String.format("/stageType/%s", stageTypeUUID), StageTypeDto.class);
+        log.info("Got Stage Type stageTypeUID {}", response.getShortCode(), value(EVENT, INFO_CLIENT_GET_TEAM_SUCCESS));
+        return response;
+    }
+
+    @Cacheable(value = "InfoClientGetAllStageTypes", unless = "#result.size() == 0")
+    public Set<StageTypeDto> getAllStageTypes() {
+        Set<StageTypeDto> response = restHelper.get(serviceBaseURL,"/stageType",
+                new ParameterizedTypeReference<Set<StageTypeDto>>(){ });
+        log.info("Got {} Stage Types", response.size(), value(EVENT, INFO_CLIENT_GET_TEAM_SUCCESS));
+        return response;
     }
 
     @Cacheable(value = "InfoClientGetTeam", unless = "#result == null", key = "#teamUUID")

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/client/infoclient/dto/StageTypeDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/client/infoclient/dto/StageTypeDto.java
@@ -1,0 +1,38 @@
+package uk.gov.digital.ho.hocs.workflow.client.infoclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@NoArgsConstructor
+@Getter
+public class StageTypeDto implements Serializable {
+
+    //TODO: remove - used in UI
+    @JsonProperty("label")
+    private String label;
+
+    //TODO: remove - used in UI
+    @JsonProperty("value")
+    private String value;
+
+    @JsonProperty("displayName")
+    private String displayName;
+
+    @JsonProperty("shortCode")
+    private String shortCode;
+
+    @JsonProperty("type")
+    private String type;
+
+    public StageTypeDto(String label, String value, String displayName, String type, String shortCode)  {
+        this.label = label;
+        this.value = value;
+        this.displayName = displayName;
+        this.shortCode = shortCode;
+        this.type = type;
+    }
+
+}

--- a/src/main/resources/processes/FOI_ACCEPTANCE.bpmn
+++ b/src/main/resources/processes/FOI_ACCEPTANCE.bpmn
@@ -41,7 +41,7 @@
       <bpmn:incoming>case_rejected</bpmn:incoming>
       <bpmn:outgoing>Flow_19r0f4t</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="SAVE_ALLOCATION_NOTE" name="Save Allocation Note" camunda:expression="${bpmnService.updateAllocationNoteWithDetails(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;AllocationCaseNote&#34;), &#34;REJECT&#34;, execution.getVariable(&#34;AcceptanceTeam&#34;), execution.getVariable(&#34;StageUUID&#34;))}">
+    <bpmn:serviceTask id="SAVE_ALLOCATION_NOTE" name="Save Allocation Note" camunda:expression="${bpmnService.updateAllocationNoteWithDetails(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;NText&#34;), &#34;REJECT&#34;, execution.getVariable(&#34;AcceptanceTeam&#34;), execution.getVariable(&#34;StageUUID&#34;))}">
       <bpmn:incoming>Flow_19r0f4t</bpmn:incoming>
       <bpmn:outgoing>Flow_1unjlmz</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/src/main/resources/processes/FOI_ACCEPTANCE.bpmn
+++ b/src/main/resources/processes/FOI_ACCEPTANCE.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0yfhzfq" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0yfhzfq" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
   <bpmn:process id="FOI_ACCEPTANCE" isExecutable="true">
     <bpmn:startEvent id="START_FOI_ACCEPTANCE" name="Stage Stage">
       <bpmn:outgoing>Flow_0y329xm</bpmn:outgoing>
@@ -41,7 +41,7 @@
       <bpmn:incoming>case_rejected</bpmn:incoming>
       <bpmn:outgoing>Flow_19r0f4t</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="SAVE_ALLOCATION_NOTE" name="Save Allocation Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;NText&#34;), &#34;ALLOCATE&#34;)}">
+    <bpmn:serviceTask id="SAVE_ALLOCATION_NOTE" name="Save Allocation Note" camunda:expression="${bpmnService.updateAllocationNoteWithDetails(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;AllocationCaseNote&#34;), &#34;REJECT&#34;, execution.getVariable(&#34;AcceptanceTeam&#34;), execution.getVariable(&#34;StageUUID&#34;))}">
       <bpmn:incoming>Flow_19r0f4t</bpmn:incoming>
       <bpmn:outgoing>Flow_1unjlmz</bpmn:outgoing>
     </bpmn:serviceTask>
@@ -83,6 +83,10 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="FOI_ACCEPTANCE">
+      <bpmndi:BPMNEdge id="Flow_1r680pp_di" bpmnElement="Flow_1r680pp">
+        <di:waypoint x="920" y="280" />
+        <di:waypoint x="950" y="280" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1es0j8i_di" bpmnElement="Flow_1es0j8i">
         <di:waypoint x="1180" y="280" />
         <di:waypoint x="1222" y="280" />
@@ -152,10 +156,6 @@
         <di:waypoint x="653" y="280" />
         <di:waypoint x="715" y="280" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1r680pp_di" bpmnElement="Flow_1r680pp">
-        <di:waypoint x="920" y="280" />
-        <di:waypoint x="950" y="280" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="START_FOI_ACCEPTANCE">
         <dc:Bounds x="172" y="262" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -164,6 +164,18 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_118ky5k_di" bpmnElement="ACCEPT_OR_REJECT">
         <dc:Bounds x="553" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1p4d6iv_di" bpmnElement="END_FOI_ACCEPTANCE">
+        <dc:Bounds x="1222" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1215" y="305" width="52" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0li7pgk_di" bpmnElement="CHOOSE_DRAFT_TEAM">
+        <dc:Bounds x="950" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1bfgolq_di" bpmnElement="DEADLINE_PASSED">
+        <dc:Bounds x="553" y="400" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1ic873f_di" bpmnElement="CALCULATE_ACCEPTANCE_DEADLINE">
         <dc:Bounds x="396" y="240" width="100" height="80" />
@@ -186,23 +198,11 @@
           <dc:Bounds x="248" y="183" width="84" height="93" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1p4d6iv_di" bpmnElement="END_FOI_ACCEPTANCE">
-        <dc:Bounds x="1222" y="262" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1215" y="305" width="52" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0li7pgk_di" bpmnElement="CHOOSE_DRAFT_TEAM">
-        <dc:Bounds x="950" y="240" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1bfgolq_di" bpmnElement="DEADLINE_PASSED">
-        <dc:Bounds x="553" y="400" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_06r8uey_di" bpmnElement="ALLOCATE_TO_DRAFT_TEAM">
+        <dc:Bounds x="1080" y="240" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0oxvate_di" bpmnElement="SET_ACCEPTANCE_DATE">
         <dc:Bounds x="820" y="240" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_06r8uey_di" bpmnElement="ALLOCATE_TO_DRAFT_TEAM">
-        <dc:Bounds x="1080" y="240" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0bge9re_di" bpmnElement="Event_0flqj0g">
         <dc:Bounds x="585" y="302" width="36" height="36" />

--- a/src/main/resources/processes/FOI_ALLOCATION.bpmn
+++ b/src/main/resources/processes/FOI_ALLOCATION.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1xw86el" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.7.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1xw86el" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
   <bpmn:process id="FOI_ALLOCATION" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0qih8xd</bpmn:outgoing>
@@ -27,7 +27,7 @@
     <bpmn:sequenceFlow id="Flow_0q7sbi9" name="Backwards" sourceRef="Gateway_0pcjy2g" targetRef="Activity_0gpqsvz">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="Activity_0dt96yu" name="Save Allocation Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;AllocationCaseNote&#34;), &#34;ALLOCATE&#34;)}">
+    <bpmn:serviceTask id="Activity_0dt96yu" name="Save Allocation Note" camunda:expression="${bpmnService.updateAllocationNoteWithDetails(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;AllocationCaseNote&#34;), &#34;ALLOCATE&#34;, execution.getVariable(&#34;AcceptanceTeam&#34;), execution.getVariable(&#34;StageUUID&#34;))}">
       <bpmn:incoming>Flow_0of9txf</bpmn:incoming>
       <bpmn:outgoing>Flow_1mcj02n</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/src/main/resources/processes/FOI_DRAFT.bpmn
+++ b/src/main/resources/processes/FOI_DRAFT.bpmn
@@ -38,7 +38,7 @@
       <bpmn:outgoing>Flow_0o0krux</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0o0krux" sourceRef="ALLOCATE_TO_ACCEPTANCE_TEAM" targetRef="SAVE_ALLOCATION_NOTE" />
-    <bpmn:serviceTask id="SAVE_ALLOCATION_NOTE" name="Save Allocation Note" camunda:expression="${bpmnService.updateAllocationNoteWithDetails(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;AllocationCaseNote&#34;), &#34;REJECT&#34;, execution.getVariable(&#34;AcceptanceTeam&#34;), execution.getVariable(&#34;StageUUID&#34;))}">
+    <bpmn:serviceTask id="SAVE_ALLOCATION_NOTE" name="Save Allocation Note" camunda:expression="${bpmnService.updateAllocationNoteWithDetails(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;NText&#34;), &#34;REJECT&#34;, execution.getVariable(&#34;AcceptanceTeam&#34;), execution.getVariable(&#34;StageUUID&#34;))}">
       <bpmn:incoming>Flow_0o0krux</bpmn:incoming>
       <bpmn:outgoing>Flow_0egr2es</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/src/main/resources/processes/FOI_DRAFT.bpmn
+++ b/src/main/resources/processes/FOI_DRAFT.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" id="Definitions_0vgkz02" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.7.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" id="Definitions_0vgkz02" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
   <bpmn:process id="FOI_DRAFT" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1t9pg7t</bpmn:outgoing>
@@ -38,7 +38,7 @@
       <bpmn:outgoing>Flow_0o0krux</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0o0krux" sourceRef="ALLOCATE_TO_ACCEPTANCE_TEAM" targetRef="SAVE_ALLOCATION_NOTE" />
-    <bpmn:serviceTask id="SAVE_ALLOCATION_NOTE" name="Save Allocation Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;NText&#34;), &#34;ALLOCATE&#34;)}">
+    <bpmn:serviceTask id="SAVE_ALLOCATION_NOTE" name="Save Allocation Note" camunda:expression="${bpmnService.updateAllocationNoteWithDetails(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;AllocationCaseNote&#34;), &#34;REJECT&#34;, execution.getVariable(&#34;AcceptanceTeam&#34;), execution.getVariable(&#34;StageUUID&#34;))}">
       <bpmn:incoming>Flow_0o0krux</bpmn:incoming>
       <bpmn:outgoing>Flow_0egr2es</bpmn:outgoing>
     </bpmn:serviceTask>
@@ -345,6 +345,25 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="FOI_DRAFT">
+      <bpmndi:BPMNEdge id="Flow_051720t_di" bpmnElement="Flow_051720t">
+        <di:waypoint x="3130" y="290" />
+        <di:waypoint x="3180" y="290" />
+        <di:waypoint x="3180" y="374" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12ep1q9_di" bpmnElement="Flow_12ep1q9">
+        <di:waypoint x="3130" y="392" />
+        <di:waypoint x="3162" y="392" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ep8ae1_di" bpmnElement="Flow_1ep8ae1">
+        <di:waypoint x="2995" y="290" />
+        <di:waypoint x="3030" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ukqf55_di" bpmnElement="Flow_0ukqf55" bioc:stroke="rgb(251, 140, 0)" bioc:fill="rgb(255, 224, 178)">
+        <di:waypoint x="2970" y="315" />
+        <di:waypoint x="2970" y="540" />
+        <di:waypoint x="2390" y="540" />
+        <di:waypoint x="2390" y="432" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0iyuwqi_di" bpmnElement="Flow_0iyuwqi">
         <di:waypoint x="2075" y="392" />
         <di:waypoint x="2130" y="392" />
@@ -659,30 +678,14 @@
         <di:waypoint x="215" y="339" />
         <di:waypoint x="290" y="339" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ukqf55_di" bpmnElement="Flow_0ukqf55" bioc:stroke="rgb(251, 140, 0)" bioc:fill="rgb(255, 224, 178)">
-        <di:waypoint x="2970" y="315" />
-        <di:waypoint x="2970" y="540" />
-        <di:waypoint x="2390" y="540" />
-        <di:waypoint x="2390" y="432" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ep8ae1_di" bpmnElement="Flow_1ep8ae1">
-        <di:waypoint x="2995" y="290" />
-        <di:waypoint x="3030" y="290" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_12ep1q9_di" bpmnElement="Flow_12ep1q9">
-        <di:waypoint x="3130" y="392" />
-        <di:waypoint x="3162" y="392" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_051720t_di" bpmnElement="Flow_051720t">
-        <di:waypoint x="3130" y="290" />
-        <di:waypoint x="3180" y="290" />
-        <di:waypoint x="3180" y="374" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="321" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0begqc1_di" bpmnElement="ACCEPT_OR_REJECT">
         <dc:Bounds x="290" y="299" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1phy81h_di" bpmnElement="END_EVENT">
+        <dc:Bounds x="3162" y="374" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_12nzvkg_di" bpmnElement="draft_case_acceptance_status" isMarkerVisible="true">
         <dc:Bounds x="465" y="367" width="50" height="50" />
@@ -839,9 +842,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0camoyd_di" bpmnElement="Gateway_0camoyd" isMarkerVisible="true" bioc:stroke="rgb(251, 140, 0)" bioc:fill="rgb(255, 224, 178)">
         <dc:Bounds x="2945" y="265" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1phy81h_di" bpmnElement="END_EVENT">
-        <dc:Bounds x="3162" y="374" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_04k4akv_di" bpmnElement="SAVE_G6_OR_G7_APPROVAL_TEAM">
         <dc:Bounds x="3030" y="250" width="100" height="80" />

--- a/src/main/resources/processes/FOI_QA.bpmn
+++ b/src/main/resources/processes/FOI_QA.bpmn
@@ -128,61 +128,6 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="FOI_QA">
-<<<<<<< HEAD
-      <bpmndi:BPMNEdge id="Flow_10qfpb5_di" bpmnElement="Flow_10qfpb5">
-        <di:waypoint x="1480" y="510" />
-        <di:waypoint x="1550" y="510" />
-        <di:waypoint x="1550" y="478" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_06byeqp_di" bpmnElement="Flow_06byeqp">
-        <di:waypoint x="1480" y="300" />
-        <di:waypoint x="1550" y="300" />
-        <di:waypoint x="1550" y="442" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1cxqjh0_di" bpmnElement="Flow_1cxqjh0">
-        <di:waypoint x="407" y="300" />
-        <di:waypoint x="457" y="300" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_122bzqh_di" bpmnElement="Flow_122bzqh">
-        <di:waypoint x="1027" y="160" />
-        <di:waypoint x="1077" y="160" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17h3adz_di" bpmnElement="Flow_17h3adz">
-        <di:waypoint x="697" y="160" />
-        <di:waypoint x="927" y="160" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0173i33_di" bpmnElement="Flow_0173i33">
-        <di:waypoint x="1297" y="325" />
-        <di:waypoint x="1297" y="380" />
-        <di:waypoint x="507" y="380" />
-        <di:waypoint x="507" y="340" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1a0dcde_di" bpmnElement="Flow_1a0dcde">
-        <di:waypoint x="1322" y="300" />
-        <di:waypoint x="1380" y="300" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0kxbt43_di" bpmnElement="Flow_0kxbt43" bioc:stroke="rgb(251, 140, 0)" bioc:fill="rgb(255, 224, 178)">
-        <di:waypoint x="1217" y="275" />
-        <di:waypoint x="1217" y="220" />
-        <di:waypoint x="767" y="220" />
-        <di:waypoint x="767" y="260" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_12czfow_di" bpmnElement="Flow_12czfow">
-        <di:waypoint x="1242" y="300" />
-        <di:waypoint x="1272" y="300" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1wbsfh7_di" bpmnElement="Flow_1wbsfh7">
-        <di:waypoint x="1157" y="300" />
-        <di:waypoint x="1192" y="300" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0q1j3fl_di" bpmnElement="Flow_0q1j3fl">
-        <di:waypoint x="1002" y="300" />
-        <di:waypoint x="1057" y="300" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0gtjkzp_di" bpmnElement="Flow_0gtjkzp">
-        <di:waypoint x="977" y="275" />
-        <di:waypoint x="977" y="200" />
-=======
       <bpmndi:BPMNEdge id="Flow_122bzqh_di" bpmnElement="Flow_122bzqh">
         <di:waypoint x="880" y="160" />
         <di:waypoint x="930" y="160" />
@@ -223,7 +168,6 @@
       <bpmndi:BPMNEdge id="Flow_0gtjkzp_di" bpmnElement="Flow_0gtjkzp">
         <di:waypoint x="830" y="275" />
         <di:waypoint x="830" y="200" />
->>>>>>> 0c1998afa3911bfbf2c7d63cc0fffa8cf88de905
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1gk3dqs_di" bpmnElement="Flow_1gk3dqs" bioc:stroke="rgb(251, 140, 0)" bioc:fill="rgb(255, 224, 178)">
         <di:waypoint x="887" y="275" />
@@ -235,18 +179,6 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_18urnji_di" bpmnElement="Flow_18urnji">
-<<<<<<< HEAD
-        <di:waypoint x="912" y="300" />
-        <di:waypoint x="952" y="300" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_09il9cc_di" bpmnElement="Flow_09il9cc">
-        <di:waypoint x="817" y="300" />
-        <di:waypoint x="862" y="300" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0w5uh2m_di" bpmnElement="Flow_0w5uh2m">
-        <di:waypoint x="672" y="300" />
-        <di:waypoint x="717" y="300" />
-=======
         <di:waypoint x="765" y="300" />
         <di:waypoint x="805" y="300" />
       </bpmndi:BPMNEdge>
@@ -257,7 +189,6 @@
       <bpmndi:BPMNEdge id="Flow_0w5uh2m_di" bpmnElement="Flow_0w5uh2m">
         <di:waypoint x="525" y="300" />
         <di:waypoint x="570" y="300" />
->>>>>>> 0c1998afa3911bfbf2c7d63cc0fffa8cf88de905
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1dan73m_di" bpmnElement="Flow_1dan73m">
         <di:waypoint x="1177" y="160" />
@@ -265,46 +196,20 @@
         <di:waypoint x="1550" y="442" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0buh4ji_di" bpmnElement="Flow_0buh4ji">
-<<<<<<< HEAD
-        <di:waypoint x="647" y="275" />
-        <di:waypoint x="647" y="200" />
-=======
         <di:waypoint x="500" y="275" />
         <di:waypoint x="500" y="200" />
->>>>>>> 0c1998afa3911bfbf2c7d63cc0fffa8cf88de905
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0iq7yhy_di" bpmnElement="Flow_0iq7yhy">
         <di:waypoint x="250" y="422" />
         <di:waypoint x="250" y="300" />
-<<<<<<< HEAD
-        <di:waypoint x="307" y="300" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="218" y="345" width="63" height="14" />
-=======
         <di:waypoint x="310" y="300" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="238" y="282" width="63" height="14" />
->>>>>>> 0c1998afa3911bfbf2c7d63cc0fffa8cf88de905
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0pjk116_di" bpmnElement="Flow_0pjk116">
         <di:waypoint x="250" y="472" />
         <di:waypoint x="250" y="510" />
-<<<<<<< HEAD
-        <di:waypoint x="1380" y="510" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="288" y="492" width="56" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_18sn5u7_di" bpmnElement="Flow_18sn5u7">
-        <di:waypoint x="557" y="300" />
-        <di:waypoint x="622" y="300" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0t16gy6_di" bpmnElement="Flow_0t16gy6">
-        <di:waypoint x="188" y="447" />
-        <di:waypoint x="225" y="447" />
-      </bpmndi:BPMNEdge>
-=======
         <di:waypoint x="1210" y="510" />
         <di:waypoint x="1210" y="478" />
         <bpmndi:BPMNLabel>
@@ -319,22 +224,14 @@
         <di:waypoint x="188" y="447" />
         <di:waypoint x="225" y="447" />
       </bpmndi:BPMNEdge>
->>>>>>> 0c1998afa3911bfbf2c7d63cc0fffa8cf88de905
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="152" y="429" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_079o9xp_di" bpmnElement="END_EVENT">
-<<<<<<< HEAD
-        <dc:Bounds x="1532" y="442" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0y56ynu_di" bpmnElement="ACCEPT_OR_REJECT_CASE_G6_OR_G7">
-        <dc:Bounds x="457" y="260" width="100" height="80" />
-=======
         <dc:Bounds x="1192" y="442" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0y56ynu_di" bpmnElement="ACCEPT_OR_REJECT_CASE_G6_OR_G7">
         <dc:Bounds x="310" y="260" width="100" height="80" />
->>>>>>> 0c1998afa3911bfbf2c7d63cc0fffa8cf88de905
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_01cuvca_di" bpmnElement="select_approval_type" isMarkerVisible="true">
         <dc:Bounds x="225" y="422" width="50" height="50" />
@@ -343,17 +240,10 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1vnqwxz_di" bpmnElement="SAVE_ALLOCATION_NOTE">
-<<<<<<< HEAD
-        <dc:Bounds x="597" y="120" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_003haky_di" bpmnElement="ALLOCATE_TO_DRAFT_TEAM">
-        <dc:Bounds x="1077" y="120" width="100" height="80" />
-=======
         <dc:Bounds x="450" y="120" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_003haky_di" bpmnElement="ALLOCATE_TO_DRAFT_TEAM">
         <dc:Bounds x="930" y="120" width="100" height="80" />
->>>>>>> 0c1998afa3911bfbf2c7d63cc0fffa8cf88de905
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0n72jd6_di" bpmnElement="Gateway_0n72jd6" isMarkerVisible="true">
         <dc:Bounds x="622" y="275" width="50" height="50" />
@@ -362,17 +252,10 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_00uctyr_di" bpmnElement="direction_check_1" isMarkerVisible="true" bioc:stroke="rgb(251, 140, 0)" bioc:fill="rgb(255, 224, 178)">
-<<<<<<< HEAD
-        <dc:Bounds x="862" y="275" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_198ux1j_di" bpmnElement="ACCEPT_OR_REJECT_SENSITIVITY_G6_OR_G7">
-        <dc:Bounds x="717" y="260" width="100" height="80" />
-=======
         <dc:Bounds x="715" y="275" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_198ux1j_di" bpmnElement="ACCEPT_OR_REJECT_SENSITIVITY_G6_OR_G7">
         <dc:Bounds x="570" y="260" width="100" height="80" />
->>>>>>> 0c1998afa3911bfbf2c7d63cc0fffa8cf88de905
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1vdvrgw_di" bpmnElement="Gateway_1vdvrgw" isMarkerVisible="true">
         <dc:Bounds x="952" y="275" width="50" height="50" />
@@ -393,22 +276,8 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1lpfwh2_di" bpmnElement="REJECT_CASE">
-<<<<<<< HEAD
-        <dc:Bounds x="927" y="120" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1sdqv1d_di" bpmnElement="SET_APPROVAL_TEAM_MEMBER_FOR_QA_STAGE">
-        <dc:Bounds x="307" y="260" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1fcfvpz_di" bpmnElement="ALLOCATE_TO_PO_TEAM">
-        <dc:Bounds x="1380" y="260" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0o4nze8_di" bpmnElement="ALLOCATE_TO_PPO_TEAM">
-        <dc:Bounds x="1380" y="470" width="100" height="80" />
-      </bpmndi:BPMNShape>
-=======
         <dc:Bounds x="780" y="120" width="100" height="80" />
       </bpmndi:BPMNShape>
->>>>>>> 0c1998afa3911bfbf2c7d63cc0fffa8cf88de905
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/processes/FOI_QA.bpmn
+++ b/src/main/resources/processes/FOI_QA.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0i7m6z8" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.14.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0i7m6z8" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.14.0">
   <bpmn:process id="FOI_QA" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0t16gy6</bpmn:outgoing>
@@ -28,7 +28,7 @@
     <bpmn:sequenceFlow id="Flow_0iq7yhy" name="Low (G6/G7)" sourceRef="select_approval_type" targetRef="SET_APPROVAL_TEAM_MEMBER_FOR_QA_STAGE">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${Sensitivity=="LOW"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="SAVE_ALLOCATION_NOTE" name="Save Allocation Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;G6orG7AcceptCase-NText&#34;), &#34;REJECT&#34;)}">
+    <bpmn:serviceTask id="SAVE_ALLOCATION_NOTE" name="Save Allocation Note" camunda:expression="${bpmnService.updateAllocationNoteWithDetails(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;G6orG7AcceptCase-NText&#34;), &#34;REJECT&#34;, execution.getVariable(&#34;AcceptanceTeam&#34;), execution.getVariable(&#34;StageUUID&#34;))}">
       <bpmn:incoming>Flow_0buh4ji</bpmn:incoming>
       <bpmn:outgoing>Flow_17h3adz</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI_ACCEPTANCE.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI_ACCEPTANCE.java
@@ -44,6 +44,8 @@ public class FOI_ACCEPTANCE {
     public static final String FOI_CASE_TYPE = "FOI";
     public static final String ALLOCATE_TO_DRAFT_TEAM = "ALLOCATE_TO_DRAFT_TEAM";
     public static final String SET_ACCEPTANCE_DATE = "SET_ACCEPTANCE_DATE";
+    public static final String N_TEXT = "NoteText";
+    public static final String ACCEPTANCE_TEAM_UUID = UUID.randomUUID().toString();
 
     @Rule
     @ClassRule
@@ -147,7 +149,8 @@ public class FOI_ACCEPTANCE {
         Scenario.run(processScenario).startBy(
                 () -> rule.getRuntimeService().startProcessInstanceByKey(
                         PROCESS_KEY, STAGE_UUID,
-                        Map.of("CaseUUID", CASE_UUID)
+                        Map.of("CaseUUID", CASE_UUID, "AcceptanceTeam", ACCEPTANCE_TEAM_UUID,"NText", N_TEXT,
+                                "StageUUID", STAGE_UUID)
                 )).execute();
 
         verify(processScenario, times(1)).hasCompleted(ACCEPT_OR_REJECT);
@@ -155,5 +158,7 @@ public class FOI_ACCEPTANCE {
         verify(processScenario, times(1)).hasCompleted(SAVE_ALLOCATION_NOTE);
         verify(processScenario, times(0)).hasCompleted(SET_ACCEPTANCE_DATE);
         verify(bpmnService).wipeVariables(eq(CASE_UUID), eq(STAGE_UUID), eq("AcceptanceTeam"), eq("Directorate"));
+        verify(bpmnService).updateAllocationNoteWithDetails(eq(CASE_UUID), eq(STAGE_UUID), eq(N_TEXT), eq("REJECT"),
+                eq(ACCEPTANCE_TEAM_UUID), eq(STAGE_UUID));
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI_DATA_INPUT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI_DATA_INPUT.java
@@ -25,7 +25,7 @@ import static uk.gov.digital.ho.hocs.workflow.util.CallActivityMockWrapper.whenA
 @RunWith(MockitoJUnitRunner.class)
 @Deployment(resources = {
         "processes/FOI_DATA_INPUT.bpmn"})
-public class FOI_Data_Input {
+public class FOI_DATA_INPUT {
 
     public static final String ALLOCATE_TO_CASE_CREATOR = "ALLOCATE_TO_CASE_CREATOR";
     public static final String SAVE_PRIMARY_CORRESPONDENT = "ServiceTask_097z7cz";

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI_DRAFT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI_DRAFT.java
@@ -32,6 +32,7 @@ public class FOI_DRAFT {
     public static final String G6G7ApprovalTeam = UUID.randomUUID().toString();
     public static final String ScsApprovalTeam = UUID.randomUUID().toString();
 
+    public static final String N_TEXT = "NoteText";
     public static final String ACCEPT_OR_REJECT = "ACCEPT_OR_REJECT";
     public static final String REJECT_CASE = "REJECT_CASE";
     public static final String ALLOCATE_TO_ACCEPTANCE_TEAM = "ALLOCATE_TO_ACCEPTANCE_TEAM";
@@ -73,21 +74,24 @@ public class FOI_DRAFT {
     @Test
     public void caseRejected() {
         when(processScenario.waitsAtUserTask(ACCEPT_OR_REJECT))
-            .thenReturn(task -> task.complete(withVariables(
-                "DraftAcceptCase", "N")));
+                .thenReturn(task -> task.complete(
+                        withVariables("DraftAcceptCase", "N")));
 
 
         Scenario.run(processScenario).startBy(
-            () -> rule.getRuntimeService().startProcessInstanceByKey(
-                PROCESS_KEY, STAGE_UUID,
-                Map.of("CaseUUID", CASE_UUID, "AcceptanceTeam", ACCEPTANCE_TEAM_UUID)
-            )).execute();
+                () -> rule.getRuntimeService().startProcessInstanceByKey(
+                        PROCESS_KEY, STAGE_UUID,
+                        Map.of("CaseUUID", CASE_UUID, "AcceptanceTeam", ACCEPTANCE_TEAM_UUID, "NText", N_TEXT,
+                                "StageUUID", STAGE_UUID)
+                )).execute();
 
         verify(processScenario, times(1)).hasCompleted(ACCEPT_OR_REJECT);
         verify(processScenario, times(1)).hasCompleted(REJECT_CASE);
         verify(processScenario, times(1)).hasCompleted(ALLOCATE_TO_ACCEPTANCE_TEAM);
         verify(processScenario, times(1)).hasCompleted(SAVE_ALLOCATION_NOTE);
         verify(bpmnService).wipeVariables(eq(CASE_UUID), eq(STAGE_UUID), eq("DraftTeam"));
+        verify(bpmnService).updateAllocationNoteWithDetails(eq(CASE_UUID), eq(STAGE_UUID), eq(N_TEXT),
+                eq("REJECT"), eq(ACCEPTANCE_TEAM_UUID), eq(STAGE_UUID));
         verify(processScenario).hasFinished(END_EVENT);
 
     }
@@ -96,25 +100,25 @@ public class FOI_DRAFT {
     public void invalidRequest() {
 
         when(processScenario.waitsAtUserTask(ACCEPT_OR_REJECT))
-            .thenReturn(task -> task.complete(withVariables(
-                "DraftAcceptCase", "Y")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "DraftAcceptCase", "Y")));
 
         when(processScenario.waitsAtUserTask(VALIDITY))
-            .thenReturn(task -> task.complete(withVariables(
-                "DraftValidity", "DraftValid-N", "DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "DraftValidity", "DraftValid-N", "DIRECTION", "FORWARD")));
 
         when(processScenario.waitsAtUserTask(INVALID))
-            .thenReturn(task -> task.complete(withVariables(
-                "DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "FORWARD")));
 
         when(processScenario.waitsAtUserTask(UPLOAD_DRAFT))
-            .thenReturn(task -> task.complete());
+                .thenReturn(task -> task.complete());
 
         Scenario.run(processScenario).startBy(
-            () -> rule.getRuntimeService().startProcessInstanceByKey(
-                PROCESS_KEY, STAGE_UUID,
-                Map.of("CaseUUID", CASE_UUID)
-            )).execute();
+                () -> rule.getRuntimeService().startProcessInstanceByKey(
+                        PROCESS_KEY, STAGE_UUID,
+                        Map.of("CaseUUID", CASE_UUID)
+                )).execute();
 
         verify(processScenario, times(1)).hasCompleted(ACCEPT_OR_REJECT);
         verify(processScenario, times(1)).hasCompleted(VALIDITY);
@@ -129,26 +133,26 @@ public class FOI_DRAFT {
     public void multipleContributions() {
 
         when(processScenario.waitsAtUserTask(ACCEPT_OR_REJECT))
-            .thenReturn(task -> task.complete(withVariables(
-                "DraftAcceptCase", "Y")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "DraftAcceptCase", "Y")));
 
         when(processScenario.waitsAtUserTask(VALIDITY))
-            .thenReturn(task -> task.complete(withVariables(
-                "DraftValidity", "DraftValid-Y", "DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "DraftValidity", "DraftValid-Y", "DIRECTION", "FORWARD")));
 
         when(processScenario.waitsAtUserTask(ARE_MCS_REQUIRED))
-            .thenReturn(task -> task.complete(withVariables(
-                "ContributionsRequired", "RequestContrib-Y", "DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "ContributionsRequired", "RequestContrib-Y", "DIRECTION", "FORWARD")));
 
         when(processScenario.waitsAtUserTask(MULTIPLE_CONTRIBUTIONS))
-            .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD")));
 
         when(processScenario.waitsAtUserTask(RESPONSE_TYPE))
-            .thenReturn(task -> task.complete(withVariables(
-                "ResponseType", "FULL_DISCLOSURE", "DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "ResponseType", "FULL_DISCLOSURE", "DIRECTION", "FORWARD")));
 
         when(processScenario.waitsAtUserTask(UPLOAD_DRAFT))
-            .thenReturn(task -> task.complete());
+                .thenReturn(task -> task.complete());
 
         when(processScenario.waitsAtUserTask(SENSITIVITY))
                 .thenReturn(task -> task.complete(withVariables(
@@ -164,10 +168,10 @@ public class FOI_DRAFT {
 
 
         Scenario.run(processScenario).startBy(
-            () -> rule.getRuntimeService().startProcessInstanceByKey(
-                PROCESS_KEY, STAGE_UUID,
-                Map.of("CaseUUID", CASE_UUID)
-            )).execute();
+                () -> rule.getRuntimeService().startProcessInstanceByKey(
+                        PROCESS_KEY, STAGE_UUID,
+                        Map.of("CaseUUID", CASE_UUID)
+                )).execute();
 
         verify(processScenario, times(1)).hasCompleted(ACCEPT_OR_REJECT);
         verify(processScenario, times(1)).hasCompleted(VALIDITY);
@@ -186,34 +190,33 @@ public class FOI_DRAFT {
     public void exemption() {
 
         when(processScenario.waitsAtUserTask(ACCEPT_OR_REJECT))
-            .thenReturn(task -> task.complete(withVariables(
-                "DraftAcceptCase", "Y")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "DraftAcceptCase", "Y")));
 
         when(processScenario.waitsAtUserTask(VALIDITY))
-            .thenReturn(task -> task.complete(withVariables(
-                "DraftValidity", "DraftValid-Y", "DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "DraftValidity", "DraftValid-Y", "DIRECTION", "FORWARD")));
 
         when(processScenario.waitsAtUserTask(ARE_MCS_REQUIRED))
-            .thenReturn(task -> task.complete(withVariables(
-                "ContributionsRequired", "RequestContrib-N", "DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "ContributionsRequired", "RequestContrib-N", "DIRECTION", "FORWARD")));
 
         when(processScenario.waitsAtUserTask(RESPONSE_TYPE))
-            .thenReturn(task -> task.complete(withVariables(
-                "ResponseType", "EXEMPTION", "DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "ResponseType", "EXEMPTION", "DIRECTION", "FORWARD")));
 
         when(processScenario.waitsAtUserTask(EXEMPTION))
-            .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD")));
 
         when(processScenario.waitsAtUserTask(UPLOAD_DRAFT))
-            .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD")));
-
+                .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD")));
 
 
         Scenario.run(processScenario).startBy(
-            () -> rule.getRuntimeService().startProcessInstanceByKey(
-                PROCESS_KEY, STAGE_UUID,
-                Map.of("CaseUUID", CASE_UUID)
-            )).execute();
+                () -> rule.getRuntimeService().startProcessInstanceByKey(
+                        PROCESS_KEY, STAGE_UUID,
+                        Map.of("CaseUUID", CASE_UUID)
+                )).execute();
 
 
         verify(processScenario, times(1)).hasCompleted(ACCEPT_OR_REJECT);
@@ -343,27 +346,27 @@ public class FOI_DRAFT {
     public void happyPath() {
 
         when(processScenario.waitsAtUserTask(ACCEPT_OR_REJECT))
-            .thenReturn(task -> task.complete(withVariables(
-                "DraftAcceptCase", "Y")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "DraftAcceptCase", "Y")));
 
         when(processScenario.waitsAtUserTask(VALIDITY))
-            .thenReturn(task -> task.complete(withVariables(
-                "DraftValidity", "DraftValid-Y", "DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "DraftValidity", "DraftValid-Y", "DIRECTION", "FORWARD")));
 
         when(processScenario.waitsAtUserTask(ARE_MCS_REQUIRED))
-            .thenReturn(task -> task.complete(withVariables(
-                "ContributionsRequired", "RequestContrib-N", "DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "ContributionsRequired", "RequestContrib-N", "DIRECTION", "FORWARD")));
 
         when(processScenario.waitsAtUserTask(RESPONSE_TYPE))
-            .thenReturn(task -> task.complete(withVariables(
-                "ResponseType", "FULL_DISCLOSURE", "DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "ResponseType", "FULL_DISCLOSURE", "DIRECTION", "FORWARD")));
 
         when(processScenario.waitsAtUserTask(QA_OFFLINE))
-            .thenReturn(task -> task.complete(withVariables(
-                "QaOffline", "QaOffline-N", "DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables(
+                        "QaOffline", "QaOffline-N", "DIRECTION", "FORWARD")));
 
         when(processScenario.waitsAtUserTask(UPLOAD_DRAFT))
-            .thenReturn(task -> task.complete());
+                .thenReturn(task -> task.complete());
 
         when(processScenario.waitsAtUserTask(SENSITIVITY))
                 .thenReturn(task -> task.complete(withVariables(
@@ -374,10 +377,10 @@ public class FOI_DRAFT {
                         "G6G7ApprovalTeam", G6G7ApprovalTeam)));
 
         Scenario.run(processScenario).startBy(
-            () -> rule.getRuntimeService().startProcessInstanceByKey(
-                PROCESS_KEY, STAGE_UUID,
-                Map.of("CaseUUID", CASE_UUID)
-            )).execute();
+                () -> rule.getRuntimeService().startProcessInstanceByKey(
+                        PROCESS_KEY, STAGE_UUID,
+                        Map.of("CaseUUID", CASE_UUID)
+                )).execute();
 
         verify(processScenario, times(1)).hasCompleted(ACCEPT_OR_REJECT);
         verify(processScenario, times(1)).hasCompleted(VALIDITY);

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI_QA.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI_QA.java
@@ -31,6 +31,7 @@ public class FOI_QA {
     public static final String STAGE_UUID = UUID.randomUUID().toString();
     public static final String DRAFT_TEAM_UUID = UUID.randomUUID().toString();
 
+    public static final String N_TEXT = "NoteText";
     public static final String SET_APPROVAL_TEAM_MEMBER_FOR_QA_STAGE = "SET_APPROVAL_TEAM_MEMBER_FOR_QA_STAGE";
     public static final String ACCEPT_OR_REJECT_CASE_G6_OR_G7 = "ACCEPT_OR_REJECT_CASE_G6_OR_G7";
     public static final String SAVE_ALLOCATION_NOTE = "SAVE_ALLOCATION_NOTE";
@@ -41,6 +42,7 @@ public class FOI_QA {
     public static final String ALLOCATE_TO_PRIVATE_PRESS_OFFICE_TEAM = "ALLOCATE_TO_PPO_TEAM";
     public static final String ALLOCATE_TO_PRESS_OFFICE_TEAM = "ALLOCATE_TO_PO_TEAM";
     public static final String END_EVENT = "END_EVENT";
+    public static final String ACCEPTANCE_TEAM_UUID = UUID.randomUUID().toString();
 
     @Rule
     @ClassRule
@@ -104,11 +106,14 @@ public class FOI_QA {
                 () -> rule.getRuntimeService().startProcessInstanceByKey(
                         PROCESS_KEY, STAGE_UUID,
                         Map.of("CaseUUID", CASE_UUID, "Sensitivity", "LOW",
-                                "DraftTeam", DRAFT_TEAM_UUID))
+                                "DraftTeam", DRAFT_TEAM_UUID, "AcceptanceTeam", ACCEPTANCE_TEAM_UUID,
+                                "NText", N_TEXT, "StageUUID", STAGE_UUID))
         ).execute();
 
         verify(processScenario, times(1)).hasCompleted(ACCEPT_OR_REJECT_CASE_G6_OR_G7);
         verify(processScenario, times(1)).hasCompleted(SAVE_ALLOCATION_NOTE);
+        verify(bpmnService).updateAllocationNoteWithDetails(eq(CASE_UUID), eq(STAGE_UUID), eq(N_TEXT),
+                eq("REJECT"), eq(ACCEPTANCE_TEAM_UUID), eq(STAGE_UUID));
         verify(processScenario, times(1)).hasCompleted(REJECT_CASE);
         verify(processScenario, times(1)).hasCompleted(ALLOCATE_TO_DRAFT_TEAM);
         verify(processScenario, times(1)).hasCompleted(END_EVENT);

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI_QA.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI_QA.java
@@ -107,7 +107,7 @@ public class FOI_QA {
                         PROCESS_KEY, STAGE_UUID,
                         Map.of("CaseUUID", CASE_UUID, "Sensitivity", "LOW",
                                 "DraftTeam", DRAFT_TEAM_UUID, "AcceptanceTeam", ACCEPTANCE_TEAM_UUID,
-                                "NText", N_TEXT, "StageUUID", STAGE_UUID))
+                                "G6orG7AcceptCase-NText", N_TEXT, "StageUUID", STAGE_UUID))
         ).execute();
 
         verify(processScenario, times(1)).hasCompleted(ACCEPT_OR_REJECT_CASE_G6_OR_G7);


### PR DESCRIPTION


Update case notes to display clearly whether they refer to a case allocation or a case rejection.

Allocation notes should show:

    The team which made the allocation
    The team the case was allocated to
    The stage at which the allocation took place

Rejection notes should show:

    The team who rejected the case
    The stage at which the rejection took place