### PR TITLE
HOCS-3193 Sticky Cases

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowService.java
@@ -11,6 +11,7 @@ import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.CaseworkClient;
 import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.dto.CreateCaseworkCaseResponse;
 import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.dto.GetAllStagesForCaseResponse;
 import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.dto.GetCaseworkCaseDataResponse;
+import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.dto.StageDto;
 import uk.gov.digital.ho.hocs.workflow.client.documentclient.DocumentClient;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.InfoClient;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.CaseDetailsFieldDto;
@@ -18,6 +19,7 @@ import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.TeamDto;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.UserDto;
 import uk.gov.digital.ho.hocs.workflow.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.workflow.domain.model.forms.*;
+import uk.gov.digital.ho.hocs.workflow.security.UserPermissionsService;
 import uk.gov.digital.ho.hocs.workflow.util.UuidUtils;
 
 import java.time.LocalDate;
@@ -37,6 +39,7 @@ public class WorkflowService {
     private final DocumentClient documentClient;
     private final InfoClient infoClient;
     private final CamundaClient camundaClient;
+    private final UserPermissionsService userPermissionsService;
 
     private static final String COMPONENT_ENTITY_LIST = "entity-list";
     private static final String COMPONENT_DROPDOWN = "dropdown";
@@ -48,15 +51,19 @@ public class WorkflowService {
 
     private static final String DOCUMENT_NOT_FOUND = "Document not found";
 
+    public static final String STICKY_CASES_VARIABLE = "STICKY_CASES";
+
     @Autowired
     public WorkflowService(CaseworkClient caseworkClient,
                            DocumentClient documentClient,
                            InfoClient infoClient,
-                           CamundaClient camundaClient) {
+                           CamundaClient camundaClient,
+                           UserPermissionsService userPermissionsService) {
         this.caseworkClient = caseworkClient;
         this.documentClient = documentClient;
         this.infoClient = infoClient;
         this.camundaClient = camundaClient;
+        this.userPermissionsService = userPermissionsService;
     }
 
     public CreateCaseResponse createCase(String caseDataType, LocalDate dateReceived, List<DocumentSummary> documents, UUID userUUID) {
@@ -97,22 +104,44 @@ public class WorkflowService {
     public GetStageResponse getStage(UUID caseUUID, UUID stageUUID) {
         String screenName = camundaClient.getStageScreenName(stageUUID);
 
-        if (!screenName.equals("FINISH")) {
+        if (screenName.equals("FINISH")) {
+            Optional<StageDto> maybeActiveStage = caseworkClient.getActiveStage(caseUUID);
+            if (maybeActiveStage.isPresent()) {
+                StageDto nextStage = maybeActiveStage.get();
+                UUID nextStageId = nextStage.getUuid();
+                boolean isUserOnTheTeamForNextStage = userPermissionsService.isUserOnTeam(nextStage.getTeamUUID());
+                boolean isStickyCasesModeOn = isStickyCasesModeOn(caseUUID);
+                if (isStickyCasesModeOn && isUserOnTheTeamForNextStage) {
+                    //assign user to the next stage
+                    caseworkClient.updateStageUser(caseUUID, nextStageId, userPermissionsService.getUserId());
 
-            GetCaseworkCaseDataResponse inputResponse = caseworkClient.getCase(caseUUID);
+                    //turn off sticky cases
+                    turnOffStickyCases(caseUUID, nextStageId);
 
-            SchemaDto schemaDto = infoClient.getSchema(screenName);
-            List<HocsFormField> fields = schemaDto.getFields().stream().map(HocsFormField::from).collect(toList());
-            List<HocsFormSecondaryAction> secondaryActions = schemaDto.getSecondaryActions().stream().map(HocsFormSecondaryAction::from).collect(toList());
-            fields = HocsFormAccordion.loadFormAccordions(fields);
-
-            HocsSchema schema = new HocsSchema(schemaDto.getTitle(), schemaDto.getDefaultActionLabel(), fields, secondaryActions, schemaDto.getProps(), schemaDto.getValidation());
-
-            HocsForm form = new HocsForm(schema, inputResponse.getData());
-            return new GetStageResponse(stageUUID, inputResponse.getReference(), form);
-        } else {
+                    //return information about the screen on the next stage
+                    return getStage(caseUUID, nextStageId);
+                }
+            }
             return new GetStageResponse(stageUUID, null, null);
         }
+
+        GetCaseworkCaseDataResponse inputResponse = caseworkClient.getCase(caseUUID);
+
+        SchemaDto schemaDto = infoClient.getSchema(screenName);
+        List<HocsFormField> fields = schemaDto.getFields().stream().map(HocsFormField::from).collect(toList());
+        List<HocsFormSecondaryAction> secondaryActions = schemaDto.getSecondaryActions().stream().map(HocsFormSecondaryAction::from).collect(toList());
+        fields = HocsFormAccordion.loadFormAccordions(fields);
+        HocsSchema schema = new HocsSchema(schemaDto.getTitle(), schemaDto.getDefaultActionLabel(), fields, secondaryActions, schemaDto.getProps(), schemaDto.getValidation());
+        HocsForm form = new HocsForm(schema, inputResponse.getData());
+        return new GetStageResponse(stageUUID, inputResponse.getReference(), form);
+    }
+
+    private boolean isStickyCasesModeOn(UUID caseUUID) {
+        return camundaClient.hasProcessInstanceVariableWithValue(caseUUID.toString(), STICKY_CASES_VARIABLE, Boolean.TRUE.toString());
+    }
+
+    private void turnOffStickyCases(UUID caseUUID, UUID stageUUID) {
+        camundaClient.removeProcessInstanceVariableFromAllScopes(caseUUID.toString(), stageUUID.toString(), STICKY_CASES_VARIABLE);
     }
 
     public GetCaseResponse getAllCaseStages(UUID caseUUID) {

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/client/camundaclient/CamundaClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/client/camundaclient/CamundaClient.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.hocs.workflow.client.camundaclient;
 
+import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.camunda.bpm.engine.RuntimeService;
 import org.camunda.bpm.engine.TaskService;
@@ -64,6 +65,8 @@ public class CamundaClient {
         return formKeyScreenName != null ? formKeyScreenName : getStageScreenNameFromProcessVariable(stageUUID);
     }
 
+
+
     public String getFormKeyForCurrentTask(UUID stageUUID) {
         Task task = taskService.createTaskQuery()
             .processInstanceBusinessKey(stageUUID.toString())
@@ -76,6 +79,26 @@ public class CamundaClient {
         String screenName = getPropertyByBusinessKey(stageUUID, "screen");
         log.info("Got current stage for bpmn Stage: '{}' Screen: '{}'", stageUUID, screenName, value(EVENT, CURRENT_STAGE_RETRIEVED));
         return screenName == null || screenName.equals("null") ? "FINISH" : screenName;
+    }
+
+    public boolean hasProcessInstanceVariableWithValue(String businessKey, String variableName, String value) {
+        List<ProcessInstance> matches = runtimeService.createProcessInstanceQuery()
+            .processInstanceBusinessKey(businessKey)
+            .variableValueEquals(variableName, value)
+            .list();
+        return !matches.isEmpty();
+    }
+
+    public void removeProcessInstanceVariableFromAllScopes(String caseUUID, String stageUUID, String variableName) {
+        List<ProcessInstance> caseProcessInstanceList = runtimeService.createProcessInstanceQuery()
+            .processInstanceBusinessKey(caseUUID)
+            .list();
+        caseProcessInstanceList.forEach(pI -> runtimeService.removeVariable(pI.getProcessInstanceId(), variableName));
+
+        List<ProcessInstance> stageProcessInstanceList = runtimeService.createProcessInstanceQuery()
+            .processInstanceBusinessKey(stageUUID)
+            .list();
+        stageProcessInstanceList.forEach(pI -> runtimeService.removeVariable(pI.getProcessInstanceId(), variableName));
     }
 
     private String getTaskIdByBusinessKey(UUID businessKey) {
@@ -117,4 +140,5 @@ public class CamundaClient {
             return null;
         }
     }
+
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/client/caseworkclient/CaseworkClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/client/caseworkclient/CaseworkClient.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.hocs.workflow.client.caseworkclient;
 
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,7 +10,6 @@ import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.dto.*;
 
 import java.time.LocalDate;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 
 import static net.logstash.logback.argument.StructuredArguments.value;
@@ -162,6 +162,10 @@ public class CaseworkClient {
         );
         log.info("Got all stages for case: {}", caseUUID);
         return response;
+    }
+
+    public Optional<StageDto> getActiveStage(UUID caseUUID) {
+        return getAllStagesForCase(caseUUID).getStages().stream().filter(s -> s.getTeamUUID() != null).findFirst();
     }
 
     public GetCorrespondentsResponse getCorrespondentsForCase(UUID caseUUID) {

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/client/caseworkclient/dto/StageDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/client/caseworkclient/dto/StageDto.java
@@ -1,6 +1,7 @@
 package uk.gov.digital.ho.hocs.workflow.client.caseworkclient.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -11,6 +12,12 @@ import lombok.NoArgsConstructor;
 @Getter
 public class StageDto {
 
+    @JsonProperty("uuid")
+    private UUID uuid;
+
     @JsonProperty("stageType")
     private String type;
+
+    @JsonProperty("teamUUID")
+    private UUID teamUUID;
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/domain/model/forms/HocsForm.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/domain/model/forms/HocsForm.java
@@ -2,11 +2,13 @@ package uk.gov.digital.ho.hocs.workflow.domain.model.forms;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.Setter;
 
 import java.util.Map;
 
 @AllArgsConstructor
+@Getter
 public class HocsForm {
 
     @JsonProperty("schema")

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/security/UserPermissionsService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/security/UserPermissionsService.java
@@ -55,6 +55,10 @@ public class UserPermissionsService {
         return userTeams;
     }
 
+    public boolean isUserOnTeam(UUID teamUUID) {
+        return getUserTeams().contains(teamUUID);
+    }
+
     public Set<String> getUserCaseTypes() {
         Set<String> userCaseTypes = getUserPermission().stream()
                 .map(p -> p.getCaseTypeCode())

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/security/UserPermissionsServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/security/UserPermissionsServiceTest.java
@@ -1,24 +1,20 @@
 package uk.gov.digital.ho.hocs.workflow.security;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import org.springframework.mock.web.MockHttpServletRequest;
-import org.springframework.web.context.request.RequestContextHolder;
-import org.springframework.web.context.request.ServletRequestAttributes;
 import uk.gov.digital.ho.hocs.workflow.application.RequestData;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.InfoClient;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.PermissionDto;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.TeamDto;
-
-import java.util.HashSet;
-import java.util.Set;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class UserPermissionsServiceTest {
@@ -31,74 +27,72 @@ public class UserPermissionsServiceTest {
 
     private UserPermissionsService service;
 
-    private String uuid1 = Base64UUID.UUIDToBase64String(UUID.fromString("1325fe16-b864-42c7-85c2-7cab2863fe01"));
-    private String uuid2 = Base64UUID.UUIDToBase64String(UUID.fromString("f1825c7d-baff-4c09-8056-2166760ccbd2"));
-    private String uuid3 = Base64UUID.UUIDToBase64String(UUID.fromString("1c1e2f17-d5d9-4ff6-a023-6c40d76e1e9d"));
+    private final UUID team1Uuid = UUID.fromString("1325fe16-b864-42c7-85c2-7cab2863fe01");
+    private final UUID team2Uuid = UUID.fromString("f1825c7d-baff-4c09-8056-2166760ccbd2");
+    private final UUID team3Uuid = UUID.fromString("1c1e2f17-d5d9-4ff6-a023-6c40d76e1e9d");
 
+    private final String team1Base64 = Base64UUID.UUIDToBase64String(team1Uuid);
+    private final String team2Base64 = Base64UUID.UUIDToBase64String(team2Uuid);
+    private final String team3Base64 = Base64UUID.UUIDToBase64String(team3Uuid);
 
     @Before
     public void setup() {
-        MockHttpServletRequest request = new MockHttpServletRequest();
-        request.setMethod("GET");
-        RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
-        setupInfoClientMocks();
-    }
 
+        String[] GROUPS = ("/" + team2Base64 + "," + "/" + team3Base64 + "," + "/" + team1Base64).split(",");
+        when(requestData.groupsArray()).thenReturn(GROUPS);
+
+        Set<TeamDto> teamDtos = new HashSet<>();
+        Set<PermissionDto> permissions1 = new HashSet<>();
+        permissions1.add(new PermissionDto("MIN", AccessLevel.READ));
+        permissions1.add(new PermissionDto("MIN", AccessLevel.OWNER));
+        TeamDto teamDto1 = new TeamDto("TEAM 1", team1Uuid, true, permissions1);
+        teamDtos.add(teamDto1);
+
+        Set<PermissionDto> permissions2 = new HashSet<>();
+        permissions2.add(new PermissionDto("MIN", AccessLevel.READ));
+        permissions2.add(new PermissionDto("TRO",   AccessLevel.OWNER));
+        TeamDto teamDto2 = new TeamDto("TEAM 2", team2Uuid, true, permissions2);
+        teamDtos.add(teamDto2);
+
+        TeamDto teamDto3 = new TeamDto("TEAM 3", team3Uuid, true, new HashSet<>());
+        teamDtos.add(teamDto3);
+
+        when(infoClient.getTeams()).thenReturn(teamDtos);
+
+        service = new UserPermissionsService(requestData, infoClient);
+    }
 
     @Test
     public void shouldParseValidUserGroups() {
 
-        String[] groups =
-                ("/" + uuid2 + "," +
-                        "/" + uuid3 + "," +
-                        "/" +  uuid1).split(",");
-
-        when(requestData.groupsArray()).thenReturn(groups);
-        service = new UserPermissionsService(requestData, infoClient);
         assertThat(service.getUserPermission().size()).isEqualTo(3);
     }
-
 
     @Test
     public void shouldIgnoreInvalidUserGroups() {
 
-        String[] groups =
-                ("/" + uuid2 + "," +
-                        "INVALID_UUID," +
-                        "/" + uuid3 + ","
-                       ).split(",");
+        String[] groups = ("/" + team2Base64 + "," + "INVALID_UUID," + "/" + team3Base64 + ",").split(",");
 
         when(requestData.groupsArray()).thenReturn(groups);
-        service = new UserPermissionsService(requestData, infoClient);
         assertThat(service.getUserPermission().size()).isEqualTo(2);
 
     }
 
-
     @Test
     public void shouldGetTeamsForUser() {
-        String[] groups =
-                ("/" + uuid3 + "," +
-                        "/" + uuid1).split(",");
+        String[] groups = ("/" + team3Base64 + "," + "/" + team1Base64).split(",");
 
         when(requestData.groupsArray()).thenReturn(groups);
-        service = new UserPermissionsService(requestData, infoClient);
         Set<UUID> teams = service.getUserTeams();
         assertThat(teams).size().isEqualTo(2);
-        assertThat(teams).contains(UUID.fromString("1c1e2f17-d5d9-4ff6-a023-6c40d76e1e9d"));
-        assertThat(teams).doesNotContain(UUID.fromString("f1825c7d-baff-4c09-8056-2166760ccbd2"));
-        assertThat(teams).contains(UUID.fromString("1325fe16-b864-42c7-85c2-7cab2863fe01"));
+        assertThat(teams).contains(team3Uuid);
+        assertThat(teams).doesNotContain(team2Uuid);
+        assertThat(teams).contains(team1Uuid);
     }
 
     @Test
     public void shouldGetCaseTypesForUser() {
-        String[] groups =
-                ("/" + uuid2 + "," +
-                        "/" + uuid3 + "," +
-                        "/" + uuid1).split(",");
 
-        when(requestData.groupsArray()).thenReturn(groups);
-        service = new UserPermissionsService(requestData, infoClient);
         Set<String> caseTypes = service.getUserCaseTypes();
         assertThat(caseTypes.stream().anyMatch(c -> c.equals("TRO"))).isTrue();
         assertThat(caseTypes.stream().anyMatch(c -> c.equals("MIN"))).isTrue();
@@ -110,12 +104,6 @@ public class UserPermissionsServiceTest {
         String caseType1 = "CASE_TYPE_1";
         String caseType2 = "CASE_TYPE_2";
 
-        String[] groups =
-                ("/" + uuid2 + "," +
-                        "/" + uuid3 + "," +
-                        "/" + uuid1).split(",");
-
-
         Set<PermissionDto> permissions1 = Set.of(
                 new PermissionDto(caseType1, AccessLevel.CASE_ADMIN),
                 new PermissionDto(caseType2, AccessLevel.OWNER)
@@ -124,39 +112,26 @@ public class UserPermissionsServiceTest {
         Set<TeamDto> teams = Set.of(
                 new TeamDto(
                         "TEAM 1",
-                        Base64UUID.Base64StringToUUID(uuid1),
+                        Base64UUID.Base64StringToUUID(team1Base64),
                         true,
                         permissions1
                 )
         );
 
-        when(requestData.groupsArray()).thenReturn(groups);
         when(infoClient.getTeams()).thenReturn(teams);
 
-        service = new UserPermissionsService(requestData, infoClient);
         Set<String> caseTypes = service.getCaseTypesIfUserTeamIsCaseTypeAdmin();
         assertThat(caseTypes.size()).isEqualTo(1);
         assertThat(caseTypes.contains(caseType1)).isTrue();
     }
 
-    private void setupInfoClientMocks() {
+    @Test
+    public void isUserOnTeamShouldReturnTrueForTeamsTheyAreAMemberOf() {
+        assertThat( service.isUserOnTeam(team2Uuid)).isTrue();
+    }
 
-        Set<TeamDto> teamDtos = new HashSet<>();
-        Set<PermissionDto> permissions1 = new HashSet<>();
-        permissions1.add(new PermissionDto("MIN", AccessLevel.READ));
-        permissions1.add(new PermissionDto("MIN", AccessLevel.OWNER));
-        TeamDto teamDto1 = new TeamDto("TEAM 1", UUID.fromString("1325fe16-b864-42c7-85c2-7cab2863fe01"), true, permissions1);
-        teamDtos.add(teamDto1);
-
-        Set<PermissionDto> permissions2 = new HashSet<>();
-        permissions2.add(new PermissionDto("MIN", AccessLevel.READ));
-        permissions2.add(new PermissionDto("TRO",   AccessLevel.OWNER));
-        TeamDto teamDto2 = new TeamDto("TEAM 2", UUID.fromString("f1825c7d-baff-4c09-8056-2166760ccbd2"), true, permissions2);
-        teamDtos.add(teamDto2);
-
-        TeamDto teamDto3 = new TeamDto("TEAM 3", UUID.fromString("f1825c7d-baff-4c09-8056-2166760ccbd2"), true, new HashSet<>());
-        teamDtos.add(teamDto3);
-
-        when(infoClient.getTeams()).thenReturn(teamDtos);
+    @Test
+    public void isUserOnTeamShouldReturnFalseForTeamsTheyAreNotAMemberOf() {
+        assertThat(service.isUserOnTeam(UUID.randomUUID())).isFalse();
     }
 }


### PR DESCRIPTION
If at the end of a stage the user is a member of the team that handles the case at the next stage, then the case might want to be be allocated to them automatically and displayed on screen, instead of just going to the workstack.

When the workflow service - updateStageForward() - detects that the end of a stage is reached - in getStage() - it checks if the current user is on the team for the next stage. If they are the user is allocated to that case, and data relating to the new stage is returned to the front end.
The front end code detects if the stageId has changed, and uses that instead when it redirects.

The feature can be turned on by setting a process variable in the Camunda diagram. 

![sticky_cases001](https://user-images.githubusercontent.com/76998072/123073752-9d61e000-d40e-11eb-84bb-7b5a4d9d0cc8.png)

