### PR TITLE
HOCS-3278 - Lowering logging level.

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/security/RestResponseSecurityExceptionHandler.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/security/RestResponseSecurityExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import uk.gov.digital.ho.hocs.workflow.application.LogEvent;
 
 import static net.logstash.logback.argument.StructuredArguments.value;
 import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
@@ -18,20 +19,32 @@ import static uk.gov.digital.ho.hocs.workflow.application.LogEvent.EVENT;
 public class RestResponseSecurityExceptionHandler {
 
     @ExceptionHandler(SecurityExceptions.PermissionCheckException.class)
-    public ResponseEntity handle(SecurityExceptions.PermissionCheckException e) {
-        log.error("SecurityException: {}", e.getMessage(), value(EVENT,e.getEvent()));
+    public ResponseEntity<String> handle(SecurityExceptions.PermissionCheckException e) {
+        log.error("SecurityException: {} {}", e.getMessage(), value(EVENT, e.getEvent()));
         return new ResponseEntity<>(e.getMessage(), UNAUTHORIZED);
     }
 
     @ExceptionHandler(SecurityExceptions.StageNotAssignedToLoggedInUserException.class)
-    public ResponseEntity handle(SecurityExceptions.StageNotAssignedToLoggedInUserException e) {
-        log.error("SecurityException: {}", e.getMessage(), value(EVENT, e.getEvent()));
+    public ResponseEntity<String> handle(SecurityExceptions.StageNotAssignedToLoggedInUserException e) {
+        // SECURITY_CASE_NOT_ALLOCATED_TO_USER is misused by the frontend to drive its logic.
+        // The original intent of the message has been lost. Lowering to WARN, so that real errors can be seen
+        if (e.getEvent().equals(LogEvent.SECURITY_CASE_NOT_ALLOCATED_TO_USER)) {
+            log.warn("SecurityException: {} {}", e.getMessage(), value(EVENT, e.getEvent()));
+        } else {
+            log.error("SecurityException: {} {}", e.getMessage(), value(EVENT, e.getEvent()));
+        }
         return new ResponseEntity<>(e.getMessage(), FORBIDDEN);
     }
 
     @ExceptionHandler(SecurityExceptions.StageNotAssignedToUserTeamException.class)
-    public ResponseEntity handle(SecurityExceptions.StageNotAssignedToUserTeamException e) {
-        log.error("SecurityException: {}", e.getMessage(), value(EVENT, e.getEvent()));
+    public ResponseEntity<String> handle(SecurityExceptions.StageNotAssignedToUserTeamException e) {
+        if (e.getEvent().equals(LogEvent.SECURITY_CASE_NOT_ALLOCATED_TO_TEAM)) {
+            // SECURITY_CASE_NOT_ALLOCATED_TO_TEAM is misused by the frontend to drive its logic.
+            // The original intent of the message has been lost. Lowering to WARN, so that real errors can be seen
+            log.warn("SecurityException: {} {}", e.getMessage(), value(EVENT, e.getEvent()));
+        } else {
+            log.error("SecurityException: {} {}", e.getMessage(), value(EVENT, e.getEvent()));
+        }
         return new ResponseEntity<>(e.getMessage(), UNAUTHORIZED);
     }
 }


### PR DESCRIPTION
The frontend is using the FORBIDDEN and UNAUTHORISED response status' to drive its logic. 

The workflow endpoints annotated with @Allocated logs error messages when called if the user or team is not currently allocated.

We either lower the logging to WARN (this ticket) or redesign the frontend logic to not rely on the error status'