### PR TITLE
HOCS-3399: default path update enquiry reason

### DIFF
--- a/src/main/resources/processes/MPAM/MPAM_UPDATE_ENQUIRY_SUBJECT_REASON.bpmn
+++ b/src/main/resources/processes/MPAM/MPAM_UPDATE_ENQUIRY_SUBJECT_REASON.bpmn
@@ -19,7 +19,7 @@
       <bpmn:outgoing>Flow_11kdclp</bpmn:outgoing>
       <bpmn:outgoing>Flow_1wjhktn</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:exclusiveGateway id="Gateway_190pv43" name="Direction Check">
+    <bpmn:exclusiveGateway id="Gateway_190pv43" name="Direction Check" default="Flow_04lkhb6">
       <bpmn:incoming>Flow_018x7sy</bpmn:incoming>
       <bpmn:outgoing>Flow_0vnqtel</bpmn:outgoing>
       <bpmn:outgoing>Flow_04lkhb6</bpmn:outgoing>
@@ -34,7 +34,7 @@
       <bpmn:outgoing>Flow_17e9b7p</bpmn:outgoing>
       <bpmn:outgoing>Flow_02k5elb</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:exclusiveGateway id="Gateway_1ouon9a" name="Direction Check">
+    <bpmn:exclusiveGateway id="Gateway_1ouon9a" name="Direction Check" default="Flow_04pe7xc">
       <bpmn:incoming>Flow_1ot2qg5</bpmn:incoming>
       <bpmn:outgoing>Flow_09qem3v</bpmn:outgoing>
       <bpmn:outgoing>Flow_04pe7xc</bpmn:outgoing>
@@ -63,13 +63,9 @@
     <bpmn:sequenceFlow id="Flow_02k5elb" sourceRef="Gateway_06eavsn" targetRef="UpdateEnquirySubjectReason_Activity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_04pe7xc" name="BACKWARD" sourceRef="Gateway_1ouon9a" targetRef="ClearTempEnquirySubjectReason_Activity">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_04pe7xc" name="BACKWARD" sourceRef="Gateway_1ouon9a" targetRef="ClearTempEnquirySubjectReason_Activity" />
     <bpmn:sequenceFlow id="Flow_12msrbc" sourceRef="UpdateEnquirySubjectReason_Activity" targetRef="ClearTempEnquirySubjectReason_Activity" />
-    <bpmn:sequenceFlow id="Flow_04lkhb6" name="BACKWARD" sourceRef="Gateway_190pv43" targetRef="ClearTempEnquirySubject_Activity">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_04lkhb6" name="BACKWARD" sourceRef="Gateway_190pv43" targetRef="ClearTempEnquirySubject_Activity" />
     <bpmn:serviceTask id="ClearTempEnquirySubject_Activity" name="Clear Temp Enquiry Subject" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;tempEnquirySubject&#34;)}">
       <bpmn:incoming>Flow_04lkhb6</bpmn:incoming>
       <bpmn:outgoing>Flow_1dkgjpa</bpmn:outgoing>

--- a/src/main/resources/processes/MPAM/MPAM_UPDATE_ENQUIRY_SUBJECT_REASON.bpmn
+++ b/src/main/resources/processes/MPAM/MPAM_UPDATE_ENQUIRY_SUBJECT_REASON.bpmn
@@ -80,33 +80,13 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_UPDATE_ENQUIRY_SUBJECT_REASON">
-      <bpmndi:BPMNEdge id="Flow_1n47na7_di" bpmnElement="Flow_1n47na7">
-        <di:waypoint x="483" y="118" />
-        <di:waypoint x="483" y="180" />
+      <bpmndi:BPMNEdge id="Flow_1qnfu0k_di" bpmnElement="Flow_1qnfu0k">
+        <di:waypoint x="180" y="500" />
+        <di:waypoint x="180" y="367" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_11kdclp_di" bpmnElement="Flow_11kdclp">
-        <di:waypoint x="508" y="463" />
-        <di:waypoint x="637" y="463" />
-        <di:waypoint x="637" y="220" />
-        <di:waypoint x="533" y="220" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="560" y="445" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_018x7sy_di" bpmnElement="Flow_018x7sy">
-        <di:waypoint x="483" y="260" />
-        <di:waypoint x="483" y="324" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0vnqtel_di" bpmnElement="Flow_0vnqtel">
-        <di:waypoint x="483" y="374" />
-        <di:waypoint x="483" y="438" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="415" y="389" width="57" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1wjhktn_di" bpmnElement="Flow_1wjhktn">
-        <di:waypoint x="483" y="488" />
-        <di:waypoint x="483" y="530" />
+      <bpmndi:BPMNEdge id="Flow_1dkgjpa_di" bpmnElement="Flow_1dkgjpa">
+        <di:waypoint x="270" y="349" />
+        <di:waypoint x="198" y="349" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_04lkhb6_di" bpmnElement="Flow_04lkhb6">
         <di:waypoint x="458" y="349" />
@@ -114,6 +94,33 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="388" y="328" width="64" height="14" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12msrbc_di" bpmnElement="Flow_12msrbc">
+        <di:waypoint x="180" y="750" />
+        <di:waypoint x="180" y="580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04pe7xc_di" bpmnElement="Flow_04pe7xc">
+        <di:waypoint x="458" y="690" />
+        <di:waypoint x="180" y="690" />
+        <di:waypoint x="180" y="580" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="339" y="673" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02k5elb_di" bpmnElement="Flow_02k5elb">
+        <di:waypoint x="458" y="790" />
+        <di:waypoint x="230" y="790" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09qem3v_di" bpmnElement="Flow_09qem3v">
+        <di:waypoint x="483" y="715" />
+        <di:waypoint x="483" y="765" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="415" y="748" width="57" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ot2qg5_di" bpmnElement="Flow_1ot2qg5">
+        <di:waypoint x="483" y="610" />
+        <di:waypoint x="483" y="665" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_17e9b7p_di" bpmnElement="Flow_17e9b7p">
         <di:waypoint x="508" y="790" />
@@ -124,41 +131,40 @@
           <dc:Bounds x="562" y="773" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ot2qg5_di" bpmnElement="Flow_1ot2qg5">
-        <di:waypoint x="483" y="610" />
-        <di:waypoint x="483" y="665" />
+      <bpmndi:BPMNEdge id="Flow_1wjhktn_di" bpmnElement="Flow_1wjhktn">
+        <di:waypoint x="483" y="488" />
+        <di:waypoint x="483" y="530" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_09qem3v_di" bpmnElement="Flow_09qem3v">
-        <di:waypoint x="483" y="715" />
-        <di:waypoint x="483" y="765" />
+      <bpmndi:BPMNEdge id="Flow_0vnqtel_di" bpmnElement="Flow_0vnqtel">
+        <di:waypoint x="483" y="374" />
+        <di:waypoint x="483" y="438" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="415" y="748" width="57" height="14" />
+          <dc:Bounds x="415" y="389" width="57" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_02k5elb_di" bpmnElement="Flow_02k5elb">
-        <di:waypoint x="458" y="790" />
-        <di:waypoint x="230" y="790" />
+      <bpmndi:BPMNEdge id="Flow_018x7sy_di" bpmnElement="Flow_018x7sy">
+        <di:waypoint x="483" y="260" />
+        <di:waypoint x="483" y="324" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_04pe7xc_di" bpmnElement="Flow_04pe7xc">
-        <di:waypoint x="458" y="690" />
-        <di:waypoint x="180" y="690" />
-        <di:waypoint x="180" y="580" />
+      <bpmndi:BPMNEdge id="Flow_11kdclp_di" bpmnElement="Flow_11kdclp">
+        <di:waypoint x="508" y="463" />
+        <di:waypoint x="637" y="463" />
+        <di:waypoint x="637" y="220" />
+        <di:waypoint x="533" y="220" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="339" y="673" width="64" height="14" />
+          <dc:Bounds x="560" y="445" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_12msrbc_di" bpmnElement="Flow_12msrbc">
-        <di:waypoint x="180" y="750" />
-        <di:waypoint x="180" y="580" />
+      <bpmndi:BPMNEdge id="Flow_1n47na7_di" bpmnElement="Flow_1n47na7">
+        <di:waypoint x="483" y="118" />
+        <di:waypoint x="483" y="180" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1dkgjpa_di" bpmnElement="Flow_1dkgjpa">
-        <di:waypoint x="270" y="349" />
-        <di:waypoint x="198" y="349" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1qnfu0k_di" bpmnElement="Flow_1qnfu0k">
-        <di:waypoint x="180" y="500" />
-        <di:waypoint x="180" y="367" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="MpamUpdateEnquirySubjectReason_StartEvent">
+        <dc:Bounds x="465" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_14lgrh1_di" bpmnElement="MpamUpdateEnquirySubjectReason_EndEvent">
+        <dc:Bounds x="162" y="331" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0zvdw3s_di" bpmnElement="MpamEnquirySubject_Activity">
         <dc:Bounds x="433" y="180" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -174,26 +180,20 @@
       <bpmndi:BPMNShape id="Activity_0sn3zuo_di" bpmnElement="MpamEnquiryReason_Activity">
         <dc:Bounds x="433" y="530" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_06eavsn_di" bpmnElement="Gateway_06eavsn" isMarkerVisible="true">
+        <dc:Bounds x="458" y="765" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1ouon9a_di" bpmnElement="Gateway_1ouon9a" isMarkerVisible="true">
         <dc:Bounds x="458" y="665" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="518" y="683" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_06eavsn_di" bpmnElement="Gateway_06eavsn" isMarkerVisible="true">
-        <dc:Bounds x="458" y="765" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="MpamUpdateEnquirySubjectReason_StartEvent">
-        <dc:Bounds x="465" y="82" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_14lgrh1_di" bpmnElement="MpamUpdateEnquirySubjectReason_EndEvent">
-        <dc:Bounds x="162" y="331" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_1d9kyjk_di" bpmnElement="UpdateEnquirySubjectReason_Activity">
+        <dc:Bounds x="130" y="750" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_148wqse_di" bpmnElement="ClearTempEnquirySubject_Activity">
         <dc:Bounds x="270" y="309" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1d9kyjk_di" bpmnElement="UpdateEnquirySubjectReason_Activity">
-        <dc:Bounds x="130" y="750" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1wmpn1s_di" bpmnElement="ClearTempEnquirySubjectReason_Activity">
         <dc:Bounds x="130" y="500" width="100" height="80" />

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/mpam/MPAMUpdateEnquirySubjectReason.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/mpam/MPAMUpdateEnquirySubjectReason.java
@@ -73,6 +73,21 @@ public class MPAMUpdateEnquirySubjectReason {
     }
 
     @Test
+    public void whenEnquirySubjectInvalidDirection_thenClearCalledAndEndEvent() {
+        when(processScenario.waitsAtUserTask(MPAM_ENQUIRY_SUBJECT_ACTIVITY))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "TEST")));
+
+        Scenario.run(processScenario)
+                .startByKey(MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_BPMN)
+                .execute();
+
+        verify(processScenario).hasCompleted(MPAM_ENQUIRY_SUBJECT_ACTIVITY);
+        verify(processScenario).hasCompleted(CLEAR_TEMP_ENQUIRY_SUBJECT_ACTIVITY);
+        verify(processScenario).hasFinished(MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_END_EVENT);
+    }
+
+    @Test
     public void whenEnquirySubjectSubmittedInvalid_thenReloadsActivity() {
         when(processScenario.waitsAtUserTask(MPAM_ENQUIRY_SUBJECT_ACTIVITY))
                 .thenReturn(task -> task.complete(withVariables(
@@ -98,6 +113,27 @@ public class MPAMUpdateEnquirySubjectReason {
         when(processScenario.waitsAtUserTask(MPAM_ENQUIRY_REASON_ACTIVITY))
                 .thenReturn(task -> task.complete(withVariables(
                         "DIRECTION", "BACKWARD")));
+
+        Scenario.run(processScenario)
+                .startByKey(MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_BPMN)
+                .execute();
+
+        verify(processScenario).hasCompleted(MPAM_ENQUIRY_SUBJECT_ACTIVITY);
+        verify(processScenario).hasCompleted(MPAM_ENQUIRY_REASON_ACTIVITY);
+        verify(processScenario).hasCompleted(CLEAR_TEMP_ENQUIRY_SUBJECT_REASON_ACTIVITY);
+        verify(processScenario).hasFinished(MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_END_EVENT);
+    }
+
+    @Test
+    public void whenEnquiryReasonInvalidDirection_thenClearCalledAndEndEvent() {
+        when(processScenario.waitsAtUserTask(MPAM_ENQUIRY_SUBJECT_ACTIVITY))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "FORWARD",
+                        "valid", "true")));
+
+        when(processScenario.waitsAtUserTask(MPAM_ENQUIRY_REASON_ACTIVITY))
+                .thenReturn(task -> task.complete(withVariables(
+                        "DIRECTION", "TEST")));
 
         Scenario.run(processScenario)
                 .startByKey(MPAM_UPDATE_ENQUIRY_SUBJECT_REASON_BPMN)


### PR DESCRIPTION
A live service issue has occurred in the 
`MPAM_UPDATE_ENQUIRY_SUBJECT_REASON` flow whereby a 
value for the direction was provided that was not `FORWARD` or 
`BACKWARD`. This change adds the default flow, so that if the 
direction is not forward it always goes back.