### PR TITLE
HOCS-3760 - Timeline: Allocation to Dispatch and Soft Close stages ap…

### DIFF
--- a/src/main/resources/processes/FOI_DISPATCH.bpmn
+++ b/src/main/resources/processes/FOI_DISPATCH.bpmn
@@ -4,15 +4,11 @@
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0i3pner</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_0i3pner" sourceRef="StartEvent_1" targetRef="ALLOCATE_TO_CASE_CREATOR" />
+    <bpmn:sequenceFlow id="Flow_0i3pner" sourceRef="StartEvent_1" targetRef="CASE_OUTCOME" />
     <bpmn:endEvent id="END_EVENT">
       <bpmn:incoming>Flow_0ta2t92</bpmn:incoming>
       <bpmn:incoming>Flow_0s00p2d</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:serviceTask id="ALLOCATE_TO_CASE_CREATOR" name="Allocate to Case Creator" camunda:expression="${bpmnService.allocateUserToStage(execution.getVariable(&#34;CaseUUID&#34;), execution.getVariable(&#34;StageUUID&#34;), execution.getVariable(&#34;LastUpdatedByUserUUID&#34;))}">
-      <bpmn:incoming>Flow_0i3pner</bpmn:incoming>
-      <bpmn:outgoing>Flow_1jkk9w7</bpmn:outgoing>
-    </bpmn:serviceTask>
     <bpmn:serviceTask id="DEALLOCATE_TEAM" name="Deallocate team" camunda:expression="${bpmnService.wipeVariables(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;AllocationTeamUUID&#34;)}">
       <bpmn:extensionElements>
         <camunda:inputOutput>
@@ -53,7 +49,7 @@
     </bpmn:serviceTask>
     <bpmn:userTask id="CASE_OUTCOME" name="Case Outcome" camunda:formKey="FOI_OUTCOME">
       <bpmn:incoming>Flow_0gzfulw</bpmn:incoming>
-      <bpmn:incoming>Flow_1jkk9w7</bpmn:incoming>
+      <bpmn:incoming>Flow_0i3pner</bpmn:incoming>
       <bpmn:outgoing>Flow_1hcz5vw</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:sequenceFlow id="Flow_1hcz5vw" sourceRef="CASE_OUTCOME" targetRef="Gateway_09dd5lo" />
@@ -93,7 +89,6 @@
     <bpmn:sequenceFlow id="Flow_0gzfulw" sourceRef="DIRECTION_CHECK_2" targetRef="CASE_OUTCOME">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1jkk9w7" sourceRef="ALLOCATE_TO_CASE_CREATOR" targetRef="CASE_OUTCOME" />
     <bpmn:userTask id="DISPATCH_CONFIRMATION" name="Dispatch Confirmation" camunda:formKey="FOI_DISPATCH_CONFIRMATION">
       <bpmn:incoming>Flow_1ukatij</bpmn:incoming>
       <bpmn:outgoing>Flow_1ezh95i</bpmn:outgoing>
@@ -119,177 +114,170 @@
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="FOI_DISPATCH">
       <bpmndi:BPMNEdge id="Flow_0s00p2d_di" bpmnElement="Flow_0s00p2d">
-        <di:waypoint x="1980" y="260" />
-        <di:waypoint x="2050" y="260" />
-        <di:waypoint x="2050" y="310" />
-        <di:waypoint x="2122" y="310" />
+        <di:waypoint x="1780" y="260" />
+        <di:waypoint x="1850" y="260" />
+        <di:waypoint x="1850" y="310" />
+        <di:waypoint x="1922" y="310" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0zibisa_di" bpmnElement="Flow_0zibisa">
-        <di:waypoint x="1655" y="370" />
-        <di:waypoint x="1720" y="370" />
+        <di:waypoint x="1455" y="370" />
+        <di:waypoint x="1520" y="370" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1679" y="352" width="18" height="14" />
+          <dc:Bounds x="1479" y="352" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_12l0aj0_di" bpmnElement="Flow_12l0aj0">
-        <di:waypoint x="610" y="395" />
-        <di:waypoint x="610" y="520" />
-        <di:waypoint x="1330" y="520" />
-        <di:waypoint x="1330" y="410" />
+        <di:waypoint x="410" y="395" />
+        <di:waypoint x="410" y="520" />
+        <di:waypoint x="1130" y="520" />
+        <di:waypoint x="1130" y="410" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="961" y="502" width="18" height="14" />
+          <dc:Bounds x="761" y="502" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1k57hmg_di" bpmnElement="Flow_1k57hmg">
-        <di:waypoint x="1010" y="280" />
-        <di:waypoint x="1100" y="280" />
-        <di:waypoint x="1100" y="370" />
-        <di:waypoint x="1165" y="370" />
+        <di:waypoint x="810" y="280" />
+        <di:waypoint x="900" y="280" />
+        <di:waypoint x="900" y="370" />
+        <di:waypoint x="965" y="370" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1558ecs_di" bpmnElement="Flow_1558ecs">
-        <di:waypoint x="635" y="370" />
-        <di:waypoint x="735" y="370" />
+        <di:waypoint x="435" y="370" />
+        <di:waypoint x="535" y="370" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="672" y="353" width="15" height="14" />
+          <dc:Bounds x="472" y="353" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ezh95i_di" bpmnElement="Flow_1ezh95i">
-        <di:waypoint x="1550" y="370" />
-        <di:waypoint x="1605" y="370" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1jkk9w7_di" bpmnElement="Flow_1jkk9w7">
-        <di:waypoint x="350" y="370" />
-        <di:waypoint x="430" y="370" />
+        <di:waypoint x="1350" y="370" />
+        <di:waypoint x="1405" y="370" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0gzfulw_di" bpmnElement="Flow_0gzfulw" bioc:stroke="rgb(251, 140, 0)" bioc:fill="rgb(255, 224, 178)">
-        <di:waypoint x="1190" y="345" />
-        <di:waypoint x="1190" y="80" />
-        <di:waypoint x="480" y="80" />
-        <di:waypoint x="480" y="330" />
+        <di:waypoint x="990" y="345" />
+        <di:waypoint x="990" y="80" />
+        <di:waypoint x="280" y="80" />
+        <di:waypoint x="280" y="330" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_19zeqm9_di" bpmnElement="Flow_19zeqm9">
-        <di:waypoint x="1215" y="370" />
-        <di:waypoint x="1280" y="370" />
+        <di:waypoint x="1015" y="370" />
+        <di:waypoint x="1080" y="370" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1mzgyaq_di" bpmnElement="Flow_1mzgyaq">
-        <di:waypoint x="1010" y="370" />
-        <di:waypoint x="1165" y="370" />
+        <di:waypoint x="810" y="370" />
+        <di:waypoint x="965" y="370" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1a7mi1m_di" bpmnElement="Flow_1a7mi1m">
-        <di:waypoint x="1010" y="190" />
-        <di:waypoint x="1100" y="190" />
-        <di:waypoint x="1100" y="370" />
-        <di:waypoint x="1165" y="370" />
+        <di:waypoint x="810" y="190" />
+        <di:waypoint x="900" y="190" />
+        <di:waypoint x="900" y="370" />
+        <di:waypoint x="965" y="370" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_03mnfkj_di" bpmnElement="CASE_IS_FOI_AND_EIR">
-        <di:waypoint x="785" y="370" />
-        <di:waypoint x="910" y="370" />
+        <di:waypoint x="585" y="370" />
+        <di:waypoint x="710" y="370" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="814" y="353" width="51" height="14" />
+          <dc:Bounds x="614" y="353" width="51" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0w2x6yv_di" bpmnElement="CASE_IS_EIR">
-        <di:waypoint x="760" y="345" />
-        <di:waypoint x="760" y="280" />
-        <di:waypoint x="910" y="280" />
+        <di:waypoint x="560" y="345" />
+        <di:waypoint x="560" y="280" />
+        <di:waypoint x="710" y="280" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="830" y="266" width="19" height="27" />
+          <dc:Bounds x="630" y="266" width="19" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_07x7muq_di" bpmnElement="CASE_IS_FOI">
-        <di:waypoint x="760" y="345" />
-        <di:waypoint x="760" y="190" />
-        <di:waypoint x="910" y="190" />
+        <di:waypoint x="560" y="345" />
+        <di:waypoint x="560" y="190" />
+        <di:waypoint x="710" y="190" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="830" y="170" width="19" height="40" />
+          <dc:Bounds x="630" y="170" width="19" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hcz5vw_di" bpmnElement="Flow_1hcz5vw">
-        <di:waypoint x="530" y="370" />
-        <di:waypoint x="585" y="370" />
+        <di:waypoint x="330" y="370" />
+        <di:waypoint x="385" y="370" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ta2t92_di" bpmnElement="Flow_0ta2t92">
-        <di:waypoint x="1980" y="370" />
-        <di:waypoint x="2050" y="370" />
-        <di:waypoint x="2050" y="310" />
-        <di:waypoint x="2122" y="310" />
+        <di:waypoint x="1780" y="370" />
+        <di:waypoint x="1850" y="370" />
+        <di:waypoint x="1850" y="310" />
+        <di:waypoint x="1922" y="310" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_17qs3fi_di" bpmnElement="Flow_17qs3fi">
-        <di:waypoint x="1820" y="370" />
-        <di:waypoint x="1880" y="370" />
+        <di:waypoint x="1620" y="370" />
+        <di:waypoint x="1680" y="370" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ukatij_di" bpmnElement="Flow_1ukatij">
-        <di:waypoint x="1380" y="370" />
-        <di:waypoint x="1450" y="370" />
+        <di:waypoint x="1180" y="370" />
+        <di:waypoint x="1250" y="370" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_12miwv3_di" bpmnElement="Flow_12miwv3">
-        <di:waypoint x="1630" y="345" />
-        <di:waypoint x="1630" y="260" />
-        <di:waypoint x="1880" y="260" />
+        <di:waypoint x="1430" y="345" />
+        <di:waypoint x="1430" y="260" />
+        <di:waypoint x="1680" y="260" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1771" y="243" width="15" height="14" />
+          <dc:Bounds x="1571" y="243" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0i3pner_di" bpmnElement="Flow_0i3pner">
         <di:waypoint x="188" y="370" />
-        <di:waypoint x="250" y="370" />
+        <di:waypoint x="230" y="370" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="152" y="352" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0qd9vc8_di" bpmnElement="END_EVENT">
-        <dc:Bounds x="2122" y="292" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1t8q2s3_di" bpmnElement="ALLOCATE_TO_CASE_CREATOR">
-        <dc:Bounds x="250" y="330" width="100" height="80" />
+        <dc:Bounds x="1922" y="292" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_171ufiu_di" bpmnElement="DEALLOCATE_TEAM">
-        <dc:Bounds x="1280" y="330" width="100" height="80" />
+        <dc:Bounds x="1080" y="330" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1j7pjr8_di" bpmnElement="DISPATCHED" isMarkerVisible="true">
-        <dc:Bounds x="1605" y="345" width="50" height="50" />
+        <dc:Bounds x="1405" y="345" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1585" y="404.5" width="90" height="27" />
+          <dc:Bounds x="1385" y="405" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0pq3ve1_di" bpmnElement="SET_DISPATCH_DATE">
-        <dc:Bounds x="1720" y="330" width="100" height="80" />
+        <dc:Bounds x="1520" y="330" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_04y4vha_di" bpmnElement="CLEAR_REJECTED">
-        <dc:Bounds x="1880" y="330" width="100" height="80" />
+        <dc:Bounds x="1680" y="330" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_07adztc_di" bpmnElement="SET_TO_REJECTED_BY_DISPATCH">
-        <dc:Bounds x="1880" y="220" width="100" height="80" />
+        <dc:Bounds x="1680" y="220" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_00xvo20_di" bpmnElement="CASE_OUTCOME">
-        <dc:Bounds x="430" y="330" width="100" height="80" />
+        <dc:Bounds x="230" y="330" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1pbb4d1_di" bpmnElement="CASE_TYPE" isMarkerVisible="true">
-        <dc:Bounds x="735" y="345" width="50" height="50" />
+        <dc:Bounds x="535" y="345" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="719" y="404.5" width="82" height="53" />
+          <dc:Bounds x="519" y="405" width="82" height="53" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1pcsd76_di" bpmnElement="FOI_CASE_TYPE_DISPATCH">
-        <dc:Bounds x="910" y="150" width="100" height="80" />
+        <dc:Bounds x="710" y="150" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_05xte1l_di" bpmnElement="FOI_AND_EIR_CASE_TYPE_DISPATCH">
-        <dc:Bounds x="910" y="330" width="100" height="80" />
+        <dc:Bounds x="710" y="330" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1p0tqhv_di" bpmnElement="DIRECTION_CHECK_2" isMarkerVisible="true" bioc:stroke="rgb(251, 140, 0)" bioc:fill="rgb(255, 224, 178)">
-        <dc:Bounds x="1165" y="345" width="50" height="50" />
+        <dc:Bounds x="965" y="345" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1vq3x3s_di" bpmnElement="DISPATCH_CONFIRMATION">
-        <dc:Bounds x="1450" y="330" width="100" height="80" />
+        <dc:Bounds x="1250" y="330" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_09dd5lo_di" bpmnElement="Gateway_09dd5lo" isMarkerVisible="true">
-        <dc:Bounds x="585" y="345" width="50" height="50" />
+        <dc:Bounds x="385" y="345" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="565" y="233" width="89" height="93" />
+          <dc:Bounds x="365" y="233" width="89" height="93" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0lc6wzu_di" bpmnElement="EIR_CASE_TYPE_DISPATCH">
-        <dc:Bounds x="910" y="240" width="100" height="80" />
+        <dc:Bounds x="710" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="352" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/FOI_SOFT_CLOSE.bpmn
+++ b/src/main/resources/processes/FOI_SOFT_CLOSE.bpmn
@@ -7,14 +7,9 @@
     <bpmn:endEvent id="END_EVENT">
       <bpmn:incoming>Flow_0vo49w1</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_17it7j7" sourceRef="StartEvent_1" targetRef="ALLOCATE_TO_CASE_CREATOR" />
-    <bpmn:serviceTask id="ALLOCATE_TO_CASE_CREATOR" name="Allocate to Case Creator" camunda:expression="${bpmnService.allocateUserToStage(execution.getVariable(&#34;CaseUUID&#34;), execution.getVariable(&#34;StageUUID&#34;), execution.getVariable(&#34;LastUpdatedByUserUUID&#34;))}">
-      <bpmn:incoming>Flow_17it7j7</bpmn:incoming>
-      <bpmn:outgoing>Flow_1btl2sl</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1btl2sl" sourceRef="ALLOCATE_TO_CASE_CREATOR" targetRef="SOFT_CLOSE" />
+    <bpmn:sequenceFlow id="Flow_17it7j7" sourceRef="StartEvent_1" targetRef="SOFT_CLOSE" />
     <bpmn:userTask id="SOFT_CLOSE" name="Soft Close" camunda:formKey="FOI_SOFT_CLOSE">
-      <bpmn:incoming>Flow_1btl2sl</bpmn:incoming>
+      <bpmn:incoming>Flow_17it7j7</bpmn:incoming>
       <bpmn:outgoing>Flow_0ho615e</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:sequenceFlow id="Flow_0ho615e" sourceRef="SOFT_CLOSE" targetRef="DEALLOCATE_TEAM" />
@@ -27,35 +22,28 @@
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="FOI_SOFT_CLOSE">
       <bpmndi:BPMNEdge id="Flow_0vo49w1_di" bpmnElement="Flow_0vo49w1">
-        <di:waypoint x="660" y="97" />
-        <di:waypoint x="762" y="97" />
+        <di:waypoint x="480" y="97" />
+        <di:waypoint x="582" y="97" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ho615e_di" bpmnElement="Flow_0ho615e">
-        <di:waypoint x="500" y="97" />
-        <di:waypoint x="560" y="97" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1btl2sl_di" bpmnElement="Flow_1btl2sl">
-        <di:waypoint x="350" y="97" />
-        <di:waypoint x="400" y="97" />
+        <di:waypoint x="320" y="97" />
+        <di:waypoint x="380" y="97" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_17it7j7_di" bpmnElement="Flow_17it7j7">
-        <di:waypoint x="215" y="97" />
-        <di:waypoint x="250" y="97" />
+        <di:waypoint x="188" y="97" />
+        <di:waypoint x="220" y="97" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="79" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0dfyrd8_di" bpmnElement="END_EVENT">
-        <dc:Bounds x="762" y="79" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1ygfey9_di" bpmnElement="ALLOCATE_TO_CASE_CREATOR">
-        <dc:Bounds x="250" y="57" width="100" height="80" />
+        <dc:Bounds x="582" y="79" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_162bphh_di" bpmnElement="SOFT_CLOSE">
-        <dc:Bounds x="400" y="57" width="100" height="80" />
+        <dc:Bounds x="220" y="57" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1sdlkof_di" bpmnElement="DEALLOCATE_TEAM">
-        <dc:Bounds x="560" y="57" width="100" height="80" />
+        <dc:Bounds x="380" y="57" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="79" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI_DISPATCH.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI_DISPATCH.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.*;
         "processes/FOI_DISPATCH.bpmn"})
 public class FOI_DISPATCH {
 
-    public static final String ALLOCATE_TO_CASE_CREATOR = "ALLOCATE_TO_CASE_CREATOR";
     public static final String DISPATCH_CONFIRMATION = "DISPATCH_CONFIRMATION";
     public static final String DEALLOCATE_TEAM = "DEALLOCATE_TEAM";
     public static final String SET_DISPATCH_DATE = "SET_DISPATCH_DATE";
@@ -75,9 +74,6 @@ public class FOI_DISPATCH {
                 .execute();
 
         verify(FOIDataInputProcess, times(1))
-                .hasCompleted(ALLOCATE_TO_CASE_CREATOR);
-
-        verify(FOIDataInputProcess, times(1))
                 .hasCompleted(CASE_OUTCOME);
 
         verify(FOIDataInputProcess, times(1))
@@ -114,9 +110,6 @@ public class FOI_DISPATCH {
         Scenario.run(FOIDataInputProcess)
                 .startByKey("FOI_DISPATCH")
                 .execute();
-
-        verify(FOIDataInputProcess, times(1))
-                .hasCompleted(ALLOCATE_TO_CASE_CREATOR);
 
         verify(FOIDataInputProcess, times(1))
                 .hasCompleted(CASE_OUTCOME);
@@ -162,9 +155,6 @@ public class FOI_DISPATCH {
                 .startByKey("FOI_DISPATCH")
                 .execute();
 
-        verify(FOIDataInputProcess, times(1))
-                .hasCompleted(ALLOCATE_TO_CASE_CREATOR);
-
         verify(FOIDataInputProcess, times(2))
                 .hasCompleted(CASE_OUTCOME);
 
@@ -207,8 +197,6 @@ public class FOI_DISPATCH {
                 .startByKey("FOI_DISPATCH")
                 .execute();
 
-        verify(FOIDataInputProcess, times(1))
-                .hasCompleted(ALLOCATE_TO_CASE_CREATOR);
 
         verify(FOIDataInputProcess, times(1))
                 .hasCompleted(CASE_OUTCOME);
@@ -254,9 +242,6 @@ public class FOI_DISPATCH {
                 .execute();
 
         verify(FOIDataInputProcess, times(1))
-                .hasCompleted(ALLOCATE_TO_CASE_CREATOR);
-
-        verify(FOIDataInputProcess, times(1))
                 .hasCompleted(CASE_OUTCOME);
 
         verify(FOIDataInputProcess, times(1))
@@ -296,9 +281,6 @@ public class FOI_DISPATCH {
                 .execute();
 
         verify(FOIDataInputProcess, times(1))
-                .hasCompleted(ALLOCATE_TO_CASE_CREATOR);
-
-        verify(FOIDataInputProcess, times(1))
                 .hasCompleted(CASE_OUTCOME);
 
         verify(FOIDataInputProcess, times(1))
@@ -333,9 +315,6 @@ public class FOI_DISPATCH {
         Scenario.run(FOIDataInputProcess)
                 .startByKey("FOI_DISPATCH")
                 .execute();
-
-        verify(FOIDataInputProcess, times(1))
-                .hasCompleted(ALLOCATE_TO_CASE_CREATOR);
 
         verify(FOIDataInputProcess, times(1))
                 .hasCompleted(CASE_OUTCOME);

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI_SOFT_CLOSE.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/FOI_SOFT_CLOSE.java
@@ -24,7 +24,6 @@ import static org.mockito.Mockito.*;
         "processes/FOI_SOFT_CLOSE.bpmn"})
 public class FOI_SOFT_CLOSE {
 
-    public static final String ALLOCATE_TO_CASE_CREATOR = "ALLOCATE_TO_CASE_CREATOR";
     public static final String SOFT_CLOSE = "SOFT_CLOSE";
     public static final String DEALLOCATE_TEAM = "DEALLOCATE_TEAM";
     public static final String END_EVENT = "END_EVENT";
@@ -55,9 +54,6 @@ public class FOI_SOFT_CLOSE {
         Scenario.run(FOIDataInputProcess)
                 .startByKey("FOI_SOFT_CLOSE")
                 .execute();
-
-        verify(FOIDataInputProcess, times(1))
-                .hasCompleted(ALLOCATE_TO_CASE_CREATOR);
 
         verify(FOIDataInputProcess, times(1))
                 .hasCompleted(SOFT_CLOSE);


### PR DESCRIPTION
…pears twice

Before sticky cases, it was necessary to explicitly reassign the case to the
previous case owner at the dispatch and soft close stages. Now sticky cases 
is handling this, the case was getting assigned to the user twice, leading to
two audit messages.

* Remove superfluous user assignments at dispatch and soft close