### PR TITLE
HOCS- 3776: rejection note from MPAM QA Secretariat Clearance

### DIFF
--- a/src/main/resources/processes/MPAM_QA_CLEARANCE_REQ.bpmn
+++ b/src/main/resources/processes/MPAM_QA_CLEARANCE_REQ.bpmn
@@ -61,43 +61,41 @@
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_QA_CLEARANCE_REQ">
       <bpmndi:BPMNEdge id="SequenceFlow_10hrj3t_di" bpmnElement="SequenceFlow_10hrj3t">
-        <di:waypoint x="600" y="244" />
-        <di:waypoint x="600" y="170" />
+        <di:waypoint x="560" y="244" />
+        <di:waypoint x="560" y="170" />
         <di:waypoint x="420" y="170" />
         <di:waypoint x="420" y="229" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="498" y="153" width="24" height="14" />
+          <dc:Bounds x="478" y="153" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0l0p60c_di" bpmnElement="Flow_0l0p60c">
-        <di:waypoint x="795" y="270" />
-        <di:waypoint x="1002" y="270" />
+        <di:waypoint x="695" y="269" />
+        <di:waypoint x="972" y="269" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0zau21k_di" bpmnElement="Flow_0zau21k">
-        <di:waypoint x="950" y="380" />
-        <di:waypoint x="1020" y="380" />
-        <di:waypoint x="1020" y="288" />
+        <di:waypoint x="940" y="380" />
+        <di:waypoint x="990" y="380" />
+        <di:waypoint x="990" y="287" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1az80al_di" bpmnElement="Flow_1az80al">
-        <di:waypoint x="770" y="245" />
-        <di:waypoint x="770" y="160" />
-        <di:waypoint x="850" y="160" />
+        <di:waypoint x="670" y="244" />
+        <di:waypoint x="670" y="160" />
+        <di:waypoint x="710" y="160" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1tbjsft_di" bpmnElement="SequenceFlow_1tbjsft">
-        <di:waypoint x="950" y="160" />
-        <di:waypoint x="1020" y="160" />
-        <di:waypoint x="1020" y="252" />
+        <di:waypoint x="810" y="160" />
+        <di:waypoint x="990" y="160" />
+        <di:waypoint x="990" y="251" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1fy5iui_di" bpmnElement="SequenceFlow_1fy5iui">
-        <di:waypoint x="770" y="295" />
-        <di:waypoint x="770" y="380" />
-        <di:waypoint x="850" y="380" />
+        <di:waypoint x="670" y="294" />
+        <di:waypoint x="670" y="380" />
+        <di:waypoint x="710" y="380" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0mxqn3d_di" bpmnElement="SequenceFlow_0mxqn3d">
-        <di:waypoint x="625" y="269" />
-        <di:waypoint x="685" y="269" />
-        <di:waypoint x="685" y="270" />
-        <di:waypoint x="745" y="270" />
+        <di:waypoint x="585" y="269" />
+        <di:waypoint x="645" y="269" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_07ee3to_di" bpmnElement="SequenceFlow_07ee3to">
         <di:waypoint x="215" y="269" />
@@ -105,7 +103,11 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1xqw3h3_di" bpmnElement="SequenceFlow_1xqw3h3">
         <di:waypoint x="470" y="269" />
-        <di:waypoint x="575" y="269" />
+        <di:waypoint x="535" y="269" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0si4cno_di" bpmnElement="Flow_0si4cno">
+        <di:waypoint x="810" y="380" />
+        <di:waypoint x="840" y="380" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="251" width="36" height="36" />
@@ -114,22 +116,25 @@
         <dc:Bounds x="370" y="229" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1jszt5w_di" bpmnElement="ExclusiveGateway_1jszt5w" isMarkerVisible="true">
-        <dc:Bounds x="575" y="244" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_1cbg2t0_di" bpmnElement="mpam_clearance_end">
-        <dc:Bounds x="1002" y="252" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1048" y="263" width="52" height="14" />
-        </bpmndi:BPMNLabel>
+        <dc:Bounds x="535" y="244" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1mk5us6_di" bpmnElement="ExclusiveGateway_1mk5us6" isMarkerVisible="true">
-        <dc:Bounds x="745" y="245" width="50" height="50" />
+        <dc:Bounds x="645" y="244" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0zwr9c3_di" bpmnElement="mpam_qa_clearance_update_po">
-        <dc:Bounds x="850" y="120" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_16yec29_di" bpmnElement="AddClearanceRejectionNote_ServiceTask">
+        <dc:Bounds x="710" y="340" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_10lw97s_di" bpmnElement="mpam_qa_clearance_update_draft">
-        <dc:Bounds x="850" y="340" width="100" height="80" />
+        <dc:Bounds x="840" y="340" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0zwr9c3_di" bpmnElement="mpam_qa_clearance_update_po">
+        <dc:Bounds x="710" y="120" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1cbg2t0_di" bpmnElement="mpam_clearance_end">
+        <dc:Bounds x="972" y="251" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1018" y="262" width="52" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/MPAM_QA_CLEARANCE_REQ.bpmn
+++ b/src/main/resources/processes/MPAM_QA_CLEARANCE_REQ.bpmn
@@ -30,7 +30,7 @@
       <bpmn:outgoing>Flow_1az80al</bpmn:outgoing>
       <bpmn:outgoing>Flow_0l0p60c</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_1fy5iui" sourceRef="ExclusiveGateway_1mk5us6" targetRef="mpam_qa_clearance_update_draft">
+    <bpmn:sequenceFlow id="SequenceFlow_1fy5iui" sourceRef="ExclusiveGateway_1mk5us6" targetRef="AddClearanceRejectionNote_ServiceTask">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ClearanceStatus == "RejectDraft"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="mpam_qa_clearance_update_po" name="Update Team for PO" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_PO&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
@@ -42,7 +42,7 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ClearanceStatus == "ApprovePO"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:serviceTask id="mpam_qa_clearance_update_draft" name="Update Team for Draft" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_DRAFT&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
-      <bpmn:incoming>SequenceFlow_1fy5iui</bpmn:incoming>
+      <bpmn:incoming>Flow_0si4cno</bpmn:incoming>
       <bpmn:outgoing>Flow_0zau21k</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_0zau21k" sourceRef="mpam_qa_clearance_update_draft" targetRef="mpam_clearance_end" />
@@ -52,6 +52,11 @@
     <bpmn:sequenceFlow id="SequenceFlow_10hrj3t" name="false" sourceRef="ExclusiveGateway_1jszt5w" targetRef="Validate_Clearance_Fulfilment">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="AddClearanceRejectionNote_ServiceTask" name="Add Rejection Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;ClearanceRejectionReason&#34;), &#34;REJECT&#34;)}">
+      <bpmn:incoming>SequenceFlow_1fy5iui</bpmn:incoming>
+      <bpmn:outgoing>Flow_0si4cno</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0si4cno" sourceRef="AddClearanceRejectionNote_ServiceTask" targetRef="mpam_qa_clearance_update_draft" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_QA_CLEARANCE_REQ">

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMQaClearanceRequest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMQaClearanceRequest.java
@@ -62,6 +62,8 @@ public class MPAMQaClearanceRequest {
                 .startByKey("MPAM_QA_CLEARANCE_REQ")
                 .execute();
 
+        verify(bpmnService).updateAllocationNote(any(), any(), any(), eq("REJECT"));
+
         verify(bpmnService).updateTeamByStageAndTexts(any(), any(), eq("MPAM_DRAFT"), any(), any(), any(), any());
     }
 


### PR DESCRIPTION
Add the rejection allocation note service task when rejecting back to
the MPAM Draft stage from the MPAM QA Secretariat Clearance page.