### PR TITLE
HOCS-3752: remove backwards action

### DIFF
--- a/src/main/resources/processes/MPAM.bpmn
+++ b/src/main/resources/processes/MPAM.bpmn
@@ -151,7 +151,8 @@
       <bpmn:incoming>Flow_1k206o9</bpmn:incoming>
       <bpmn:incoming>Flow_04db6ze</bpmn:incoming>
       <bpmn:incoming>Flow_09i9au2</bpmn:incoming>
-      <bpmn:incoming>Flow_05z56qu</bpmn:incoming>
+      <bpmn:incoming>Flow_0k8hx52</bpmn:incoming>
+      <bpmn:incoming>Flow_19olhi7</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0d2t738</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_0d2t738" sourceRef="ServiceTask_0rwk9ie" targetRef="EndEvent_MPAM" />
@@ -362,7 +363,6 @@
         <camunda:in source="BusArea" target="BusArea" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1hnwm4d</bpmn:incoming>
-      <bpmn:incoming>Flow_1sg7yiu</bpmn:incoming>
       <bpmn:incoming>Flow_0ak0hys</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1d7lzq0</bpmn:outgoing>
     </bpmn:callActivity>
@@ -1146,15 +1146,13 @@
         <camunda:out source="LastUpdatedByUserUUID" target="LastUpdatedByUserUUID" />
         <camunda:out source="DraftUserUUID" target="CampaignUserUUID" />
         <camunda:in source="BusArea" target="BusArea" />
-        <camunda:out source="DIRECTION" target="DIRECTION" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1b84wxg</bpmn:incoming>
-      <bpmn:outgoing>SequenceFlow_0tx11bz</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0k8hx52</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="SequenceFlow_1b84wxg" name="Approved-Ministerial-Dispatch" sourceRef="ExclusiveGateway_168lif2" targetRef="CallActivity_0g8kpaf">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PoStatus == "Approved-Ministerial-Dispatch"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0tx11bz" sourceRef="CallActivity_0g8kpaf" targetRef="Gateway_0mh4ivk" />
     <bpmn:sequenceFlow id="SequenceFlow_1hnwm4d" name="Ministerial" sourceRef="ExclusiveGateway_1n7066i" targetRef="CallActivity_0wfokmb">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${RefType == "Ministerial"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -1175,27 +1173,13 @@
         <camunda:out source="LastUpdatedByUserUUID" target="LastUpdatedByUserUUID" />
         <camunda:out source="DraftUserUUID" target="CampaignUserUUID" />
         <camunda:in source="BusArea" target="BusArea" />
-        <camunda:out source="DIRECTION" target="DIRECTION" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_04jhw84</bpmn:incoming>
-      <bpmn:outgoing>Flow_04g6wk6</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19olhi7</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="SequenceFlow_04jhw84" name="Approved-Local-Dispatch" sourceRef="ExclusiveGateway_168lif2" targetRef="Activity_1ac1wjw">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${PoStatus == "Approved-Local-Dispatch"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="Gateway_0mh4ivk" name="Direction check">
-      <bpmn:incoming>SequenceFlow_0tx11bz</bpmn:incoming>
-      <bpmn:incoming>Flow_04g6wk6</bpmn:incoming>
-      <bpmn:outgoing>Flow_05z56qu</bpmn:outgoing>
-      <bpmn:outgoing>Flow_1sg7yiu</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_05z56qu" sourceRef="Gateway_0mh4ivk" targetRef="ServiceTask_0rwk9ie">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1sg7yiu" sourceRef="Gateway_0mh4ivk" targetRef="CallActivity_0wfokmb">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_04g6wk6" sourceRef="Activity_1ac1wjw" targetRef="Gateway_0mh4ivk" />
     <bpmn:callActivity id="CallActivity_QaClearanceReq" name="QA Clearance Requested" calledElement="STAGE_WITH_USER">
       <bpmn:extensionElements>
         <camunda:in source="QaOnHoldUUID" target="StageUUID" />
@@ -1238,6 +1222,8 @@
       <bpmn:outgoing>Flow_1ik0xae</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_18u47e2" sourceRef="CallActivity_QaClearanceReq" targetRef="Gateway_1iqhsrd" />
+    <bpmn:sequenceFlow id="Flow_0k8hx52" sourceRef="CallActivity_0g8kpaf" targetRef="ServiceTask_0rwk9ie" />
+    <bpmn:sequenceFlow id="Flow_19olhi7" sourceRef="Activity_1ac1wjw" targetRef="ServiceTask_0rwk9ie" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM">
@@ -1248,8 +1234,8 @@
       <bpmndi:BPMNEdge id="Flow_0ak0hys_di" bpmnElement="Flow_0ak0hys">
         <di:waypoint x="3525" y="940" />
         <di:waypoint x="4280" y="940" />
-        <di:waypoint x="4280" y="390" />
-        <di:waypoint x="4330" y="390" />
+        <di:waypoint x="4280" y="406" />
+        <di:waypoint x="4330" y="406" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_150gn8o_di" bpmnElement="Flow_150gn8o">
         <di:waypoint x="3475" y="940" />
@@ -1268,24 +1254,8 @@
         <di:waypoint x="3590" y="820" />
         <di:waypoint x="3540" y="820" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_04g6wk6_di" bpmnElement="Flow_04g6wk6">
-        <di:waypoint x="4850" y="520" />
-        <di:waypoint x="4950" y="520" />
-        <di:waypoint x="4950" y="399" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1sg7yiu_di" bpmnElement="Flow_1sg7yiu">
-        <di:waypoint x="4950" y="349" />
-        <di:waypoint x="4950" y="310" />
-        <di:waypoint x="4420" y="310" />
-        <di:waypoint x="4420" y="334" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_05z56qu_di" bpmnElement="Flow_05z56qu">
-        <di:waypoint x="4975" y="374" />
-        <di:waypoint x="5070" y="374" />
-        <di:waypoint x="5070" y="457" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_04jhw84_di" bpmnElement="SequenceFlow_04jhw84">
-        <di:waypoint x="4580" y="376" />
+        <di:waypoint x="4580" y="392" />
         <di:waypoint x="4580" y="500" />
         <di:waypoint x="4750" y="500" />
         <bpmndi:BPMNLabel>
@@ -1294,23 +1264,17 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1hnwm4d_di" bpmnElement="SequenceFlow_1hnwm4d">
         <di:waypoint x="4192" y="472" />
-        <di:waypoint x="4192" y="374" />
-        <di:waypoint x="4330" y="374" />
+        <di:waypoint x="4192" y="390" />
+        <di:waypoint x="4330" y="390" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="4135" y="422" width="50" height="14" />
+          <dc:Bounds x="4135" y="429" width="50" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0tx11bz_di" bpmnElement="SequenceFlow_0tx11bz">
-        <di:waypoint x="4830" y="374" />
-        <di:waypoint x="4925" y="374" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1b84wxg_di" bpmnElement="SequenceFlow_1b84wxg">
-        <di:waypoint x="4582" y="374" />
-        <di:waypoint x="4691" y="374" />
-        <di:waypoint x="4691" y="364" />
-        <di:waypoint x="4730" y="364" />
+        <di:waypoint x="4582" y="390" />
+        <di:waypoint x="4750" y="390" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="4646" y="382" width="54" height="40" />
+          <dc:Bounds x="4601" y="398" width="54" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ndomu1_di" bpmnElement="Flow_0ndomu1">
@@ -1873,13 +1837,13 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_18on675_di" bpmnElement="SequenceFlow_18on675">
-        <di:waypoint x="4548" y="390" />
+        <di:waypoint x="4548" y="406" />
         <di:waypoint x="4441" y="580" />
         <di:waypoint x="4441" y="980" />
         <di:waypoint x="1655" y="980" />
         <di:waypoint x="1655" y="1008" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="4473" y="523" width="82" height="14" />
+          <dc:Bounds x="4472" y="530" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_07swn4y_di" bpmnElement="SequenceFlow_07swn4y">
@@ -1926,23 +1890,23 @@
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1d7lzq0_di" bpmnElement="SequenceFlow_1d7lzq0">
-        <di:waypoint x="4430" y="374" />
-        <di:waypoint x="4532" y="374" />
+        <di:waypoint x="4430" y="390" />
+        <di:waypoint x="4532" y="390" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_04743df_di" bpmnElement="SequenceFlow_04743df">
-        <di:waypoint x="4561" y="353" />
-        <di:waypoint x="4610" y="280" />
-        <di:waypoint x="5090" y="280" />
+        <di:waypoint x="4561" y="369" />
+        <di:waypoint x="4610" y="300" />
+        <di:waypoint x="5090" y="300" />
         <di:waypoint x="5090" y="457" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="4650" y="261" width="22" height="14" />
+          <dc:Bounds x="4650" y="281" width="22" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1vol2gw_di" bpmnElement="SequenceFlow_1vol2gw">
-        <di:waypoint x="4557" y="349" />
+        <di:waypoint x="4557" y="365" />
         <di:waypoint x="4557" y="335" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="4579" y="330" width="53" height="14" />
+          <dc:Bounds x="4579" y="332" width="53" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0q4cqdw_di" bpmnElement="SequenceFlow_0q4cqdw">
@@ -2108,6 +2072,18 @@
         <di:waypoint x="238" y="502" />
         <di:waypoint x="280" y="502" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0k8hx52_di" bpmnElement="Flow_0k8hx52">
+        <di:waypoint x="4850" y="390" />
+        <di:waypoint x="4920" y="390" />
+        <di:waypoint x="4920" y="480" />
+        <di:waypoint x="5040" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19olhi7_di" bpmnElement="Flow_19olhi7">
+        <di:waypoint x="4850" y="520" />
+        <di:waypoint x="4920" y="520" />
+        <di:waypoint x="4920" y="480" />
+        <di:waypoint x="5040" y="480" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="202" y="484" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -2233,15 +2209,6 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="3603" y="442" width="82" height="27" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_168lif2_di" bpmnElement="ExclusiveGateway_168lif2" isMarkerVisible="true">
-        <dc:Bounds x="4532" y="349" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="4488" y="344" width="51" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="CallActivity_0wfokmb_di" bpmnElement="CallActivity_0wfokmb">
-        <dc:Bounds x="4330" y="334" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_08l5iqf_di" bpmnElement="ExclusiveGateway_08l5iqf" isMarkerVisible="true">
         <dc:Bounds x="3344" y="591" width="50" height="50" />
@@ -2417,23 +2384,26 @@
           <dc:Bounds x="4488" y="280" width="51" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0g8kpaf_di" bpmnElement="CallActivity_0g8kpaf">
-        <dc:Bounds x="4730" y="334" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1ac1wjw_di" bpmnElement="Activity_1ac1wjw">
-        <dc:Bounds x="4750" y="480" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0mh4ivk_di" bpmnElement="Gateway_0mh4ivk" isMarkerVisible="true">
-        <dc:Bounds x="4925" y="349" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="4912" y="406" width="76" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1tkqx68_di" bpmnElement="CallActivity_QaClearanceReq">
         <dc:Bounds x="3440" y="780" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1iqhsrd_di" bpmnElement="Gateway_1iqhsrd" isMarkerVisible="true">
         <dc:Bounds x="3475" y="915" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ac1wjw_di" bpmnElement="Activity_1ac1wjw">
+        <dc:Bounds x="4750" y="480" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_168lif2_di" bpmnElement="ExclusiveGateway_168lif2" isMarkerVisible="true">
+        <dc:Bounds x="4532" y="365" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="4488" y="360" width="51" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="CallActivity_0wfokmb_di" bpmnElement="CallActivity_0wfokmb">
+        <dc:Bounds x="4330" y="350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0g8kpaf_di" bpmnElement="CallActivity_0g8kpaf">
+        <dc:Bounds x="4750" y="350" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/MPAM_PO_APPROVED_LOCAL_DISPATCH.bpmn
+++ b/src/main/resources/processes/MPAM_PO_APPROVED_LOCAL_DISPATCH.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1l0bltw" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1l0bltw" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <bpmn:process id="MPAM_PO_APPROVED_LOCAL_DISPATCH" isExecutable="true">
     <bpmn:startEvent id="Event_0labn39">
       <bpmn:outgoing>Flow_1srarzf</bpmn:outgoing>
@@ -7,15 +7,14 @@
     <bpmn:userTask id="Validate_UserInput" name="Validate User Input" camunda:formKey="MPAM_PO_APPROVED_LOCAL_DISPATCH">
       <bpmn:incoming>Flow_1701vp2</bpmn:incoming>
       <bpmn:incoming>Flow_1srarzf</bpmn:incoming>
-      <bpmn:outgoing>Flow_1wyrl45</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1ctncmc</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:exclusiveGateway id="Gateway_1rzl6x4" default="Flow_1701vp2">
-      <bpmn:incoming>Flow_00qkakh</bpmn:incoming>
+      <bpmn:incoming>Flow_1ctncmc</bpmn:incoming>
       <bpmn:outgoing>Flow_1701vp2</bpmn:outgoing>
       <bpmn:outgoing>Flow_1oj8dp4</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:endEvent id="EndEvent_MPAMPoApprovedLocalDispatch" name="End Stage">
-      <bpmn:incoming>Flow_1horw0g</bpmn:incoming>
       <bpmn:incoming>Flow_1oj8dp4</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1srarzf" sourceRef="Event_0labn39" targetRef="Validate_UserInput" />
@@ -23,58 +22,30 @@
     <bpmn:sequenceFlow id="Flow_1oj8dp4" sourceRef="Gateway_1rzl6x4" targetRef="EndEvent_MPAMPoApprovedLocalDispatch">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="Gateway_1w1z44s" name="" default="Flow_00qkakh">
-      <bpmn:incoming>Flow_1wyrl45</bpmn:incoming>
-      <bpmn:outgoing>Flow_1oarje3</bpmn:outgoing>
-      <bpmn:outgoing>Flow_00qkakh</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_1oarje3" sourceRef="Gateway_1w1z44s" targetRef="Activity_0ry80sz">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="Activity_0ry80sz" name="Update Team for Private Office" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_PO&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
-      <bpmn:incoming>Flow_1oarje3</bpmn:incoming>
-      <bpmn:outgoing>Flow_1horw0g</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1horw0g" sourceRef="Activity_0ry80sz" targetRef="EndEvent_MPAMPoApprovedLocalDispatch" />
-    <bpmn:sequenceFlow id="Flow_1wyrl45" sourceRef="Validate_UserInput" targetRef="Gateway_1w1z44s" />
-    <bpmn:sequenceFlow id="Flow_00qkakh" sourceRef="Gateway_1w1z44s" targetRef="Gateway_1rzl6x4" />
+    <bpmn:sequenceFlow id="Flow_1ctncmc" sourceRef="Validate_UserInput" targetRef="Gateway_1rzl6x4" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_PO_APPROVED_LOCAL_DISPATCH">
       <bpmndi:BPMNEdge id="Flow_1oj8dp4_di" bpmnElement="Flow_1oj8dp4">
-        <di:waypoint x="513" y="203" />
-        <di:waypoint x="742" y="203" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1wyrl45_di" bpmnElement="Flow_1wyrl45">
-        <di:waypoint x="358" y="203" />
-        <di:waypoint x="385" y="203" />
+        <di:waypoint x="455" y="203" />
+        <di:waypoint x="502" y="203" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1701vp2_di" bpmnElement="Flow_1701vp2">
-        <di:waypoint x="488" y="178" />
-        <di:waypoint x="488" y="120" />
+        <di:waypoint x="430" y="178" />
+        <di:waypoint x="430" y="120" />
         <di:waypoint x="308" y="120" />
         <di:waypoint x="308" y="163" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="498" y="113" width="24" height="14" />
+          <dc:Bounds x="440" y="113" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1srarzf_di" bpmnElement="Flow_1srarzf">
         <di:waypoint x="188" y="203" />
         <di:waypoint x="258" y="203" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_00qkakh_di" bpmnElement="Flow_00qkakh">
-        <di:waypoint x="435" y="203" />
-        <di:waypoint x="463" y="203" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1oarje3_di" bpmnElement="Flow_1oarje3">
-        <di:waypoint x="410" y="228" />
-        <di:waypoint x="410" y="370" />
-        <di:waypoint x="530" y="370" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1horw0g_di" bpmnElement="Flow_1horw0g">
-        <di:waypoint x="630" y="370" />
-        <di:waypoint x="760" y="370" />
-        <di:waypoint x="760" y="221" />
+      <bpmndi:BPMNEdge id="Flow_1ctncmc_di" bpmnElement="Flow_1ctncmc">
+        <di:waypoint x="358" y="203" />
+        <di:waypoint x="405" y="203" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0labn39_di" bpmnElement="Event_0labn39">
         <dc:Bounds x="152" y="185" width="36" height="36" />
@@ -83,22 +54,13 @@
         <dc:Bounds x="258" y="163" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1rzl6x4_di" bpmnElement="Gateway_1rzl6x4" isMarkerVisible="true">
-        <dc:Bounds x="463" y="178" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1w1z44s_di" bpmnElement="Gateway_1w1z44s" isMarkerVisible="true">
-        <dc:Bounds x="385" y="178" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="562" y="148" width="76" height="14" />
-        </bpmndi:BPMNLabel>
+        <dc:Bounds x="405" y="178" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0620mms_di" bpmnElement="EndEvent_MPAMPoApprovedLocalDispatch">
-        <dc:Bounds x="742" y="185" width="36" height="36" />
+        <dc:Bounds x="502" y="185" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="734" y="161" width="52" height="14" />
+          <dc:Bounds x="494" y="161" width="52" height="14" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0ry80sz_di" bpmnElement="Activity_0ry80sz">
-        <dc:Bounds x="530" y="330" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/MPAM_PO_APPROVED_MIN_DISPATCH.bpmn
+++ b/src/main/resources/processes/MPAM_PO_APPROVED_MIN_DISPATCH.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1l0bltw" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.4.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1l0bltw" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <bpmn:process id="MPAM_PO_APPROVED_MIN_DISPATCH" isExecutable="true">
     <bpmn:startEvent id="Event_0labn39">
       <bpmn:outgoing>Flow_1srarzf</bpmn:outgoing>
@@ -10,71 +10,42 @@
       <bpmn:outgoing>Flow_1wyrl45</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:exclusiveGateway id="Gateway_1rzl6x4" default="Flow_1701vp2">
-      <bpmn:incoming>Flow_0rwc2vz</bpmn:incoming>
+      <bpmn:incoming>Flow_1wyrl45</bpmn:incoming>
       <bpmn:outgoing>Flow_1701vp2</bpmn:outgoing>
       <bpmn:outgoing>Flow_1oj8dp4</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:endEvent id="EndEvent_MPAMPoApprovedMinDispatch" name="End Stage">
-      <bpmn:incoming>Flow_1i87da6</bpmn:incoming>
       <bpmn:incoming>Flow_1oj8dp4</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1srarzf" sourceRef="Event_0labn39" targetRef="Validate_UserInput" />
     <bpmn:sequenceFlow id="Flow_1701vp2" name="false" sourceRef="Gateway_1rzl6x4" targetRef="Validate_UserInput" />
-    <bpmn:exclusiveGateway id="Gateway_1mcuhuz" name="" default="Flow_0rwc2vz">
-      <bpmn:incoming>Flow_1wyrl45</bpmn:incoming>
-      <bpmn:outgoing>Flow_1o2cq3f</bpmn:outgoing>
-      <bpmn:outgoing>Flow_0rwc2vz</bpmn:outgoing>
-    </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_1o2cq3f" sourceRef="Gateway_1mcuhuz" targetRef="Activity_13s3swa">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="Activity_13s3swa" name="Update Team for Private Office" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;MPAM_PO&#34;,&#34;QueueTeamUUID&#34;, &#34;QueueTeamName&#34;,&#34;BusArea&#34;,&#34;RefType&#34;)}">
-      <bpmn:incoming>Flow_1o2cq3f</bpmn:incoming>
-      <bpmn:outgoing>Flow_1i87da6</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1i87da6" sourceRef="Activity_13s3swa" targetRef="EndEvent_MPAMPoApprovedMinDispatch" />
     <bpmn:sequenceFlow id="Flow_1oj8dp4" sourceRef="Gateway_1rzl6x4" targetRef="EndEvent_MPAMPoApprovedMinDispatch">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1wyrl45" sourceRef="Validate_UserInput" targetRef="Gateway_1mcuhuz" />
-    <bpmn:sequenceFlow id="Flow_0rwc2vz" sourceRef="Gateway_1mcuhuz" targetRef="Gateway_1rzl6x4" />
+    <bpmn:sequenceFlow id="Flow_1wyrl45" sourceRef="Validate_UserInput" targetRef="Gateway_1rzl6x4" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_PO_APPROVED_MIN_DISPATCH">
-      <bpmndi:BPMNEdge id="Flow_1oj8dp4_di" bpmnElement="Flow_1oj8dp4">
-        <di:waypoint x="503" y="203" />
-        <di:waypoint x="622" y="203" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1wyrl45_di" bpmnElement="Flow_1wyrl45">
         <di:waypoint x="348" y="203" />
-        <di:waypoint x="365" y="203" />
+        <di:waypoint x="405" y="203" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1oj8dp4_di" bpmnElement="Flow_1oj8dp4">
+        <di:waypoint x="455" y="203" />
+        <di:waypoint x="502" y="203" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1701vp2_di" bpmnElement="Flow_1701vp2">
-        <di:waypoint x="478" y="178" />
-        <di:waypoint x="478" y="120" />
+        <di:waypoint x="430" y="178" />
+        <di:waypoint x="430" y="120" />
         <di:waypoint x="298" y="120" />
         <di:waypoint x="298" y="163" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="488" y="133" width="24" height="14" />
+          <dc:Bounds x="440" y="133" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1srarzf_di" bpmnElement="Flow_1srarzf">
         <di:waypoint x="188" y="203" />
         <di:waypoint x="248" y="203" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0rwc2vz_di" bpmnElement="Flow_0rwc2vz">
-        <di:waypoint x="415" y="203" />
-        <di:waypoint x="453" y="203" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1o2cq3f_di" bpmnElement="Flow_1o2cq3f">
-        <di:waypoint x="390" y="228" />
-        <di:waypoint x="390" y="320" />
-        <di:waypoint x="460" y="320" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1i87da6_di" bpmnElement="Flow_1i87da6">
-        <di:waypoint x="560" y="320" />
-        <di:waypoint x="640" y="320" />
-        <di:waypoint x="640" y="221" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0labn39_di" bpmnElement="Event_0labn39">
         <dc:Bounds x="152" y="185" width="36" height="36" />
@@ -83,22 +54,13 @@
         <dc:Bounds x="248" y="163" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1rzl6x4_di" bpmnElement="Gateway_1rzl6x4" isMarkerVisible="true">
-        <dc:Bounds x="453" y="178" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1mcuhuz_di" bpmnElement="Gateway_1mcuhuz" isMarkerVisible="true">
-        <dc:Bounds x="365" y="178" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="492" y="148" width="76" height="14" />
-        </bpmndi:BPMNLabel>
+        <dc:Bounds x="405" y="178" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0620mms_di" bpmnElement="EndEvent_MPAMPoApprovedMinDispatch">
-        <dc:Bounds x="622" y="185" width="36" height="36" />
+        <dc:Bounds x="502" y="185" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="614" y="161" width="52" height="14" />
+          <dc:Bounds x="494" y="161" width="52" height="14" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_13s3swa_di" bpmnElement="Activity_13s3swa">
-        <dc:Bounds x="460" y="280" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAM.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAM.java
@@ -771,60 +771,6 @@ public class MPAM {
     }
 
     @Test
-    public void whenAwaitingMinDispatchBackwards_ThenCompleteCase() {
-        ProcessExpressions.registerCallActivityMock("MPAM_PO_APPROVED_MIN_DISPATCH")
-                .onExecutionDo(new ExecutionVariableSequence(
-                        Arrays.asList(
-                                // first call
-                                Collections.singletonList(
-                                        new CallActivityReturnVariable("DIRECTION", "BACKWARD")
-                                ),
-                                // second call
-                                Collections.singletonList(
-                                        new CallActivityReturnVariable("DIRECTION", "FORWARD")
-                                )
-                        )
-                ))
-                .deploy(rule);
-
-        Scenario.run(mpamProcess)
-                .startByKey("MPAM")
-                .execute();
-
-        verify(mpamProcess, times(2))
-                .hasCompleted("CallActivity_0wfokmb");
-    }
-
-    @Test
-    public void whenAwaitingLocalDispatchBackwards_ThenCompleteCase() {
-        ProcessExpressions.registerCallActivityMock("MPAM_PO")
-                .onExecutionAddVariable("PoStatus", "Approved-Local-Dispatch")
-                .deploy(rule);
-
-        ProcessExpressions.registerCallActivityMock("MPAM_PO_APPROVED_LOCAL_DISPATCH")
-                .onExecutionDo(new ExecutionVariableSequence(
-                        Arrays.asList(
-                                // first call
-                                Collections.singletonList(
-                                        new CallActivityReturnVariable("DIRECTION", "BACKWARD")
-                                ),
-                                // second call
-                                Collections.singletonList(
-                                        new CallActivityReturnVariable("DIRECTION", "FORWARD")
-                                )
-                        )
-                ))
-                .deploy(rule);
-
-        Scenario.run(mpamProcess)
-                .startByKey("MPAM")
-                .execute();
-
-        verify(mpamProcess, times(2))
-                .hasCompleted("CallActivity_0wfokmb");
-    }
-
-    @Test
     public void whenQaClearanceRequestCancelled_thenReturnToQa() {
 
         ProcessExpressions.registerCallActivityMock("MPAM_QA")

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMPoApprovedLocalDispatch.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMPoApprovedLocalDispatch.java
@@ -27,7 +27,7 @@ public class MPAMPoApprovedLocalDispatch {
     @Rule
     @ClassRule
     public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
-            .assertClassCoverageAtLeast(0.8)
+            .assertClassCoverageAtLeast(1)
             .build();
 
     @Rule
@@ -47,10 +47,8 @@ public class MPAMPoApprovedLocalDispatch {
 
         when(processScenario.waitsAtUserTask("Validate_UserInput"))
                 .thenReturn(task -> task.complete(withVariables(
-                        "DIRECTION", "FORWARD",
                         "valid", false)))
                 .thenReturn(task -> task.complete(withVariables(
-                        "DIRECTION", "FORWARD",
                         "valid", true
                 )));
 
@@ -58,23 +56,6 @@ public class MPAMPoApprovedLocalDispatch {
                 .startByKey("MPAM_PO_APPROVED_LOCAL_DISPATCH")
                 .execute();
 
-        verify(processScenario).hasFinished("EndEvent_MPAMPoApprovedLocalDispatch");
-    }
-
-    @Test
-    public void setDirectionBackward_ThenEndStage() {
-
-        when(processScenario.waitsAtUserTask("Validate_UserInput"))
-                .thenReturn(task -> task.complete(withVariables(
-                        "DIRECTION", "BACKWARD",
-                        "valid", true
-                )));
-
-        Scenario.run(processScenario)
-                .startByKey("MPAM_PO_APPROVED_LOCAL_DISPATCH")
-                .execute();
-
-        verify(processScenario).hasCompleted("Activity_0ry80sz");
         verify(processScenario).hasFinished("EndEvent_MPAMPoApprovedLocalDispatch");
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMPoApprovedMinDispatch.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/MPAMPoApprovedMinDispatch.java
@@ -27,7 +27,7 @@ public class MPAMPoApprovedMinDispatch {
     @Rule
     @ClassRule
     public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create()
-            .assertClassCoverageAtLeast(0.8)
+            .assertClassCoverageAtLeast(1)
             .build();
 
     @Rule
@@ -47,33 +47,14 @@ public class MPAMPoApprovedMinDispatch {
 
         when(processScenario.waitsAtUserTask("Validate_UserInput"))
                 .thenReturn(task -> task.complete(withVariables(
-                        "DIRECTION", "FORWARD",
                         "valid", false)))
                 .thenReturn(task -> task.complete(withVariables(
-                        "DIRECTION", "FORWARD",
                         "valid", true)));
 
         Scenario.run(processScenario)
                 .startByKey("MPAM_PO_APPROVED_MIN_DISPATCH")
                 .execute();
 
-        verify(processScenario).hasFinished("EndEvent_MPAMPoApprovedMinDispatch");
-    }
-
-    @Test
-    public void setDirectionBackward_ThenEndStage() {
-
-        when(processScenario.waitsAtUserTask("Validate_UserInput"))
-                .thenReturn(task -> task.complete(withVariables(
-                        "DIRECTION", "BACKWARD",
-                        "valid", true
-                )));
-
-        Scenario.run(processScenario)
-                .startByKey("MPAM_PO_APPROVED_MIN_DISPATCH")
-                .execute();
-
-        verify(processScenario).hasCompleted("Activity_13s3swa");
         verify(processScenario).hasFinished("EndEvent_MPAMPoApprovedMinDispatch");
     }
 


### PR DESCRIPTION
Remove the backwards action from the MPAM Private Office Local and
Ministerial dispatch workflows as they are no longer required.