### PR TITLE
HOCS-3611: Revert InfoClient Change

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/client/infoclient/InfoClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/client/infoclient/InfoClient.java
@@ -56,7 +56,7 @@ public class InfoClient {
 
     @Cacheable(value = "InfoClientGetSchema", unless = "#result == null", key = "#type")
     public SchemaDto getSchema(String type) {
-        SchemaDto response = restHelper.get("http://localhost:8095", String.format("/schema/%s", type), SchemaDto.class);
+        SchemaDto response = restHelper.get(serviceBaseURL, String.format("/schema/%s", type), SchemaDto.class);
         log.info("Got Form {}", type, value(EVENT, INFO_CLIENT_GET_FORM_SUCCESS));
         return response;
     }


### PR DESCRIPTION
In a previous peer review this line was accidentally committed and
ended up in the main branch. This breaks both local and released
versions.