### PR TITLE
HOCS-4046: move unit and wrap in null

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
@@ -223,22 +223,31 @@ public class BpmnService {
                                            String topicUUIDString,
                                            String stageType,
                                            String teamNameKey,
+                                           String teamUUIDKey) {
+        updateTeamsForPrimaryTopic(caseUUIDString, stageUUIDString, topicUUIDString, stageType, teamNameKey, teamUUIDKey, null);
+    }
+
+    public void updateTeamsForPrimaryTopic(String caseUUIDString,
+                                           String stageUUIDString,
+                                           String topicUUIDString,
+                                           String stageType,
+                                           String teamNameKey,
                                            String teamUUIDKey,
                                            String unitNameKey) {
         UUID caseUUID = UUID.fromString(caseUUIDString);
         UUID stageUUID = UUID.fromString(stageUUIDString);
         UUID topicUUID = UUID.fromString(topicUUIDString);
 
-
         Map<String, String> teamsForTopic = new HashMap<>();
         TeamDto teamDto = infoClient.getTeamForTopicAndStage(caseUUID, topicUUID, stageType);
 
-        UnitDto unit = infoClient.getUnitForTeam(teamDto.getUuid());
-
         if (teamDto.isActive()) {
+            if (unitNameKey != null) {
+                UnitDto unit = infoClient.getUnitForTeam(teamDto.getUuid());
+                teamsForTopic.put(unitNameKey, unit.getDisplayName());
+            }
             teamsForTopic.put(teamNameKey, teamDto.getUuid().toString());
             teamsForTopic.put(teamUUIDKey, teamDto.getDisplayName());
-            teamsForTopic.put(unitNameKey, unit.getDisplayName());
         } else {
             log.warn("Avoiding assigning orphaned team {}", teamDto.getDisplayName());
         }


### PR DESCRIPTION
Currently, there is a use case of the old method that requires 6
parameters. This change reintroduces this and sends null as the 7th
parameter. A new null check has been added to the 7th method parameter.