### PR TITLE
HOCS-3987: Add pending path to SMC_TRIAGE

### DIFF
--- a/src/main/resources/processes/SMC_TRIAGE.bpmn
+++ b/src/main/resources/processes/SMC_TRIAGE.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0a8virv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0a8virv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
   <bpmn:process id="SMC_TRIAGE" isExecutable="true">
     <bpmn:startEvent id="StartEvent_SCM_CREATION">
       <bpmn:outgoing>Flow_1lciqyx</bpmn:outgoing>
@@ -123,6 +123,7 @@
       <bpmn:incoming>Flow_1gfxyfp</bpmn:incoming>
       <bpmn:incoming>Flow_08elfne</bpmn:incoming>
       <bpmn:incoming>Flow_05bbb05</bpmn:incoming>
+      <bpmn:incoming>Flow_1547yy0</bpmn:incoming>
       <bpmn:outgoing>Flow_1lbzifu</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:sequenceFlow id="Flow_1lbzifu" sourceRef="Validate_Input" targetRef="Gateway_1j2eg6u" />
@@ -174,6 +175,7 @@
       <bpmn:outgoing>Flow_0umeej4</bpmn:outgoing>
       <bpmn:outgoing>Flow_0fskqhi</bpmn:outgoing>
       <bpmn:outgoing>Flow_0y7c2qt</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1547yy0</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_0umeej4" sourceRef="Gateway_07j18cg" targetRef="EndEvent_SCM_TRIAGE" />
     <bpmn:exclusiveGateway id="Gateway_0ljy3uj">
@@ -399,9 +401,38 @@
     <bpmn:sequenceFlow id="Flow_0ios2rf" sourceRef="Gateway_1c179h4" targetRef="Validate_PSU">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1547yy0" sourceRef="Gateway_07j18cg" targetRef="Validate_Input">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ScmTriageResult == "Pending" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="SMC_TRIAGE">
+      <bpmndi:BPMNEdge id="Flow_0ios2rf_di" bpmnElement="Flow_0ios2rf">
+        <di:waypoint x="960" y="455" />
+        <di:waypoint x="960" y="390" />
+        <di:waypoint x="700" y="390" />
+        <di:waypoint x="700" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05eegm6_di" bpmnElement="Flow_05eegm6">
+        <di:waypoint x="840" y="505" />
+        <di:waypoint x="840" y="550" />
+        <di:waypoint x="310" y="550" />
+        <di:waypoint x="310" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0y628fl_di" bpmnElement="Flow_0y628fl">
+        <di:waypoint x="985" y="480" />
+        <di:waypoint x="1048" y="480" />
+        <di:waypoint x="1048" y="479" />
+        <di:waypoint x="1110" y="479" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06ozafo_di" bpmnElement="Flow_06ozafo">
+        <di:waypoint x="865" y="480" />
+        <di:waypoint x="935" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13l8y8t_di" bpmnElement="Flow_13l8y8t">
+        <di:waypoint x="750" y="480" />
+        <di:waypoint x="815" y="480" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1qj6mpl_di" bpmnElement="Flow_1qj6mpl">
         <di:waypoint x="1930" y="120" />
         <di:waypoint x="3320" y="120" />
@@ -681,6 +712,20 @@
         <di:waypoint x="1530" y="479" />
         <di:waypoint x="1565" y="479" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0a7p2w7_di" bpmnElement="Flow_0a7p2w7">
+        <di:waypoint x="450" y="455" />
+        <di:waypoint x="450" y="381" />
+        <di:waypoint x="310" y="381" />
+        <di:waypoint x="310" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16273oq_di" bpmnElement="Flow_16273oq">
+        <di:waypoint x="475" y="480" />
+        <di:waypoint x="525" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1of1hdr_di" bpmnElement="Flow_1of1hdr">
+        <di:waypoint x="360" y="480" />
+        <di:waypoint x="425" y="480" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1aiurc0_di" bpmnElement="Flow_1aiurc0">
         <di:waypoint x="1360" y="454" />
         <di:waypoint x="1360" y="380" />
@@ -699,46 +744,15 @@
         <di:waypoint x="188" y="480" />
         <di:waypoint x="260" y="480" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0a7p2w7_di" bpmnElement="Flow_0a7p2w7">
-        <di:waypoint x="450" y="455" />
-        <di:waypoint x="450" y="381" />
-        <di:waypoint x="310" y="381" />
-        <di:waypoint x="310" y="440" />
+      <bpmndi:BPMNEdge id="Flow_1547yy0_di" bpmnElement="Flow_1547yy0">
+        <di:waypoint x="2430" y="454" />
+        <di:waypoint x="2430" y="320" />
+        <di:waypoint x="2130" y="320" />
+        <di:waypoint x="2130" y="439" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1of1hdr_di" bpmnElement="Flow_1of1hdr">
-        <di:waypoint x="360" y="480" />
-        <di:waypoint x="425" y="480" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_16273oq_di" bpmnElement="Flow_16273oq">
-        <di:waypoint x="475" y="480" />
-        <di:waypoint x="525" y="480" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_13l8y8t_di" bpmnElement="Flow_13l8y8t">
-        <di:waypoint x="750" y="480" />
-        <di:waypoint x="815" y="480" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_06ozafo_di" bpmnElement="Flow_06ozafo">
-        <di:waypoint x="865" y="480" />
-        <di:waypoint x="935" y="480" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0y628fl_di" bpmnElement="Flow_0y628fl">
-        <di:waypoint x="985" y="480" />
-        <di:waypoint x="1048" y="480" />
-        <di:waypoint x="1048" y="479" />
-        <di:waypoint x="1110" y="479" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_05eegm6_di" bpmnElement="Flow_05eegm6">
-        <di:waypoint x="840" y="505" />
-        <di:waypoint x="840" y="550" />
-        <di:waypoint x="310" y="550" />
-        <di:waypoint x="310" y="520" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ios2rf_di" bpmnElement="Flow_0ios2rf">
-        <di:waypoint x="960" y="455" />
-        <di:waypoint x="960" y="390" />
-        <di:waypoint x="700" y="390" />
-        <di:waypoint x="700" y="440" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_SCM_CREATION">
+        <dc:Bounds x="152" y="462" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_0pmmumb_di" bpmnElement="EndEvent_SCM_TRIAGE">
         <dc:Bounds x="3302" y="461" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -747,6 +761,12 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1uy0qdp_di" bpmnElement="Gateway_1uy0qdp" isMarkerVisible="true">
         <dc:Bounds x="1335" y="454" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_021qlar_di" bpmnElement="Validate_Case">
+        <dc:Bounds x="260" y="440" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_00ouqyf_di" bpmnElement="Gateway_00ouqyf" isMarkerVisible="true">
+        <dc:Bounds x="425" y="455" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0e2u7qm_di" bpmnElement="Validate_Details">
         <dc:Bounds x="1430" y="439" width="100" height="80" />
@@ -829,6 +849,9 @@
       <bpmndi:BPMNShape id="Gateway_0mdg77m_di" bpmnElement="Gateway_0mdg77m" isMarkerVisible="true">
         <dc:Bounds x="2975" y="925" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1pg2ieb_di" bpmnElement="Gateway_1pg2ieb" isMarkerVisible="true">
+        <dc:Bounds x="525" y="455" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1iktxlb_di" bpmnElement="Transfer_Case">
         <dc:Bounds x="1110" y="210" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -850,26 +873,14 @@
       <bpmndi:BPMNShape id="Gateway_0uzp5gs_di" bpmnElement="Gateway_0uzp5gs" isMarkerVisible="true">
         <dc:Bounds x="1665" y="225" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_SCM_CREATION">
-        <dc:Bounds x="152" y="462" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_021qlar_di" bpmnElement="Validate_Case">
-        <dc:Bounds x="260" y="440" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_00ouqyf_di" bpmnElement="Gateway_00ouqyf" isMarkerVisible="true">
-        <dc:Bounds x="425" y="455" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1pg2ieb_di" bpmnElement="Gateway_1pg2ieb" isMarkerVisible="true">
-        <dc:Bounds x="525" y="455" width="50" height="50" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0jybflc_di" bpmnElement="Validate_PSU">
         <dc:Bounds x="650" y="440" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1c179h4_di" bpmnElement="Gateway_1c179h4" isMarkerVisible="true">
-        <dc:Bounds x="935" y="455" width="50" height="50" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0u1ljyz_di" bpmnElement="Gateway_0u1ljyz" isMarkerVisible="true">
         <dc:Bounds x="815" y="455" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1c179h4_di" bpmnElement="Gateway_1c179h4" isMarkerVisible="true">
+        <dc:Bounds x="935" y="455" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/SMC_TRIAGE.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/SMC_TRIAGE.java
@@ -155,6 +155,34 @@ public class SMC_TRIAGE {
     }
 
     @Test
+    public void testSaveAtTriage() {
+        when(process.waitsAtUserTask("Validate_Case"))
+                .thenReturn(task -> task.complete(withVariables("valid", true, "CctTriageAccept", "Yes")));
+
+        when(process.waitsAtUserTask("Validate_PSU"))
+                .thenReturn(task -> task.complete(withVariables("valid", true, "DIRECTION", "FORWARD")));
+
+        when(process.waitsAtUserTask("Validate_Category"))
+                .thenReturn(task -> task.complete(withVariables("valid", true, "DIRECTION", "FORWARD")));
+
+        when(process.waitsAtUserTask("Validate_Details"))
+                .thenReturn(task -> task.complete(withVariables("valid", true, "DIRECTION", "FORWARD")));
+
+        when(process.waitsAtUserTask("Validate_Reasons"))
+                .thenReturn(task -> task.complete(withVariables("valid", true, "DIRECTION", "FORWARD")));
+
+        when(process.waitsAtUserTask("Validate_Input"))
+                .thenReturn(task -> task.complete(withVariables("valid", false, "DIRECTION", "BACKWARD")))
+                .thenReturn(task -> task.complete(withVariables("valid", false, "DIRECTION", "FORWARD")))
+                .thenReturn(task -> task.complete(withVariables("valid", true, "DIRECTION", "FORWARD", "ScmTriageResult", "Pending")))
+                .thenReturn(task -> task.complete(withVariables("valid", true, "DIRECTION", "FORWARD", "ScmTriageResult", "NotPending")));
+
+        Scenario.run(process).startByKey("SMC_TRIAGE").execute();
+
+        verify(process).hasCompleted("EndEvent_SCM_TRIAGE");
+    }
+
+    @Test
     public void testTransferCaseToCCH(){
         when(process.waitsAtUserTask("Validate_Case"))
                 .thenReturn(task -> task.complete(withVariables("valid", true, "CctTriageAccept", "No")));


### PR DESCRIPTION
Currently, there isn't a path for pending in the SMC_TRIAGE model. This
means that the case moves to draft instead of staying in triage. This
change adds this path and the required test coverage.