### PR TITLE
HOCS-4081 add check for null field when adding case notes

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
@@ -420,6 +420,10 @@ public class BpmnService {
 
     public void updateAllocationNote(String caseUUIDString, String stageUUIDString, String allocationNote, String allocationNoteType) {
         log.debug("######## Save Allocation Note ########");
+        if (allocationNote == null) {
+            log.error("updateAllocationNote was passed a null allocation note parameter, this has been set to an empty string.");
+            allocationNote = "";
+        }
         caseworkClient.createCaseNote(UUID.fromString(caseUUIDString), allocationNoteType, allocationNote);
         log.info("Adding Casenote to Case: {}", caseUUIDString);
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/BpmnServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/BpmnServiceTest.java
@@ -724,6 +724,43 @@ public class BpmnServiceTest {
     }
 
     @Test
+    public void shouldUpdateAllocationNote() {
+
+        UUID testCaseId = UUID.randomUUID();
+        UUID testStageId = UUID.randomUUID();
+        String testCaseNote = "Case note text";
+        ArgumentCaptor<String> valueCapture = ArgumentCaptor.forClass(String.class);
+
+        when(caseworkClient.createCaseNote(testCaseId, "CLOSE_CASE", testCaseNote)).thenReturn(testCaseId);
+
+        bpmnService.updateAllocationNote(testCaseId.toString(), testStageId.toString(), testCaseNote, "CLOSE_CASE");
+
+        verify(caseworkClient, times(1)).createCaseNote(testCaseId, "CLOSE_CASE", testCaseNote);
+        verify(caseworkClient).createCaseNote(eq(testCaseId), eq("CLOSE_CASE"), valueCapture.capture());
+        assertThat(valueCapture.getValue()).isEqualTo(testCaseNote);
+        verifyNoMoreInteractions(caseworkClient, infoClient, camundaClient);
+    }
+
+    @Test
+    public void shouldUpdateAllocationNoteFromNullNote() {
+
+        UUID testCaseId = UUID.randomUUID();
+        UUID testStageId = UUID.randomUUID();
+        String testCaseNote = null;
+        String expectedCaseNote ="";
+        ArgumentCaptor<String> valueCapture = ArgumentCaptor.forClass(String.class);
+
+        when(caseworkClient.createCaseNote(testCaseId, "CLOSE_CASE", expectedCaseNote)).thenReturn(testCaseId);
+
+        bpmnService.updateAllocationNote(testCaseId.toString(), testStageId.toString(), testCaseNote, "CLOSE_CASE");
+
+        verify(caseworkClient, times(1)).createCaseNote(testCaseId, "CLOSE_CASE", expectedCaseNote);
+        verify(caseworkClient).createCaseNote(eq(testCaseId), eq("CLOSE_CASE"), valueCapture.capture());
+        assertThat(valueCapture.getValue()).isEqualTo(expectedCaseNote);
+        verifyNoMoreInteractions(caseworkClient, infoClient, camundaClient);
+    }
+
+    @Test
     public void shouldCreateCaseNote() {
 
         UUID testCaseId = UUID.randomUUID();


### PR DESCRIPTION
added check for null field when adding case notes. Null field is replaced by empty string and error logged as this should not really be happening.