### PR TITLE
HOCS-4081 update to null case note issue

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
@@ -421,11 +421,11 @@ public class BpmnService {
     public void updateAllocationNote(String caseUUIDString, String stageUUIDString, String allocationNote, String allocationNoteType) {
         log.debug("######## Save Allocation Note ########");
         if (allocationNote == null) {
-            log.error("updateAllocationNote was passed a null allocation note parameter, this has been set to an empty string.");
-            allocationNote = "";
+            log.error("updateAllocationNote was passed a null allocation note, this note shall not be updated.");
+        } else {
+            caseworkClient.createCaseNote(UUID.fromString(caseUUIDString), allocationNoteType, allocationNote);
+            log.info("Adding Casenote to Case: {}", caseUUIDString);
         }
-        caseworkClient.createCaseNote(UUID.fromString(caseUUIDString), allocationNoteType, allocationNote);
-        log.info("Adding Casenote to Case: {}", caseUUIDString);
     }
 
     /**

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/BpmnServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/BpmnServiceTest.java
@@ -742,21 +742,15 @@ public class BpmnServiceTest {
     }
 
     @Test
-    public void shouldUpdateAllocationNoteFromNullNote() {
+    public void shouldNotUpdateAllocationNoteFromNullNote() {
 
         UUID testCaseId = UUID.randomUUID();
         UUID testStageId = UUID.randomUUID();
         String testCaseNote = null;
-        String expectedCaseNote ="";
-        ArgumentCaptor<String> valueCapture = ArgumentCaptor.forClass(String.class);
-
-        when(caseworkClient.createCaseNote(testCaseId, "CLOSE_CASE", expectedCaseNote)).thenReturn(testCaseId);
 
         bpmnService.updateAllocationNote(testCaseId.toString(), testStageId.toString(), testCaseNote, "CLOSE_CASE");
 
-        verify(caseworkClient, times(1)).createCaseNote(testCaseId, "CLOSE_CASE", expectedCaseNote);
-        verify(caseworkClient).createCaseNote(eq(testCaseId), eq("CLOSE_CASE"), valueCapture.capture());
-        assertThat(valueCapture.getValue()).isEqualTo(expectedCaseNote);
+        verify(caseworkClient, times(0)).createCaseNote(any(), any(), any());
         verifyNoMoreInteractions(caseworkClient, infoClient, camundaClient);
     }
 


### PR DESCRIPTION
I have altered the way updates to existing case notes are handling when the text value is null. Previously the null value was replaced with an empty string but that leads to blank case notes in the timeline so any null values are now ignored and the case note is unaltered.