### PR TITLE
Fix: pipeline resource allocation

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -3,6 +3,11 @@ kind: pipeline
 type: kubernetes
 name: build
 
+resources:
+  requests:
+    cpu: 400
+    memory: 200MiB
+
 services:
   - name: postgres
     image: quay.io/ukhomeofficedigital/postgres-alpine
@@ -93,6 +98,11 @@ trigger:
     exclude:
       - pull_request
       - tag
+
+resources:
+  requests:
+    cpu: 400
+    memory: 200MiB
 
 services:
   - name: docker


### PR DESCRIPTION
When pushing to main the pipeline is thought to be running out of
resources and failing on the deployment to the dev environments. This
change doubles the default to see if this is the case.