### PR TITLE
HOCS-4030: fix pipeline directory

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -106,7 +106,7 @@ steps:
   - name: deploy to cs-dev
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     commands:
-      - cd kube-hocs-workflow
+      - cd kube
       - ./deploy.sh
     environment:
       ENVIRONMENT: cs-dev
@@ -123,7 +123,7 @@ steps:
   - name: deploy to wcs-dev
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     commands:
-      - cd kube-hocs-workflow
+      - cd kube
       - ./deploy.sh
     environment:
       ENVIRONMENT: wcs-dev

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,11 +3,6 @@ kind: pipeline
 type: kubernetes
 name: build
 
-resources:
-  requests:
-    cpu: 400
-    memory: 200MiB
-
 services:
   - name: postgres
     image: quay.io/ukhomeofficedigital/postgres-alpine
@@ -98,11 +93,6 @@ trigger:
     exclude:
       - pull_request
       - tag
-
-resources:
-  requests:
-    cpu: 400
-    memory: 200MiB
 
 services:
   - name: docker


### PR DESCRIPTION
This change incorporates a reversion on the resources allocated to the pipeline as they aren't required. Alongside this, a correction to the directory we `cd` into in the `deploy to *dev` steps to use the `kube` has been applied.