### PR TITLE
HOCS-4238: Update CompType when transferring case

### DIFF
--- a/src/main/resources/processes/COMP2_CCH_RETURNS.bpmn
+++ b/src/main/resources/processes/COMP2_CCH_RETURNS.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0hfmmol" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0hfmmol" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
   <bpmn:process id="COMP2_CCH_RETURNS" isExecutable="true">
     <bpmn:startEvent id="StartEvent_COMP_CCH_RETURNS">
       <bpmn:outgoing>SequenceFlow_11mc9vq</bpmn:outgoing>
@@ -10,11 +10,9 @@
       <bpmn:outgoing>SequenceFlow_1qleufl</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:endEvent id="EndEvent_COMP_CCH_RETURNS">
-      <bpmn:incoming>SequenceFlow_06swky8</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_15spiqu</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_11if814</bpmn:incoming>
-      <bpmn:incoming>Flow_1dyb3tn</bpmn:incoming>
-      <bpmn:incoming>Flow_02vhra1</bpmn:incoming>
+      <bpmn:incoming>Flow_15s3cvd</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:serviceTask id="Screen_Input" name="Input" camunda:expression="COMP_CCH_RETURNS_INPUT" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_089625j</bpmn:incoming>
@@ -47,7 +45,7 @@
       <bpmn:incoming>SequenceFlow_0v072d2</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_06swky8</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_06swky8" sourceRef="ServiceTask_1ipast6" targetRef="EndEvent_COMP_CCH_RETURNS" />
+    <bpmn:sequenceFlow id="SequenceFlow_06swky8" sourceRef="ServiceTask_1ipast6" targetRef="Activity_0mtedcn" />
     <bpmn:sequenceFlow id="SequenceFlow_0v072d2" sourceRef="ExclusiveGateway_0xt0css" targetRef="ServiceTask_1ipast6">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CchCompType == "Service"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -144,7 +142,7 @@
     <bpmn:sequenceFlow id="Flow_0kwu5wg" sourceRef="ExclusiveGateway_0xt0css" targetRef="Activity_1fcu4pc">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CchCompType == "Ex-Gratia"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1dyb3tn" sourceRef="Activity_1fcu4pc" targetRef="EndEvent_COMP_CCH_RETURNS" />
+    <bpmn:sequenceFlow id="Flow_1dyb3tn" sourceRef="Activity_1fcu4pc" targetRef="Activity_0mtedcn" />
     <bpmn:serviceTask id="Activity_05t6j35" name="Update Team for Minor Misconduct Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;COMP2_MINORMISCONDUCT_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;Stage&#34;)}">
       <bpmn:incoming>Flow_1h03zxo</bpmn:incoming>
       <bpmn:outgoing>Flow_02vhra1</bpmn:outgoing>
@@ -152,20 +150,47 @@
     <bpmn:sequenceFlow id="Flow_1h03zxo" sourceRef="ExclusiveGateway_0xt0css" targetRef="Activity_05t6j35">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CchCompType == "MinorMisconduct"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_02vhra1" sourceRef="Activity_05t6j35" targetRef="EndEvent_COMP_CCH_RETURNS" />
+    <bpmn:sequenceFlow id="Flow_02vhra1" sourceRef="Activity_05t6j35" targetRef="Activity_0mtedcn" />
+    <bpmn:serviceTask id="Activity_0mtedcn" name="Update CompType" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;CompType&#34;, CchCompType)}">
+      <bpmn:incoming>SequenceFlow_06swky8</bpmn:incoming>
+      <bpmn:incoming>Flow_02vhra1</bpmn:incoming>
+      <bpmn:incoming>Flow_1dyb3tn</bpmn:incoming>
+      <bpmn:outgoing>Flow_15s3cvd</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_15s3cvd" sourceRef="Activity_0mtedcn" targetRef="EndEvent_COMP_CCH_RETURNS" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMP2_CCH_RETURNS">
+      <bpmndi:BPMNEdge id="Flow_02vhra1_di" bpmnElement="Flow_02vhra1">
+        <di:waypoint x="2135" y="330" />
+        <di:waypoint x="2330" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1h03zxo_di" bpmnElement="Flow_1h03zxo">
+        <di:waypoint x="912" y="146" />
+        <di:waypoint x="912" y="330" />
+        <di:waypoint x="2035" y="330" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1dyb3tn_di" bpmnElement="Flow_1dyb3tn">
         <di:waypoint x="2135" y="210" />
-        <di:waypoint x="2221" y="210" />
-        <di:waypoint x="2221" y="121" />
-        <di:waypoint x="2306" y="121" />
+        <di:waypoint x="2290" y="210" />
+        <di:waypoint x="2290" y="330" />
+        <di:waypoint x="2330" y="330" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0kwu5wg_di" bpmnElement="Flow_0kwu5wg">
         <di:waypoint x="912" y="146" />
         <di:waypoint x="912" y="210" />
         <di:waypoint x="2035" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0wjz2wc_di" bpmnElement="SequenceFlow_0wjz2wc">
+        <di:waypoint x="1878" y="613" />
+        <di:waypoint x="1878" y="848" />
+        <di:waypoint x="941" y="848" />
+        <di:waypoint x="941" y="588" />
+        <di:waypoint x="1002" y="588" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1hi7fxv_di" bpmnElement="SequenceFlow_1hi7fxv">
+        <di:waypoint x="1903" y="588" />
+        <di:waypoint x="2035" y="588" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0d0tbtg_di" bpmnElement="SequenceFlow_0d0tbtg">
         <di:waypoint x="1207" y="751" />
@@ -175,18 +200,70 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_11if814_di" bpmnElement="SequenceFlow_11if814">
         <di:waypoint x="2135" y="588" />
-        <di:waypoint x="2221" y="588" />
-        <di:waypoint x="2221" y="121" />
-        <di:waypoint x="2306" y="121" />
+        <di:waypoint x="2480" y="588" />
+        <di:waypoint x="2480" y="139" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1uqd4wf_di" bpmnElement="SequenceFlow_1uqd4wf">
         <di:waypoint x="912" y="146" />
         <di:waypoint x="912" y="588" />
         <di:waypoint x="1002" y="588" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1cfdrv3_di" bpmnElement="SequenceFlow_1cfdrv3">
+        <di:waypoint x="1525" y="628" />
+        <di:waypoint x="1525" y="711" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_19vp1fu_di" bpmnElement="SequenceFlow_19vp1fu">
+        <di:waypoint x="1705" y="776" />
+        <di:waypoint x="1705" y="848" />
+        <di:waypoint x="941" y="848" />
+        <di:waypoint x="941" y="588" />
+        <di:waypoint x="1002" y="588" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1hgog2p_di" bpmnElement="SequenceFlow_1hgog2p">
+        <di:waypoint x="1575" y="751" />
+        <di:waypoint x="1680" y="751" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1s2qc2w_di" bpmnElement="SequenceFlow_1s2qc2w">
+        <di:waypoint x="1730" y="588" />
+        <di:waypoint x="1853" y="588" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1rna4fc_di" bpmnElement="SequenceFlow_1rna4fc">
+        <di:waypoint x="1680" y="588" />
+        <di:waypoint x="1575" y="588" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1664" y="569" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0pccpov_di" bpmnElement="SequenceFlow_0pccpov">
+        <di:waypoint x="1705" y="726" />
+        <di:waypoint x="1705" y="613" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0bmspp1_di" bpmnElement="SequenceFlow_0bmspp1">
+        <di:waypoint x="1052" y="628" />
+        <di:waypoint x="1052" y="711" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1666vtr_di" bpmnElement="SequenceFlow_1666vtr">
+        <di:waypoint x="1102" y="751" />
+        <di:waypoint x="1207" y="751" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0nx3sp8_di" bpmnElement="SequenceFlow_0nx3sp8">
+        <di:waypoint x="1257" y="588" />
+        <di:waypoint x="1475" y="588" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0xmjgk2_di" bpmnElement="SequenceFlow_0xmjgk2">
+        <di:waypoint x="1207" y="588" />
+        <di:waypoint x="1102" y="588" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1191" y="569" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1fl1tkp_di" bpmnElement="SequenceFlow_1fl1tkp">
+        <di:waypoint x="1232" y="726" />
+        <di:waypoint x="1232" y="613" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_15spiqu_di" bpmnElement="SequenceFlow_15spiqu">
         <di:waypoint x="937" y="121" />
-        <di:waypoint x="2306" y="121" />
+        <di:waypoint x="2462" y="121" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0v072d2_di" bpmnElement="SequenceFlow_0v072d2">
         <di:waypoint x="912" y="146" />
@@ -195,9 +272,9 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_06swky8_di" bpmnElement="SequenceFlow_06swky8">
         <di:waypoint x="2135" y="460" />
-        <di:waypoint x="2221" y="460" />
-        <di:waypoint x="2221" y="121" />
-        <di:waypoint x="2306" y="121" />
+        <di:waypoint x="2290" y="460" />
+        <di:waypoint x="2290" y="330" />
+        <di:waypoint x="2330" y="330" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_11mc9vq_di" bpmnElement="SequenceFlow_11mc9vq">
         <di:waypoint x="215" y="121" />
@@ -223,89 +300,16 @@
         <di:waypoint x="645" y="284" />
         <di:waypoint x="645" y="146" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1fl1tkp_di" bpmnElement="SequenceFlow_1fl1tkp">
-        <di:waypoint x="1232" y="726" />
-        <di:waypoint x="1232" y="613" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0xmjgk2_di" bpmnElement="SequenceFlow_0xmjgk2">
-        <di:waypoint x="1207" y="588" />
-        <di:waypoint x="1102" y="588" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1191" y="569" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0nx3sp8_di" bpmnElement="SequenceFlow_0nx3sp8">
-        <di:waypoint x="1257" y="588" />
-        <di:waypoint x="1475" y="588" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1666vtr_di" bpmnElement="SequenceFlow_1666vtr">
-        <di:waypoint x="1102" y="751" />
-        <di:waypoint x="1207" y="751" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0pccpov_di" bpmnElement="SequenceFlow_0pccpov">
-        <di:waypoint x="1705" y="726" />
-        <di:waypoint x="1705" y="613" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1rna4fc_di" bpmnElement="SequenceFlow_1rna4fc">
-        <di:waypoint x="1680" y="588" />
-        <di:waypoint x="1575" y="588" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1664" y="569" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1s2qc2w_di" bpmnElement="SequenceFlow_1s2qc2w">
-        <di:waypoint x="1730" y="588" />
-        <di:waypoint x="1853" y="588" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1hgog2p_di" bpmnElement="SequenceFlow_1hgog2p">
-        <di:waypoint x="1575" y="751" />
-        <di:waypoint x="1680" y="751" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_19vp1fu_di" bpmnElement="SequenceFlow_19vp1fu">
-        <di:waypoint x="1705" y="776" />
-        <di:waypoint x="1705" y="848" />
-        <di:waypoint x="941" y="848" />
-        <di:waypoint x="941" y="588" />
-        <di:waypoint x="1002" y="588" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0wjz2wc_di" bpmnElement="SequenceFlow_0wjz2wc">
-        <di:waypoint x="1878" y="613" />
-        <di:waypoint x="1878" y="848" />
-        <di:waypoint x="941" y="848" />
-        <di:waypoint x="941" y="588" />
-        <di:waypoint x="1002" y="588" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0bmspp1_di" bpmnElement="SequenceFlow_0bmspp1">
-        <di:waypoint x="1052" y="628" />
-        <di:waypoint x="1052" y="711" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1cfdrv3_di" bpmnElement="SequenceFlow_1cfdrv3">
-        <di:waypoint x="1525" y="628" />
-        <di:waypoint x="1525" y="711" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1hi7fxv_di" bpmnElement="SequenceFlow_1hi7fxv">
-        <di:waypoint x="1903" y="588" />
-        <di:waypoint x="2035" y="588" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1h03zxo_di" bpmnElement="Flow_1h03zxo">
-        <di:waypoint x="912" y="146" />
-        <di:waypoint x="912" y="330" />
-        <di:waypoint x="2035" y="330" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_02vhra1_di" bpmnElement="Flow_02vhra1">
-        <di:waypoint x="2135" y="330" />
-        <di:waypoint x="2221" y="330" />
-        <di:waypoint x="2221" y="121" />
-        <di:waypoint x="2306" y="121" />
+      <bpmndi:BPMNEdge id="Flow_15s3cvd_di" bpmnElement="Flow_15s3cvd">
+        <di:waypoint x="2430" y="330" />
+        <di:waypoint x="2480" y="330" />
+        <di:waypoint x="2480" y="139" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_COMP_CCH_RETURNS">
         <dc:Bounds x="179" y="103" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1kd69md_di" bpmnElement="ExclusiveGateway_1kd69md" isMarkerVisible="true">
         <dc:Bounds x="620" y="96" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_0jfpr6b_di" bpmnElement="EndEvent_COMP_CCH_RETURNS">
-        <dc:Bounds x="2306" y="103" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1bd9i4m_di" bpmnElement="Screen_Input">
         <dc:Bounds x="415" y="81" width="100" height="80" />
@@ -315,9 +319,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0xt0css_di" bpmnElement="ExclusiveGateway_0xt0css" isMarkerVisible="true">
         <dc:Bounds x="887" y="96" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1fcu4pc_di" bpmnElement="Activity_1fcu4pc">
-        <dc:Bounds x="2035" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1ipast6_di" bpmnElement="ServiceTask_1ipast6">
         <dc:Bounds x="2035" y="420" width="100" height="80" />
@@ -358,8 +359,17 @@
       <bpmndi:BPMNShape id="ExclusiveGateway_0hcp2sf_di" bpmnElement="ExclusiveGateway_0hcp2sf" isMarkerVisible="true">
         <dc:Bounds x="1853" y="563" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fcu4pc_di" bpmnElement="Activity_1fcu4pc">
+        <dc:Bounds x="2035" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_05t6j35_di" bpmnElement="Activity_05t6j35">
         <dc:Bounds x="2035" y="290" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0mtedcn_di" bpmnElement="Activity_0mtedcn">
+        <dc:Bounds x="2330" y="290" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0jfpr6b_di" bpmnElement="EndEvent_COMP_CCH_RETURNS">
+        <dc:Bounds x="2462" y="103" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/COMP_CCH_RETURNS.bpmn
+++ b/src/main/resources/processes/COMP_CCH_RETURNS.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0hfmmol" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0hfmmol" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
   <bpmn:process id="COMP_CCH_RETURNS" isExecutable="true">
     <bpmn:startEvent id="StartEvent_COMP_CCH_RETURNS">
       <bpmn:outgoing>SequenceFlow_11mc9vq</bpmn:outgoing>
@@ -10,11 +10,9 @@
       <bpmn:outgoing>SequenceFlow_1qleufl</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:endEvent id="EndEvent_COMP_CCH_RETURNS">
-      <bpmn:incoming>SequenceFlow_06swky8</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_15spiqu</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_11if814</bpmn:incoming>
-      <bpmn:incoming>Flow_1dyb3tn</bpmn:incoming>
-      <bpmn:incoming>Flow_02vhra1</bpmn:incoming>
+      <bpmn:incoming>Flow_15s3cvd</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:serviceTask id="Screen_Input" name="Input" camunda:expression="COMP_CCH_RETURNS_INPUT" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_089625j</bpmn:incoming>
@@ -47,7 +45,7 @@
       <bpmn:incoming>SequenceFlow_0v072d2</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_06swky8</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="SequenceFlow_06swky8" sourceRef="ServiceTask_1ipast6" targetRef="EndEvent_COMP_CCH_RETURNS" />
+    <bpmn:sequenceFlow id="SequenceFlow_06swky8" sourceRef="ServiceTask_1ipast6" targetRef="Activity_0mtedcn" />
     <bpmn:sequenceFlow id="SequenceFlow_0v072d2" sourceRef="ExclusiveGateway_0xt0css" targetRef="ServiceTask_1ipast6">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CchCompType == "Service"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -144,7 +142,7 @@
     <bpmn:sequenceFlow id="Flow_0kwu5wg" sourceRef="ExclusiveGateway_0xt0css" targetRef="Activity_1fcu4pc">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CchCompType == "Ex-Gratia"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1dyb3tn" sourceRef="Activity_1fcu4pc" targetRef="EndEvent_COMP_CCH_RETURNS" />
+    <bpmn:sequenceFlow id="Flow_1dyb3tn" sourceRef="Activity_1fcu4pc" targetRef="Activity_0mtedcn" />
     <bpmn:serviceTask id="Activity_05t6j35" name="Update Team for Minor Misconduct Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;COMP_MINORMISCONDUCT_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;Stage&#34;)}">
       <bpmn:incoming>Flow_1h03zxo</bpmn:incoming>
       <bpmn:outgoing>Flow_02vhra1</bpmn:outgoing>
@@ -152,20 +150,47 @@
     <bpmn:sequenceFlow id="Flow_1h03zxo" sourceRef="ExclusiveGateway_0xt0css" targetRef="Activity_05t6j35">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CchCompType == "MinorMisconduct"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_02vhra1" sourceRef="Activity_05t6j35" targetRef="EndEvent_COMP_CCH_RETURNS" />
+    <bpmn:sequenceFlow id="Flow_02vhra1" sourceRef="Activity_05t6j35" targetRef="Activity_0mtedcn" />
+    <bpmn:serviceTask id="Activity_0mtedcn" name="Update CompType" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;CompType&#34;, CchCompType)}">
+      <bpmn:incoming>SequenceFlow_06swky8</bpmn:incoming>
+      <bpmn:incoming>Flow_02vhra1</bpmn:incoming>
+      <bpmn:incoming>Flow_1dyb3tn</bpmn:incoming>
+      <bpmn:outgoing>Flow_15s3cvd</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_15s3cvd" sourceRef="Activity_0mtedcn" targetRef="EndEvent_COMP_CCH_RETURNS" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMP_CCH_RETURNS">
+      <bpmndi:BPMNEdge id="Flow_02vhra1_di" bpmnElement="Flow_02vhra1">
+        <di:waypoint x="2135" y="330" />
+        <di:waypoint x="2330" y="330" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1h03zxo_di" bpmnElement="Flow_1h03zxo">
+        <di:waypoint x="912" y="146" />
+        <di:waypoint x="912" y="330" />
+        <di:waypoint x="2035" y="330" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1dyb3tn_di" bpmnElement="Flow_1dyb3tn">
         <di:waypoint x="2135" y="210" />
-        <di:waypoint x="2221" y="210" />
-        <di:waypoint x="2221" y="121" />
-        <di:waypoint x="2306" y="121" />
+        <di:waypoint x="2290" y="210" />
+        <di:waypoint x="2290" y="330" />
+        <di:waypoint x="2330" y="330" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0kwu5wg_di" bpmnElement="Flow_0kwu5wg">
         <di:waypoint x="912" y="146" />
         <di:waypoint x="912" y="210" />
         <di:waypoint x="2035" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0wjz2wc_di" bpmnElement="SequenceFlow_0wjz2wc">
+        <di:waypoint x="1878" y="613" />
+        <di:waypoint x="1878" y="848" />
+        <di:waypoint x="941" y="848" />
+        <di:waypoint x="941" y="588" />
+        <di:waypoint x="1002" y="588" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1hi7fxv_di" bpmnElement="SequenceFlow_1hi7fxv">
+        <di:waypoint x="1903" y="588" />
+        <di:waypoint x="2035" y="588" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0d0tbtg_di" bpmnElement="SequenceFlow_0d0tbtg">
         <di:waypoint x="1207" y="751" />
@@ -175,18 +200,70 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_11if814_di" bpmnElement="SequenceFlow_11if814">
         <di:waypoint x="2135" y="588" />
-        <di:waypoint x="2221" y="588" />
-        <di:waypoint x="2221" y="121" />
-        <di:waypoint x="2306" y="121" />
+        <di:waypoint x="2480" y="588" />
+        <di:waypoint x="2480" y="139" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1uqd4wf_di" bpmnElement="SequenceFlow_1uqd4wf">
         <di:waypoint x="912" y="146" />
         <di:waypoint x="912" y="588" />
         <di:waypoint x="1002" y="588" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1cfdrv3_di" bpmnElement="SequenceFlow_1cfdrv3">
+        <di:waypoint x="1525" y="628" />
+        <di:waypoint x="1525" y="711" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_19vp1fu_di" bpmnElement="SequenceFlow_19vp1fu">
+        <di:waypoint x="1705" y="776" />
+        <di:waypoint x="1705" y="848" />
+        <di:waypoint x="941" y="848" />
+        <di:waypoint x="941" y="588" />
+        <di:waypoint x="1002" y="588" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1hgog2p_di" bpmnElement="SequenceFlow_1hgog2p">
+        <di:waypoint x="1575" y="751" />
+        <di:waypoint x="1680" y="751" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1s2qc2w_di" bpmnElement="SequenceFlow_1s2qc2w">
+        <di:waypoint x="1730" y="588" />
+        <di:waypoint x="1853" y="588" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1rna4fc_di" bpmnElement="SequenceFlow_1rna4fc">
+        <di:waypoint x="1680" y="588" />
+        <di:waypoint x="1575" y="588" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1664" y="569" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0pccpov_di" bpmnElement="SequenceFlow_0pccpov">
+        <di:waypoint x="1705" y="726" />
+        <di:waypoint x="1705" y="613" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0bmspp1_di" bpmnElement="SequenceFlow_0bmspp1">
+        <di:waypoint x="1052" y="628" />
+        <di:waypoint x="1052" y="711" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1666vtr_di" bpmnElement="SequenceFlow_1666vtr">
+        <di:waypoint x="1102" y="751" />
+        <di:waypoint x="1207" y="751" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0nx3sp8_di" bpmnElement="SequenceFlow_0nx3sp8">
+        <di:waypoint x="1257" y="588" />
+        <di:waypoint x="1475" y="588" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0xmjgk2_di" bpmnElement="SequenceFlow_0xmjgk2">
+        <di:waypoint x="1207" y="588" />
+        <di:waypoint x="1102" y="588" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1191" y="569" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1fl1tkp_di" bpmnElement="SequenceFlow_1fl1tkp">
+        <di:waypoint x="1232" y="726" />
+        <di:waypoint x="1232" y="613" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_15spiqu_di" bpmnElement="SequenceFlow_15spiqu">
         <di:waypoint x="937" y="121" />
-        <di:waypoint x="2306" y="121" />
+        <di:waypoint x="2462" y="121" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0v072d2_di" bpmnElement="SequenceFlow_0v072d2">
         <di:waypoint x="912" y="146" />
@@ -195,9 +272,9 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_06swky8_di" bpmnElement="SequenceFlow_06swky8">
         <di:waypoint x="2135" y="460" />
-        <di:waypoint x="2221" y="460" />
-        <di:waypoint x="2221" y="121" />
-        <di:waypoint x="2306" y="121" />
+        <di:waypoint x="2290" y="460" />
+        <di:waypoint x="2290" y="330" />
+        <di:waypoint x="2330" y="330" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_11mc9vq_di" bpmnElement="SequenceFlow_11mc9vq">
         <di:waypoint x="215" y="121" />
@@ -223,89 +300,16 @@
         <di:waypoint x="645" y="284" />
         <di:waypoint x="645" y="146" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1fl1tkp_di" bpmnElement="SequenceFlow_1fl1tkp">
-        <di:waypoint x="1232" y="726" />
-        <di:waypoint x="1232" y="613" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0xmjgk2_di" bpmnElement="SequenceFlow_0xmjgk2">
-        <di:waypoint x="1207" y="588" />
-        <di:waypoint x="1102" y="588" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1191" y="569" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0nx3sp8_di" bpmnElement="SequenceFlow_0nx3sp8">
-        <di:waypoint x="1257" y="588" />
-        <di:waypoint x="1475" y="588" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1666vtr_di" bpmnElement="SequenceFlow_1666vtr">
-        <di:waypoint x="1102" y="751" />
-        <di:waypoint x="1207" y="751" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0pccpov_di" bpmnElement="SequenceFlow_0pccpov">
-        <di:waypoint x="1705" y="726" />
-        <di:waypoint x="1705" y="613" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1rna4fc_di" bpmnElement="SequenceFlow_1rna4fc">
-        <di:waypoint x="1680" y="588" />
-        <di:waypoint x="1575" y="588" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1664" y="569" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1s2qc2w_di" bpmnElement="SequenceFlow_1s2qc2w">
-        <di:waypoint x="1730" y="588" />
-        <di:waypoint x="1853" y="588" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1hgog2p_di" bpmnElement="SequenceFlow_1hgog2p">
-        <di:waypoint x="1575" y="751" />
-        <di:waypoint x="1680" y="751" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_19vp1fu_di" bpmnElement="SequenceFlow_19vp1fu">
-        <di:waypoint x="1705" y="776" />
-        <di:waypoint x="1705" y="848" />
-        <di:waypoint x="941" y="848" />
-        <di:waypoint x="941" y="588" />
-        <di:waypoint x="1002" y="588" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0wjz2wc_di" bpmnElement="SequenceFlow_0wjz2wc">
-        <di:waypoint x="1878" y="613" />
-        <di:waypoint x="1878" y="848" />
-        <di:waypoint x="941" y="848" />
-        <di:waypoint x="941" y="588" />
-        <di:waypoint x="1002" y="588" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0bmspp1_di" bpmnElement="SequenceFlow_0bmspp1">
-        <di:waypoint x="1052" y="628" />
-        <di:waypoint x="1052" y="711" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1cfdrv3_di" bpmnElement="SequenceFlow_1cfdrv3">
-        <di:waypoint x="1525" y="628" />
-        <di:waypoint x="1525" y="711" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1hi7fxv_di" bpmnElement="SequenceFlow_1hi7fxv">
-        <di:waypoint x="1903" y="588" />
-        <di:waypoint x="2035" y="588" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1h03zxo_di" bpmnElement="Flow_1h03zxo">
-        <di:waypoint x="912" y="146" />
-        <di:waypoint x="912" y="330" />
-        <di:waypoint x="2035" y="330" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_02vhra1_di" bpmnElement="Flow_02vhra1">
-        <di:waypoint x="2135" y="330" />
-        <di:waypoint x="2221" y="330" />
-        <di:waypoint x="2221" y="121" />
-        <di:waypoint x="2306" y="121" />
+      <bpmndi:BPMNEdge id="Flow_15s3cvd_di" bpmnElement="Flow_15s3cvd">
+        <di:waypoint x="2430" y="330" />
+        <di:waypoint x="2480" y="330" />
+        <di:waypoint x="2480" y="139" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_COMP_CCH_RETURNS">
         <dc:Bounds x="179" y="103" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1kd69md_di" bpmnElement="ExclusiveGateway_1kd69md" isMarkerVisible="true">
         <dc:Bounds x="620" y="96" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_0jfpr6b_di" bpmnElement="EndEvent_COMP_CCH_RETURNS">
-        <dc:Bounds x="2306" y="103" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1bd9i4m_di" bpmnElement="Screen_Input">
         <dc:Bounds x="415" y="81" width="100" height="80" />
@@ -315,9 +319,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0xt0css_di" bpmnElement="ExclusiveGateway_0xt0css" isMarkerVisible="true">
         <dc:Bounds x="887" y="96" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1fcu4pc_di" bpmnElement="Activity_1fcu4pc">
-        <dc:Bounds x="2035" y="170" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1ipast6_di" bpmnElement="ServiceTask_1ipast6">
         <dc:Bounds x="2035" y="420" width="100" height="80" />
@@ -358,8 +359,17 @@
       <bpmndi:BPMNShape id="ExclusiveGateway_0hcp2sf_di" bpmnElement="ExclusiveGateway_0hcp2sf" isMarkerVisible="true">
         <dc:Bounds x="1853" y="563" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1fcu4pc_di" bpmnElement="Activity_1fcu4pc">
+        <dc:Bounds x="2035" y="170" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_05t6j35_di" bpmnElement="Activity_05t6j35">
         <dc:Bounds x="2035" y="290" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0mtedcn_di" bpmnElement="Activity_0mtedcn">
+        <dc:Bounds x="2330" y="290" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0jfpr6b_di" bpmnElement="EndEvent_COMP_CCH_RETURNS">
+        <dc:Bounds x="2462" y="103" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/diffs/COMP_CCH_RETURNS-COMP2_CCH_RETURNS.diff
+++ b/src/test/diffs/COMP_CCH_RETURNS-COMP2_CCH_RETURNS.diff
@@ -2,19 +2,19 @@
 <   <bpmn:process id="COMP_CCH_RETURNS" isExecutable="true">
 ---
 >   <bpmn:process id="COMP2_CCH_RETURNS" isExecutable="true">
-46c46
+44c44
 <     <bpmn:serviceTask id="ServiceTask_1ipast6" name="Update Team for Service Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;COMP_SERVICE_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;Stage&#34;)}">
 ---
 >     <bpmn:serviceTask id="ServiceTask_1ipast6" name="Update Team for Service Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;COMP2_SERVICE_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;Stage&#34;)}">
-140c140
+138c138
 <     <bpmn:serviceTask id="Activity_1fcu4pc" name="Update Team for Ex-Gratia Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;COMP_EXGRATIA_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;Stage&#34;)}">
 ---
 >     <bpmn:serviceTask id="Activity_1fcu4pc" name="Update Team for Ex-Gratia Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;COMP2_EXGRATIA_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;Stage&#34;)}">
-148c148
+146c146
 <     <bpmn:serviceTask id="Activity_05t6j35" name="Update Team for Minor Misconduct Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;COMP_MINORMISCONDUCT_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;Stage&#34;)}">
 ---
 >     <bpmn:serviceTask id="Activity_05t6j35" name="Update Team for Minor Misconduct Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;COMP2_MINORMISCONDUCT_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;Stage&#34;)}">
-158c158
+163c163
 <     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMP_CCH_RETURNS">
 ---
 >     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMP2_CCH_RETURNS">

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/COMP_CCH_RETURNS.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/COMP_CCH_RETURNS.java
@@ -51,6 +51,8 @@ public class COMP_CCH_RETURNS {
 
         verify(compReturnProcess, times(2)).hasCompleted("Screen_Input");
         verify(compReturnProcess).hasCompleted("ServiceTask_1ipast6");
+        verify(compReturnProcess).hasCompleted("Activity_0mtedcn");
+        verify(bpmnService, times(1)).updateValue(any(), any(), eq("CompType"), eq("Service"));
         verify(compReturnProcess, never()).hasCompleted("Service_CompleteReason");
     }
 
@@ -150,6 +152,8 @@ public class COMP_CCH_RETURNS {
 
         verify(compReturnProcess).hasCompleted("Screen_Input");
         verify(compReturnProcess).hasCompleted("Activity_1fcu4pc");
+        verify(compReturnProcess).hasCompleted("Activity_0mtedcn");
+        verify(bpmnService, times(1)).updateValue(any(), any(), eq("CompType"), eq("Ex-Gratia"));
     }
 
     @Test
@@ -161,6 +165,8 @@ public class COMP_CCH_RETURNS {
 
         verify(compReturnProcess).hasCompleted("Screen_Input");
         verify(compReturnProcess).hasCompleted("Activity_05t6j35");
+        verify(compReturnProcess).hasCompleted("Activity_0mtedcn");
+        verify(bpmnService, times(1)).updateValue(any(), any(), eq("CompType"), eq("MinorMisconduct"));
     }
 
 }


### PR DESCRIPTION
At the moment when a case is transferred via CCH returns the CompType is
not changed. This change adds an activity to the COMP and COMP2 CCH flow
that updates the CompType before transfer.