### PR TITLE
Hocs-3430 disable compression

### DIFF
--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -285,9 +285,9 @@ spec:
               httpHeaders:
                 - name: X-probe
                   value: kubelet
-            initialDelaySeconds: 6
+            initialDelaySeconds: 10
             periodSeconds: 2
-            failureThreshold: 22
+            failureThreshold: 20
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -13,6 +13,8 @@ spring.datasource.url=jdbc:postgresql://${db.host:localhost}:${db.port:5432}/${d
 spring.datasource.username=${db.username:root}
 spring.datasource.password=${db.password:dev}
 spring.datasource.driverClassName=org.postgresql.Driver
+spring.datasource.hikari.maximumPoolSize=40
+spring.datasource.hikari.minimumIdle=20
 spring.jpa.properties.hibernate.temp.use_jdbc_metadata_defaults=false
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
 


### PR DESCRIPTION
during testing the compression it was observed that increasing the connection pool limit did decrease the response times for both casework and workflow services