### PR TITLE
HOCS-4312 - Remove the Retry annotation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,6 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-json')
     implementation('org.springframework.boot:spring-boot-starter-cache')
     implementation('org.springframework.boot:spring-boot-starter-validation')
-    implementation('org.springframework.retry:spring-retry')
     implementation("org.apache.camel:camel-aws:${camelVersion}")
     implementation("org.apache.camel:camel-spring-boot-starter:${camelVersion}")
     implementation('com.github.ben-manes.caffeine:caffeine')

--- a/src/integration-test/resources/application.properties
+++ b/src/integration-test/resources/application.properties
@@ -22,9 +22,6 @@ docs.queue=seda://${docs.queue.name}
 aws.region=eu-west-2
 aws.account.id=12345
 
-retry.maxAttempts=3
-retry.delay=2000
-
 camel.springboot.main-run-controller=true
 
 spring.cache.caffeine.spec=initialCapacity=5000,expireAfterWrite=36000s

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/HocsWorkflowApplication.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/HocsWorkflowApplication.java
@@ -4,16 +4,12 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
-import org.springframework.retry.annotation.EnableRetry;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 import javax.annotation.PreDestroy;
 
 @Slf4j
 @SpringBootApplication
 @EnableCaching
-@EnableScheduling
-@EnableRetry
 public class HocsWorkflowApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/application/RestHelper.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/application/RestHelper.java
@@ -5,8 +5,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.*;
-import org.springframework.retry.annotation.Backoff;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
@@ -34,28 +32,24 @@ public class RestHelper {
         this.requestData = requestData;
     }
 
-    @Retryable(maxAttemptsExpression = "${retry.maxAttempts}", backoff = @Backoff(delayExpression = "${retry.delay}"))
     public <T,R> R post(String serviceBaseURL, String url, T request, Class<R> responseType) {
         log.info("RestHelper making POST request to {}{}", serviceBaseURL, url, value(EVENT, REST_HELPER_POST));
         ResponseEntity<R> response = restTemplate.exchange(String.format("%s%s", serviceBaseURL, url), HttpMethod.POST, new HttpEntity<>(request, createAuthHeaders()), responseType);
         return response.getBody();
     }
 
-    @Retryable(maxAttemptsExpression = "${retry.maxAttempts}", backoff = @Backoff(delayExpression = "${retry.delay}"))
     public <T,R> R put(String serviceBaseURL, String url, T request, Class<R> responseType) {
         log.info("RestHelper making PUT request to {}{}", serviceBaseURL, url, value(EVENT, REST_HELPER_PUT));
         ResponseEntity<R> response = restTemplate.exchange(String.format("%s%s", serviceBaseURL, url), HttpMethod.PUT, new HttpEntity<>(request, createAuthHeaders()), responseType);
         return response.getBody();
     }
 
-    @Retryable(maxAttemptsExpression = "${retry.maxAttempts}", backoff = @Backoff(delayExpression = "${retry.delay}"))
     public <R> R get(String serviceBaseURL, String url, Class<R> responseType) {
         log.info("RestHelper making GET request to {}{}", serviceBaseURL, url, value(EVENT, REST_HELPER_GET));
         ResponseEntity<R> response = restTemplate.exchange(String.format("%s%s", serviceBaseURL, url), HttpMethod.GET, new HttpEntity<>(null, createAuthHeaders()), responseType);
         return response.getBody();
     }
 
-    @Retryable(maxAttemptsExpression = "${retry.maxAttempts}", backoff = @Backoff(delayExpression = "${retry.delay}"))
     public <R> R get(String serviceBaseURL, String url, ParameterizedTypeReference<R> responseType) {
         log.info("RestHelper making GET request to {}{}", serviceBaseURL, url, value(EVENT, REST_HELPER_GET));
         ResponseEntity<R> response = restTemplate.exchange(String.format("%s%s", serviceBaseURL, url), HttpMethod.GET, new HttpEntity<>(null, createAuthHeaders()), responseType);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,9 +27,6 @@ docs.queue=seda://${docs.queue.name}
 aws.region=eu-west-2
 aws.account.id=12345
 
-retry.maxAttempts=3
-retry.delay=2000
-
 camel.springboot.main-run-controller=true
 
 spring.cache.caffeine.spec=initialCapacity=5000,expireAfterWrite=3600s


### PR DESCRIPTION
As part of the investigation it was determined that the application was failing to create new threads for the retry code, we have given the pods more memory but we don't believe we need to use @Retry at all - we prefer to fail fast.