### PR TITLE
HOCS-4055: add case flow for BF escalated cases

### DIFF
--- a/src/main/resources/processes/BF.bpmn
+++ b/src/main/resources/processes/BF.bpmn
@@ -54,6 +54,7 @@
         <camunda:out source="TriageResult" target="TriageResult" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_08fga3p</bpmn:incoming>
+      <bpmn:incoming>Flow_106rzcp</bpmn:incoming>
       <bpmn:outgoing>Flow_1xr2nd0</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:callActivity id="CallActivity_BF_SEND" name="SEND" calledElement="STAGE">
@@ -95,7 +96,7 @@
         <camunda:out source="BfDraftResult" target="BfDraftResult" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0ybbpfj</bpmn:incoming>
-      <bpmn:incoming>Flow_0f7wh3p</bpmn:incoming>
+      <bpmn:incoming>Flow_1e3yq3q</bpmn:incoming>
       <bpmn:outgoing>Flow_1e0lle4</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="Flow_1e0lle4" sourceRef="CallActivity_BF_DRAFT" targetRef="Gateway_0seoltl" />
@@ -127,15 +128,15 @@
         <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
         <camunda:out source="CompType" target="CompType" />
         <camunda:out source="Stage" target="Stage" />
+        <camunda:out source="BfEscalationResult" target="EscalationResult" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0ilq1fw</bpmn:incoming>
       <bpmn:incoming>Flow_0kevzbw</bpmn:incoming>
-      <bpmn:outgoing>Flow_0f7wh3p</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1xhrh97</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="Flow_0ilq1fw" sourceRef="Gateway_11e7u0t" targetRef="CallActivity_BF_ESCALATE">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageResult == "Escalate"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0f7wh3p" sourceRef="CallActivity_BF_ESCALATE" targetRef="CallActivity_BF_DRAFT" />
     <bpmn:exclusiveGateway id="Gateway_0seoltl">
       <bpmn:incoming>Flow_1e0lle4</bpmn:incoming>
       <bpmn:outgoing>Flow_0scfnca</bpmn:outgoing>
@@ -171,9 +172,44 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${BfDraftResult == "QA"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1ckkodx" sourceRef="CallActivity_BF_QA" targetRef="CallActivity_BF_SEND" />
+    <bpmn:sequenceFlow id="Flow_1e3yq3q" sourceRef="Gateway_1j0kezi" targetRef="CallActivity_BF_DRAFT">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${EscalationResult == "SendToDraft"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_106rzcp" sourceRef="Gateway_1j0kezi" targetRef="CallActivity_BF_TRIAGE">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${EscalationResult == "SendToTriage"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="Gateway_1j0kezi">
+      <bpmn:incoming>Flow_1xhrh97</bpmn:incoming>
+      <bpmn:outgoing>Flow_1e3yq3q</bpmn:outgoing>
+      <bpmn:outgoing>Flow_106rzcp</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1xhrh97" sourceRef="CallActivity_BF_ESCALATE" targetRef="Gateway_1j0kezi" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="BF">
+      <bpmndi:BPMNEdge id="Flow_1ckkodx_di" bpmnElement="Flow_1ckkodx">
+        <di:waypoint x="1120" y="320" />
+        <di:waypoint x="1120" y="231" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_048qgem_di" bpmnElement="Flow_048qgem">
+        <di:waypoint x="980" y="216" />
+        <di:waypoint x="980" y="370" />
+        <di:waypoint x="1070" y="370" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0kevzbw_di" bpmnElement="Flow_0kevzbw">
+        <di:waypoint x="980" y="216" />
+        <di:waypoint x="980" y="440" />
+        <di:waypoint x="620" y="440" />
+        <di:waypoint x="620" y="400" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0scfnca_di" bpmnElement="Flow_0scfnca">
+        <di:waypoint x="1005" y="191" />
+        <di:waypoint x="1070" y="191" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ilq1fw_di" bpmnElement="Flow_0ilq1fw">
+        <di:waypoint x="720" y="206" />
+        <di:waypoint x="640" y="320" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ybkkcr_di" bpmnElement="Flow_0ybkkcr">
         <di:waypoint x="730" y="166" />
         <di:waypoint x="730" y="80" />
@@ -192,48 +228,34 @@
         <di:waypoint x="890" y="191" />
         <di:waypoint x="955" y="191" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1i9x1ld_di" bpmnElement="Flow_1i9x1ld">
+        <di:waypoint x="1170" y="191" />
+        <di:waypoint x="1250" y="191" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08fga3p_di" bpmnElement="Flow_08fga3p">
         <di:waypoint x="440" y="191" />
         <di:waypoint x="570" y="191" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1jkxh22_di" bpmnElement="SequenceFlow_1jkxh22">
-        <di:waypoint x="218" y="191" />
-        <di:waypoint x="340" y="191" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ilq1fw_di" bpmnElement="Flow_0ilq1fw">
-        <di:waypoint x="730" y="216" />
-        <di:waypoint x="730" y="320" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0f7wh3p_di" bpmnElement="Flow_0f7wh3p">
-        <di:waypoint x="760" y="320" />
-        <di:waypoint x="760" y="211" />
-        <di:waypoint x="790" y="211" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1y94fvq_di" bpmnElement="SequenceFlow_1y94fvq">
         <di:waypoint x="1350" y="191" />
         <di:waypoint x="1422" y="191" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1i9x1ld_di" bpmnElement="Flow_1i9x1ld">
-        <di:waypoint x="1170" y="191" />
-        <di:waypoint x="1250" y="191" />
+      <bpmndi:BPMNEdge id="SequenceFlow_1jkxh22_di" bpmnElement="SequenceFlow_1jkxh22">
+        <di:waypoint x="218" y="191" />
+        <di:waypoint x="340" y="191" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0scfnca_di" bpmnElement="Flow_0scfnca">
-        <di:waypoint x="1005" y="191" />
-        <di:waypoint x="1070" y="191" />
+      <bpmndi:BPMNEdge id="Flow_1e3yq3q_di" bpmnElement="Flow_1e3yq3q">
+        <di:waypoint x="785" y="360" />
+        <di:waypoint x="840" y="360" />
+        <di:waypoint x="840" y="231" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0kevzbw_di" bpmnElement="Flow_0kevzbw">
-        <di:waypoint x="980" y="216" />
-        <di:waypoint x="980" y="370" />
-        <di:waypoint x="780" y="370" />
+      <bpmndi:BPMNEdge id="Flow_106rzcp_di" bpmnElement="Flow_106rzcp">
+        <di:waypoint x="753" y="343" />
+        <di:waypoint x="641" y="231" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_048qgem_di" bpmnElement="Flow_048qgem">
-        <di:waypoint x="980" y="216" />
-        <di:waypoint x="980" y="370" />
-        <di:waypoint x="1070" y="370" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ckkodx_di" bpmnElement="Flow_1ckkodx">
-        <di:waypoint x="1120" y="320" />
-        <di:waypoint x="1120" y="231" />
+      <bpmndi:BPMNEdge id="Flow_1xhrh97_di" bpmnElement="Flow_1xhrh97">
+        <di:waypoint x="670" y="360" />
+        <di:waypoint x="735" y="360" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_BF">
         <dc:Bounds x="182" y="173" width="36" height="36" />
@@ -241,8 +263,17 @@
       <bpmndi:BPMNShape id="CallActivity_104cnqu_di" bpmnElement="CallActivity_BF_REGISTRATION">
         <dc:Bounds x="340" y="151" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_1afztus_di" bpmnElement="EndEvent_BF">
+        <dc:Bounds x="1422" y="173" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_16gueal_di" bpmnElement="ServiceTask_CompleteCase">
+        <dc:Bounds x="1250" y="151" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0vwpt24_di" bpmnElement="CallActivity_BF_TRIAGE">
         <dc:Bounds x="570" y="151" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1r6hsvl_di" bpmnElement="CallActivity_BF_SEND">
+        <dc:Bounds x="1070" y="151" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_17xikz2_di" bpmnElement="CallActivity_BF_DRAFT">
         <dc:Bounds x="790" y="151" width="100" height="80" />
@@ -250,23 +281,17 @@
       <bpmndi:BPMNShape id="Gateway_11e7u0t_di" bpmnElement="Gateway_11e7u0t" isMarkerVisible="true">
         <dc:Bounds x="705" y="166" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1msj7o8_di" bpmnElement="CallActivity_BF_ESCALATE">
-        <dc:Bounds x="680" y="320" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_1afztus_di" bpmnElement="EndEvent_BF">
-        <dc:Bounds x="1422" y="173" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_16gueal_di" bpmnElement="ServiceTask_CompleteCase">
-        <dc:Bounds x="1250" y="151" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1r6hsvl_di" bpmnElement="CallActivity_BF_SEND">
-        <dc:Bounds x="1070" y="151" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0seoltl_di" bpmnElement="Gateway_0seoltl" isMarkerVisible="true">
         <dc:Bounds x="955" y="166" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1r7xsyc_di" bpmnElement="CallActivity_BF_QA">
         <dc:Bounds x="1070" y="320" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1msj7o8_di" bpmnElement="CallActivity_BF_ESCALATE">
+        <dc:Bounds x="570" y="320" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1j0kezi_di" bpmnElement="Gateway_1j0kezi" isMarkerVisible="true">
+        <dc:Bounds x="735" y="335" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/BF_ESCALATE.bpmn
+++ b/src/main/resources/processes/BF_ESCALATE.bpmn
@@ -5,33 +5,56 @@
       <bpmn:outgoing>Flow_1em77sj</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:endEvent id="EndEvent_BF_ESCALATE">
-      <bpmn:incoming>Flow_1o0eegu</bpmn:incoming>
+      <bpmn:incoming>Flow_0xjsht5</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1em77sj" sourceRef="StartEvent_BF_ESCALATE" targetRef="Validate_Input" />
     <bpmn:userTask id="Validate_Input" name="Input" camunda:formKey="BF_ESCALATE_INPUT">
       <bpmn:incoming>Flow_1em77sj</bpmn:incoming>
+      <bpmn:incoming>Flow_0f16owc</bpmn:incoming>
       <bpmn:outgoing>Flow_1o0eegu</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:sequenceFlow id="Flow_1o0eegu" sourceRef="Validate_Input" targetRef="EndEvent_BF_ESCALATE" />
+    <bpmn:sequenceFlow id="Flow_1o0eegu" sourceRef="Validate_Input" targetRef="Gateway_0je7vl9" />
+    <bpmn:exclusiveGateway id="Gateway_0je7vl9" default="Flow_0f16owc">
+      <bpmn:incoming>Flow_1o0eegu</bpmn:incoming>
+      <bpmn:outgoing>Flow_0xjsht5</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0f16owc</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0xjsht5" sourceRef="Gateway_0je7vl9" targetRef="EndEvent_BF_ESCALATE">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0f16owc" sourceRef="Gateway_0je7vl9" targetRef="Validate_Input" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="BF_ESCALATE">
-      <bpmndi:BPMNEdge id="Flow_1em77sj_di" bpmnElement="Flow_1em77sj">
-        <di:waypoint x="188" y="101" />
-        <di:waypoint x="290" y="101" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1o0eegu_di" bpmnElement="Flow_1o0eegu">
-        <di:waypoint x="390" y="101" />
-        <di:waypoint x="632" y="101" />
+        <di:waypoint x="390" y="181" />
+        <di:waypoint x="455" y="181" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1em77sj_di" bpmnElement="Flow_1em77sj">
+        <di:waypoint x="218" y="181" />
+        <di:waypoint x="290" y="181" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xjsht5_di" bpmnElement="Flow_0xjsht5">
+        <di:waypoint x="505" y="181" />
+        <di:waypoint x="572" y="181" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0f16owc_di" bpmnElement="Flow_0f16owc">
+        <di:waypoint x="480" y="156" />
+        <di:waypoint x="480" y="80" />
+        <di:waypoint x="340" y="80" />
+        <di:waypoint x="340" y="141" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_15ej0qm_di" bpmnElement="Validate_Input">
+        <dc:Bounds x="290" y="141" width="100" height="80" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_BF_ESCALATE">
-        <dc:Bounds x="152" y="83" width="36" height="36" />
+        <dc:Bounds x="182" y="163" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0je7vl9_di" bpmnElement="Gateway_0je7vl9" isMarkerVisible="true">
+        <dc:Bounds x="455" y="156" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_0z0qboe_di" bpmnElement="EndEvent_BF_ESCALATE">
-        <dc:Bounds x="632" y="83" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_15ej0qm_di" bpmnElement="Validate_Input">
-        <dc:Bounds x="290" y="61" width="100" height="80" />
+        <dc:Bounds x="572" y="163" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/BF.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/BF.java
@@ -89,10 +89,12 @@ public class BF {
 
         whenAtCallActivity("BF_TRIAGE")
                 .thenReturn("valid", "true", "TriageResult", "Escalate")
+                .thenReturn("valid", "true", "TriageResult", "Escalate")
                 .deploy(rule);
 
         whenAtCallActivity("BF_ESCALATE")
-                .thenReturn("valid", "true")
+                .thenReturn("valid", "true", "BfEscalationResult", "SendToTriage")
+                .thenReturn("valid", "true", "BfEscalationResult", "SendToDraft")
                 .deploy(rule);
 
         whenAtCallActivity("BF_DRAFT")
@@ -109,9 +111,9 @@ public class BF {
 
         verify(processScenario, times(1)).hasCompleted("StartEvent_BF");
         verify(processScenario, times(1)).hasCompleted("CallActivity_BF_REGISTRATION");
-        verify(processScenario, times(1)).hasCompleted("CallActivity_BF_TRIAGE");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_BF_TRIAGE");
         verify(processScenario, times(1)).hasCompleted("CallActivity_BF_DRAFT");
-        verify(processScenario, times(1)).hasCompleted("CallActivity_BF_ESCALATE");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_BF_ESCALATE");
         verify(processScenario, times(1)).hasCompleted("CallActivity_BF_SEND");
         verify(processScenario, times(1)).hasCompleted("ServiceTask_CompleteCase");
         verify(processScenario, times(1)).hasCompleted("EndEvent_BF");

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/BF_ESCALATE.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/BF_ESCALATE.java
@@ -17,6 +17,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.digital.ho.hocs.workflow.BpmnService;
 
 import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.withVariables;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -26,7 +27,10 @@ public class BF_ESCALATE {
 
     @Rule
     @ClassRule
-    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create().assertClassCoverageAtLeast(1).build();
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder
+            .create()
+            .assertClassCoverageAtLeast(1)
+            .build();
 
     @Rule
     public ProcessEngineRule processEngineRule = new ProcessEngineRule();
@@ -45,9 +49,12 @@ public class BF_ESCALATE {
     @Test
     public void testHappyPath(){
         when(process.waitsAtUserTask("Validate_Input"))
-                .thenReturn(task -> task.complete(withVariables("valid", true, "DIRECTION", "FORWARD")));
+                .thenReturn(task -> task.complete(withVariables("valid", false)))
+                .thenReturn(task -> task.complete(withVariables("valid", true)));
 
         Scenario.run(process).startByKey("BF_ESCALATE").execute();
+
+        verify(process, times(2)).hasCompleted("Validate_Input");
         verify(process).hasCompleted("EndEvent_BF_ESCALATE");
     }
 }


### PR DESCRIPTION
Add the sequence flows for cases that are being sent through the BF
escalation process. For cases that come through there is the option to
send the case to Triage or Draft. This direction happens through the
main BF process diagram is handled through an output process variable.