### PR TITLE
HOCS-4440: WebForm complaints allows early closure

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,8 +162,8 @@ task checkCOMPSnapshots {
         exec {
             commandLine 'src/test/scripts/check_COMP_COMP2.sh', compFiles, compDiffs
         }
-
     }
+
 }
 
 jar {

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowConstants.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowConstants.java
@@ -23,4 +23,7 @@ public interface WorkflowConstants {
     String REQUEST_QUESTION = "RequestQuestion";
     String TOPICS = "Topics";
     String CASE_DATA_TYPE_FOI = "FOI";
+    String CASE_DATA_TYPE_COMP = "COMP";
+    String CHANNEL = "Channel";
+    String CHANNEL_COMP_WEBFORM = "Webform";
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowService.java
@@ -102,19 +102,19 @@ public class WorkflowService {
 
             // Start a new camunda workflow (caseUUID is the business key).
             Map<String, String> seedData = new HashMap<>();
-            if (Objects.equals(caseDataType, WorkflowConstants.CASE_DATA_TYPE_FOI) && receivedData != null) {
-                seedData.put(WorkflowConstants.CASE_REFERENCE, caseResponse.getReference());
-                seedData.put(WorkflowConstants.DATE_RECEIVED, dateReceived.toString());
-                seedData.put(WorkflowConstants.LAST_UPDATED_BY_USER, userUUID.toString());
-                seedData.put(WorkflowConstants.KIMU_DATE_RECEIVED, receivedData.get(WorkflowConstants.KIMU_DATE_RECEIVED));
-                seedData.put(WorkflowConstants.TOPICS, receivedData.get(WorkflowConstants.TOPICS));
-                seedData.put(WorkflowConstants.REQUEST_QUESTION, receivedData.get(WorkflowConstants.REQUEST_QUESTION));
-                seedData.put(WorkflowConstants.ORIGINAL_CHANNEL, receivedData.get(WorkflowConstants.ORIGINAL_CHANNEL));
-            } else {
-                seedData.put(WorkflowConstants.CASE_REFERENCE, caseResponse.getReference());
-                seedData.put(WorkflowConstants.DATE_RECEIVED, dateReceived.toString());
-                seedData.put(WorkflowConstants.LAST_UPDATED_BY_USER, userUUID.toString());
+            if (receivedData != null) {
+                if (Objects.equals(caseDataType, WorkflowConstants.CASE_DATA_TYPE_FOI)) {
+                    seedData.put(WorkflowConstants.KIMU_DATE_RECEIVED, receivedData.get(WorkflowConstants.KIMU_DATE_RECEIVED));
+                    seedData.put(WorkflowConstants.TOPICS, receivedData.get(WorkflowConstants.TOPICS));
+                    seedData.put(WorkflowConstants.REQUEST_QUESTION, receivedData.get(WorkflowConstants.REQUEST_QUESTION));
+                    seedData.put(WorkflowConstants.ORIGINAL_CHANNEL, receivedData.get(WorkflowConstants.ORIGINAL_CHANNEL));
+                } else if (isCreationForCompWebformCase(caseDataType, receivedData)) {
+                    seedData.putAll(receivedData);
+                }
             }
+            seedData.put(WorkflowConstants.CASE_REFERENCE, caseResponse.getReference());
+            seedData.put(WorkflowConstants.DATE_RECEIVED, dateReceived.toString());
+            seedData.put(WorkflowConstants.LAST_UPDATED_BY_USER, userUUID.toString());
 
             camundaClient.startCase(caseUUID, caseDataType, seedData);
             //Create correspondent
@@ -399,6 +399,11 @@ public class WorkflowService {
 
     public void deleteProcess(UUID stageUuid){
         camundaClient.removeProcess(stageUuid);
+    }
+
+    private boolean isCreationForCompWebformCase(String caseDataType, Map<String, String> receivedData) {
+        return Objects.equals(caseDataType, WorkflowConstants.CASE_DATA_TYPE_COMP)
+                    && Objects.equals(receivedData.get(WorkflowConstants.CHANNEL), WorkflowConstants.CHANNEL_COMP_WEBFORM);
     }
 
 }

--- a/src/main/resources/processes/COMP.bpmn
+++ b/src/main/resources/processes/COMP.bpmn
@@ -19,6 +19,7 @@
         <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
         <camunda:out source="CompType" target="CompType" />
         <camunda:out source="Stage" target="Stage" />
+        <camunda:out source="WebformComplaintInvalid" target="WebformComplaintInvalid" />
       </bpmn:extensionElements>
       <bpmn:incoming>SequenceFlow_1jkxh22</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_15z7c6l</bpmn:outgoing>
@@ -145,7 +146,7 @@
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="SequenceFlow_1tn7n28" sourceRef="CallActivity_COMP_RETURNS" targetRef="ExclusiveGateway_11h64pd" />
     <bpmn:sequenceFlow id="SequenceFlow_09ub2ao" sourceRef="ExclusiveGateway_11h64pd" targetRef="ServiceTask_CompleteCase">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CompType == "Complete"}</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CompType == "Complete" || WebformComplaintInvalid == "Yes"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:callActivity id="CallActivity_COMP_SERVICE_QA" name="Service Response QA" calledElement="STAGE">
       <bpmn:extensionElements>

--- a/src/main/resources/processes/COMP_REGISTRATION.bpmn
+++ b/src/main/resources/processes/COMP_REGISTRATION.bpmn
@@ -6,9 +6,10 @@
     </bpmn:startEvent>
     <bpmn:serviceTask id="Screen_Correspondents" name="Correspondents" camunda:expression="COMP_REGISTRATION_CORRESPONDENTS" camunda:resultVariable="screen">
       <bpmn:incoming>SequenceFlow_12vx36b</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_1wght7h</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_0l9e253</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_11whjkg</bpmn:incoming>
+      <bpmn:incoming>Flow_12kxvim</bpmn:incoming>
+      <bpmn:incoming>Flow_137x3a1</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_0helqjm</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:userTask id="Validate_CorrespondentInput" name="Validate Correspondents">
@@ -30,8 +31,9 @@
       <bpmn:incoming>SequenceFlow_0ivrt61</bpmn:incoming>
       <bpmn:incoming>Flow_1phqhkq</bpmn:incoming>
       <bpmn:incoming>Flow_1yiblq8</bpmn:incoming>
+      <bpmn:incoming>Flow_06qfv1d</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="SequenceFlow_1wght7h" sourceRef="StartEvent_COMP_CREATION" targetRef="Screen_Correspondents" />
+    <bpmn:sequenceFlow id="SequenceFlow_1wght7h" sourceRef="StartEvent_COMP_CREATION" targetRef="Gateway_126rajf" />
     <bpmn:sequenceFlow id="SequenceFlow_1tmtkaf" sourceRef="ExclusiveGateway_02izrdr" targetRef="Service_UpdatePrimaryCorrespondent">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -285,385 +287,462 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CompType == "MinorMisconduct"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1yiblq8" sourceRef="UpdateTeamForMinorMisconduct" targetRef="EndEvent_COMP_CREATION" />
+    <bpmn:exclusiveGateway id="Gateway_126rajf" default="Flow_12kxvim">
+      <bpmn:incoming>SequenceFlow_1wght7h</bpmn:incoming>
+      <bpmn:outgoing>Flow_12kxvim</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0o39lvp</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_12kxvim" sourceRef="Gateway_126rajf" targetRef="Screen_Correspondents" />
+    <bpmn:userTask id="Validate_WebformComplaint" name="Validate Webform Complaint" camunda:formKey="COMP_REGISTRATION_WEBFORM_VALID">
+      <bpmn:incoming>Flow_0o39lvp</bpmn:incoming>
+      <bpmn:incoming>Flow_0t13050</bpmn:incoming>
+      <bpmn:outgoing>Flow_196fu1d</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0o39lvp" sourceRef="Gateway_126rajf" targetRef="Validate_WebformComplaint">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${execution.hasVariable("Channel") &amp;&amp; Channel == "Webform"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="Gateway_0ziwchp" default="Flow_0t13050">
+      <bpmn:incoming>Flow_196fu1d</bpmn:incoming>
+      <bpmn:outgoing>Flow_0t13050</bpmn:outgoing>
+      <bpmn:outgoing>Flow_14b4wts</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0t13050" sourceRef="Gateway_0ziwchp" targetRef="Validate_WebformComplaint" />
+    <bpmn:sequenceFlow id="Flow_196fu1d" sourceRef="Validate_WebformComplaint" targetRef="Gateway_0ziwchp" />
+    <bpmn:exclusiveGateway id="Gateway_1b26ws3" default="Flow_137x3a1">
+      <bpmn:incoming>Flow_14b4wts</bpmn:incoming>
+      <bpmn:outgoing>Flow_137x3a1</bpmn:outgoing>
+      <bpmn:outgoing>Flow_06qfv1d</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_14b4wts" sourceRef="Gateway_0ziwchp" targetRef="Gateway_1b26ws3">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_137x3a1" sourceRef="Gateway_1b26ws3" targetRef="Screen_Correspondents" />
+    <bpmn:sequenceFlow id="Flow_06qfv1d" sourceRef="Gateway_1b26ws3" targetRef="EndEvent_COMP_CREATION">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${execution.hasVariable("WebformComplaintInvalid") &amp;&amp; WebformComplaintInvalid == "Yes"}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMP_REGISTRATION">
+      <bpmndi:BPMNEdge id="Flow_06qfv1d_di" bpmnElement="Flow_06qfv1d">
+        <di:waypoint x="621" y="255" />
+        <di:waypoint x="621" y="40" />
+        <di:waypoint x="3957" y="60" />
+        <di:waypoint x="3957" y="441" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_137x3a1_di" bpmnElement="Flow_137x3a1">
+        <di:waypoint x="621" y="305" />
+        <di:waypoint x="621" y="419" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14b4wts_di" bpmnElement="Flow_14b4wts">
+        <di:waypoint x="505" y="280" />
+        <di:waypoint x="596" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_196fu1d_di" bpmnElement="Flow_196fu1d">
+        <di:waypoint x="360" y="280" />
+        <di:waypoint x="455" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0t13050_di" bpmnElement="Flow_0t13050">
+        <di:waypoint x="480" y="255" />
+        <di:waypoint x="480" y="190" />
+        <di:waypoint x="310" y="190" />
+        <di:waypoint x="310" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0o39lvp_di" bpmnElement="Flow_0o39lvp">
+        <di:waypoint x="310" y="434" />
+        <di:waypoint x="310" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_12kxvim_di" bpmnElement="Flow_12kxvim">
+        <di:waypoint x="335" y="459" />
+        <di:waypoint x="571" y="459" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1yiblq8_di" bpmnElement="Flow_1yiblq8">
-        <di:waypoint x="3603" y="910" />
-        <di:waypoint x="3767" y="910" />
-        <di:waypoint x="3767" y="477" />
+        <di:waypoint x="3793" y="910" />
+        <di:waypoint x="3957" y="910" />
+        <di:waypoint x="3957" y="477" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_04g1zh8_di" bpmnElement="Flow_04g1zh8">
-        <di:waypoint x="3426" y="484" />
-        <di:waypoint x="3426" y="910" />
-        <di:waypoint x="3503" y="910" />
+        <di:waypoint x="3616" y="484" />
+        <di:waypoint x="3616" y="910" />
+        <di:waypoint x="3693" y="910" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1tb95wz_di" bpmnElement="Flow_1tb95wz">
-        <di:waypoint x="2476" y="305" />
-        <di:waypoint x="2476" y="360" />
-        <di:waypoint x="1826" y="360" />
-        <di:waypoint x="1826" y="419" />
+        <di:waypoint x="2666" y="305" />
+        <di:waypoint x="2666" y="360" />
+        <di:waypoint x="2016" y="360" />
+        <di:waypoint x="2016" y="419" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0zt8acc_di" bpmnElement="Flow_0zt8acc">
-        <di:waypoint x="2501" y="120" />
-        <di:waypoint x="3203" y="120" />
-        <di:waypoint x="3203" y="419" />
+        <di:waypoint x="2691" y="120" />
+        <di:waypoint x="3393" y="120" />
+        <di:waypoint x="3393" y="419" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_080613g_di" bpmnElement="Flow_080613g">
-        <di:waypoint x="2451" y="120" />
-        <di:waypoint x="2346" y="120" />
+        <di:waypoint x="2641" y="120" />
+        <di:waypoint x="2536" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0rjl95k_di" bpmnElement="Flow_0rjl95k">
-        <di:waypoint x="2476" y="255" />
-        <di:waypoint x="2476" y="145" />
+        <di:waypoint x="2666" y="255" />
+        <di:waypoint x="2666" y="145" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0z8v8ts_di" bpmnElement="Flow_0z8v8ts">
-        <di:waypoint x="2346" y="280" />
-        <di:waypoint x="2451" y="280" />
+        <di:waypoint x="2536" y="280" />
+        <di:waypoint x="2641" y="280" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1rik1fq_di" bpmnElement="Flow_1rik1fq">
-        <di:waypoint x="2296" y="160" />
-        <di:waypoint x="2296" y="240" />
+        <di:waypoint x="2486" y="160" />
+        <di:waypoint x="2486" y="240" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1c0y5ua_di" bpmnElement="Flow_1c0y5ua">
-        <di:waypoint x="2006" y="434" />
-        <di:waypoint x="2006" y="120" />
-        <di:waypoint x="2246" y="120" />
+        <di:waypoint x="2196" y="434" />
+        <di:waypoint x="2196" y="120" />
+        <di:waypoint x="2436" y="120" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1phqhkq_di" bpmnElement="Flow_1phqhkq">
-        <di:waypoint x="3603" y="770" />
-        <di:waypoint x="3767" y="770" />
-        <di:waypoint x="3767" y="477" />
+        <di:waypoint x="3793" y="770" />
+        <di:waypoint x="3957" y="770" />
+        <di:waypoint x="3957" y="477" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1xespdq_di" bpmnElement="Flow_1xespdq">
-        <di:waypoint x="3426" y="484" />
-        <di:waypoint x="3426" y="770" />
-        <di:waypoint x="3503" y="770" />
+        <di:waypoint x="3616" y="484" />
+        <di:waypoint x="3616" y="770" />
+        <di:waypoint x="3693" y="770" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0ivrt61_di" bpmnElement="SequenceFlow_0ivrt61">
-        <di:waypoint x="3603" y="633" />
-        <di:waypoint x="3767" y="633" />
-        <di:waypoint x="3767" y="477" />
+        <di:waypoint x="3793" y="633" />
+        <di:waypoint x="3957" y="633" />
+        <di:waypoint x="3957" y="477" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1t807yu_di" bpmnElement="SequenceFlow_1t807yu">
-        <di:waypoint x="3426" y="484" />
-        <di:waypoint x="3426" y="633" />
-        <di:waypoint x="3503" y="633" />
+        <di:waypoint x="3616" y="484" />
+        <di:waypoint x="3616" y="633" />
+        <di:waypoint x="3693" y="633" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0dxnr2k_di" bpmnElement="SequenceFlow_0dxnr2k">
-        <di:waypoint x="3451" y="459" />
-        <di:waypoint x="3749" y="459" />
+        <di:waypoint x="3641" y="459" />
+        <di:waypoint x="3939" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1ho2nv6_di" bpmnElement="SequenceFlow_1ho2nv6">
-        <di:waypoint x="3253" y="459" />
-        <di:waypoint x="3401" y="459" />
+        <di:waypoint x="3443" y="459" />
+        <di:waypoint x="3591" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_11whjkg_di" bpmnElement="SequenceFlow_11whjkg">
-        <di:waypoint x="1521" y="647" />
-        <di:waypoint x="1521" y="880" />
-        <di:waypoint x="271" y="880" />
-        <di:waypoint x="271" y="459" />
-        <di:waypoint x="381" y="459" />
+        <di:waypoint x="1711" y="647" />
+        <di:waypoint x="1711" y="880" />
+        <di:waypoint x="520" y="880" />
+        <di:waypoint x="520" y="459" />
+        <di:waypoint x="571" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0m4s053_di" bpmnElement="SequenceFlow_0m4s053">
-        <di:waypoint x="1546" y="459" />
-        <di:waypoint x="1776" y="459" />
+        <di:waypoint x="1736" y="459" />
+        <di:waypoint x="1966" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_03i4bzc_di" bpmnElement="SequenceFlow_03i4bzc">
-        <di:waypoint x="1496" y="459" />
-        <di:waypoint x="1391" y="459" />
+        <di:waypoint x="1686" y="459" />
+        <di:waypoint x="1581" y="459" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1477" y="440" width="24" height="14" />
+          <dc:Bounds x="1667" y="440" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0iiqx84_di" bpmnElement="SequenceFlow_0iiqx84">
-        <di:waypoint x="1521" y="597" />
-        <di:waypoint x="1521" y="484" />
+        <di:waypoint x="1711" y="597" />
+        <di:waypoint x="1711" y="484" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_11zs70y_di" bpmnElement="SequenceFlow_11zs70y">
-        <di:waypoint x="1391" y="622" />
-        <di:waypoint x="1496" y="622" />
+        <di:waypoint x="1581" y="622" />
+        <di:waypoint x="1686" y="622" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_02dyvii_di" bpmnElement="SequenceFlow_02dyvii">
-        <di:waypoint x="1341" y="499" />
-        <di:waypoint x="1341" y="582" />
+        <di:waypoint x="1531" y="499" />
+        <di:waypoint x="1531" y="582" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0qzrzfe_di" bpmnElement="SequenceFlow_0qzrzfe">
-        <di:waypoint x="1092" y="484" />
-        <di:waypoint x="1092" y="622" />
-        <di:waypoint x="809" y="622" />
+        <di:waypoint x="1282" y="484" />
+        <di:waypoint x="1282" y="622" />
+        <di:waypoint x="999" y="622" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0l9e253_di" bpmnElement="SequenceFlow_0l9e253">
-        <di:waypoint x="939" y="810" />
-        <di:waypoint x="939" y="880" />
-        <di:waypoint x="271" y="880" />
-        <di:waypoint x="271" y="459" />
-        <di:waypoint x="381" y="459" />
+        <di:waypoint x="1129" y="810" />
+        <di:waypoint x="1129" y="880" />
+        <di:waypoint x="520" y="880" />
+        <di:waypoint x="520" y="459" />
+        <di:waypoint x="571" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0eukthn_di" bpmnElement="SequenceFlow_0eukthn">
-        <di:waypoint x="809" y="785" />
-        <di:waypoint x="914" y="785" />
+        <di:waypoint x="999" y="785" />
+        <di:waypoint x="1104" y="785" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0s727qp_di" bpmnElement="SequenceFlow_0s727qp">
-        <di:waypoint x="759" y="662" />
-        <di:waypoint x="759" y="745" />
+        <di:waypoint x="949" y="662" />
+        <di:waypoint x="949" y="745" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0gae7tm_di" bpmnElement="SequenceFlow_0gae7tm">
-        <di:waypoint x="939" y="760" />
-        <di:waypoint x="939" y="622" />
-        <di:waypoint x="809" y="622" />
+        <di:waypoint x="1129" y="760" />
+        <di:waypoint x="1129" y="622" />
+        <di:waypoint x="999" y="622" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="901" y="751" width="24" height="14" />
+          <dc:Bounds x="1091" y="751" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1uh2rmw_di" bpmnElement="SequenceFlow_1uh2rmw">
-        <di:waypoint x="1117" y="459" />
-        <di:waypoint x="1291" y="459" />
+        <di:waypoint x="1307" y="459" />
+        <di:waypoint x="1481" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1kx4u58_di" bpmnElement="SequenceFlow_1kx4u58">
-        <di:waypoint x="983" y="459" />
-        <di:waypoint x="1067" y="459" />
+        <di:waypoint x="1173" y="459" />
+        <di:waypoint x="1257" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_04d6e2u_di" bpmnElement="SequenceFlow_04d6e2u">
-        <di:waypoint x="809" y="459" />
-        <di:waypoint x="883" y="459" />
+        <di:waypoint x="999" y="459" />
+        <di:waypoint x="1073" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0vok10k_di" bpmnElement="SequenceFlow_0vok10k">
-        <di:waypoint x="2962" y="647" />
-        <di:waypoint x="2962" y="783" />
-        <di:waypoint x="2185" y="783" />
-        <di:waypoint x="2185" y="459" />
-        <di:waypoint x="2245" y="459" />
+        <di:waypoint x="3152" y="647" />
+        <di:waypoint x="3152" y="783" />
+        <di:waypoint x="2375" y="783" />
+        <di:waypoint x="2375" y="459" />
+        <di:waypoint x="2435" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0fw73o9_di" bpmnElement="SequenceFlow_0fw73o9">
-        <di:waypoint x="2987" y="459" />
-        <di:waypoint x="3153" y="459" />
+        <di:waypoint x="3177" y="459" />
+        <di:waypoint x="3343" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1ygr6ir_di" bpmnElement="SequenceFlow_1ygr6ir">
-        <di:waypoint x="2832" y="622" />
-        <di:waypoint x="2937" y="622" />
+        <di:waypoint x="3022" y="622" />
+        <di:waypoint x="3127" y="622" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0rif8yi_di" bpmnElement="SequenceFlow_0rif8yi">
-        <di:waypoint x="2782" y="499" />
-        <di:waypoint x="2782" y="582" />
+        <di:waypoint x="2972" y="499" />
+        <di:waypoint x="2972" y="582" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_098en1t_di" bpmnElement="SequenceFlow_098en1t">
-        <di:waypoint x="2937" y="459" />
-        <di:waypoint x="2832" y="459" />
+        <di:waypoint x="3127" y="459" />
+        <di:waypoint x="3022" y="459" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2920" y="436" width="24" height="14" />
+          <dc:Bounds x="3110" y="436" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_09xhbcb_di" bpmnElement="SequenceFlow_09xhbcb">
-        <di:waypoint x="2962" y="597" />
-        <di:waypoint x="2962" y="484" />
+        <di:waypoint x="3152" y="597" />
+        <di:waypoint x="3152" y="484" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0bgkub9_di" bpmnElement="SequenceFlow_0bgkub9">
-        <di:waypoint x="2476" y="647" />
-        <di:waypoint x="2476" y="814" />
-        <di:waypoint x="1693" y="814" />
-        <di:waypoint x="1693" y="459" />
-        <di:waypoint x="1776" y="459" />
+        <di:waypoint x="2666" y="647" />
+        <di:waypoint x="2666" y="814" />
+        <di:waypoint x="1883" y="814" />
+        <di:waypoint x="1883" y="459" />
+        <di:waypoint x="1966" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0nm8aus_di" bpmnElement="SequenceFlow_0nm8aus">
-        <di:waypoint x="2476" y="597" />
-        <di:waypoint x="2476" y="484" />
+        <di:waypoint x="2666" y="597" />
+        <di:waypoint x="2666" y="484" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0t0ud5u_di" bpmnElement="SequenceFlow_0t0ud5u">
-        <di:waypoint x="2501" y="459" />
-        <di:waypoint x="2732" y="459" />
+        <di:waypoint x="2691" y="459" />
+        <di:waypoint x="2922" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0huxrwp_di" bpmnElement="SequenceFlow_0huxrwp">
-        <di:waypoint x="2346" y="622" />
-        <di:waypoint x="2451" y="622" />
+        <di:waypoint x="2536" y="622" />
+        <di:waypoint x="2641" y="622" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1bptkmd_di" bpmnElement="SequenceFlow_1bptkmd">
-        <di:waypoint x="2296" y="499" />
-        <di:waypoint x="2296" y="582" />
+        <di:waypoint x="2486" y="499" />
+        <di:waypoint x="2486" y="582" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0qm2vns_di" bpmnElement="SequenceFlow_0qm2vns">
-        <di:waypoint x="2451" y="459" />
-        <di:waypoint x="2346" y="459" />
+        <di:waypoint x="2641" y="459" />
+        <di:waypoint x="2536" y="459" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2431" y="437" width="24" height="14" />
+          <dc:Bounds x="2621" y="437" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_10ljnwx_di" bpmnElement="SequenceFlow_10ljnwx">
-        <di:waypoint x="2006" y="647" />
-        <di:waypoint x="2006" y="847" />
-        <di:waypoint x="1194" y="847" />
-        <di:waypoint x="1194" y="459" />
-        <di:waypoint x="1291" y="459" />
+        <di:waypoint x="2196" y="647" />
+        <di:waypoint x="2196" y="847" />
+        <di:waypoint x="1384" y="847" />
+        <di:waypoint x="1384" y="459" />
+        <di:waypoint x="1481" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1onxhsq_di" bpmnElement="SequenceFlow_1onxhsq">
-        <di:waypoint x="2006" y="597" />
-        <di:waypoint x="2006" y="484" />
+        <di:waypoint x="2196" y="597" />
+        <di:waypoint x="2196" y="484" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1ckq4uv_di" bpmnElement="SequenceFlow_1ckq4uv">
-        <di:waypoint x="2031" y="459" />
-        <di:waypoint x="2246" y="459" />
+        <di:waypoint x="2221" y="459" />
+        <di:waypoint x="2436" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0oodugm_di" bpmnElement="SequenceFlow_0oodugm">
-        <di:waypoint x="1981" y="459" />
-        <di:waypoint x="1876" y="459" />
+        <di:waypoint x="2171" y="459" />
+        <di:waypoint x="2066" y="459" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1961" y="440" width="24" height="14" />
+          <dc:Bounds x="2151" y="440" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0a0poq2_di" bpmnElement="SequenceFlow_0a0poq2">
-        <di:waypoint x="1876" y="622" />
-        <di:waypoint x="1981" y="622" />
+        <di:waypoint x="2066" y="622" />
+        <di:waypoint x="2171" y="622" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0e8421f_di" bpmnElement="SequenceFlow_0e8421f">
-        <di:waypoint x="1826" y="499" />
-        <di:waypoint x="1826" y="582" />
+        <di:waypoint x="2016" y="499" />
+        <di:waypoint x="2016" y="582" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1tmtkaf_di" bpmnElement="SequenceFlow_1tmtkaf">
-        <di:waypoint x="636" y="459" />
-        <di:waypoint x="709" y="459" />
+        <di:waypoint x="826" y="459" />
+        <di:waypoint x="899" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1wght7h_di" bpmnElement="SequenceFlow_1wght7h">
-        <di:waypoint x="192" y="459" />
-        <di:waypoint x="381" y="459" />
+        <di:waypoint x="188" y="459" />
+        <di:waypoint x="285" y="459" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0hokxc0_di" bpmnElement="SequenceFlow_0hokxc0">
-        <di:waypoint x="481" y="622" />
-        <di:waypoint x="611" y="622" />
-        <di:waypoint x="611" y="484" />
+        <di:waypoint x="671" y="622" />
+        <di:waypoint x="801" y="622" />
+        <di:waypoint x="801" y="484" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0helqjm_di" bpmnElement="SequenceFlow_0helqjm">
-        <di:waypoint x="431" y="499" />
-        <di:waypoint x="431" y="582" />
+        <di:waypoint x="621" y="499" />
+        <di:waypoint x="621" y="582" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_12vx36b_di" bpmnElement="SequenceFlow_12vx36b">
-        <di:waypoint x="586" y="459" />
-        <di:waypoint x="481" y="459" />
+        <di:waypoint x="776" y="459" />
+        <di:waypoint x="671" y="459" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="567" y="439" width="24" height="14" />
+          <dc:Bounds x="757" y="439" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_COMP_CREATION">
-        <dc:Bounds x="156" y="441" width="36" height="36" />
+        <dc:Bounds x="152" y="441" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_05jjdjd_di" bpmnElement="Screen_Correspondents">
-        <dc:Bounds x="381" y="419" width="100" height="80" />
+        <dc:Bounds x="571" y="419" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_1yhumui_di" bpmnElement="Validate_CorrespondentInput">
-        <dc:Bounds x="381" y="582" width="100" height="80" />
+        <dc:Bounds x="571" y="582" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_02izrdr_di" bpmnElement="ExclusiveGateway_02izrdr" isMarkerVisible="true">
-        <dc:Bounds x="586" y="434" width="50" height="50" />
+        <dc:Bounds x="776" y="434" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_0pmmumb_di" bpmnElement="EndEvent_COMP_CREATION">
-        <dc:Bounds x="3749" y="441" width="36" height="36" />
+        <dc:Bounds x="3939" y="441" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0tntnep_di" bpmnElement="Validate_Complaint">
-        <dc:Bounds x="1776" y="582" width="100" height="80" />
+        <dc:Bounds x="1966" y="582" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0q5xpfe_di" bpmnElement="ExclusiveGateway_0q5xpfe" isMarkerVisible="true">
-        <dc:Bounds x="1981" y="434" width="50" height="50" />
+        <dc:Bounds x="2171" y="434" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0grub5i_di" bpmnElement="Screen_Complaint">
-        <dc:Bounds x="1776" y="419" width="100" height="80" />
+        <dc:Bounds x="1966" y="419" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_13i27xe_di" bpmnElement="ExclusiveGateway_13i27xe" isMarkerVisible="true">
-        <dc:Bounds x="1981" y="597" width="50" height="50" />
+        <dc:Bounds x="2171" y="597" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2041" y="615" width="76" height="14" />
+          <dc:Bounds x="2231" y="615" width="76" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_13vxbr0_di" bpmnElement="Screen_Input">
-        <dc:Bounds x="2246" y="419" width="100" height="80" />
+        <dc:Bounds x="2436" y="419" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0k00jya_di" bpmnElement="UserTask_0k00jya">
-        <dc:Bounds x="2246" y="582" width="100" height="80" />
+        <dc:Bounds x="2436" y="582" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0ln1fgr_di" bpmnElement="ExclusiveGateway_0ln1fgr" isMarkerVisible="true">
-        <dc:Bounds x="2451" y="434" width="50" height="50" />
+        <dc:Bounds x="2641" y="434" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0kbzifz_di" bpmnElement="ExclusiveGateway_0kbzifz" isMarkerVisible="true">
-        <dc:Bounds x="2451" y="597" width="50" height="50" />
+        <dc:Bounds x="2641" y="597" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2511" y="615" width="76" height="14" />
+          <dc:Bounds x="2701" y="615" width="76" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0r6ojig_di" bpmnElement="ExclusiveGateway_0r6ojig" isMarkerVisible="true">
-        <dc:Bounds x="2937" y="434" width="50" height="50" />
+        <dc:Bounds x="3127" y="434" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0vkxg3s_di" bpmnElement="ExclusiveGateway_0vkxg3s" isMarkerVisible="true">
-        <dc:Bounds x="2937" y="597" width="50" height="50" />
+        <dc:Bounds x="3127" y="597" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2997" y="615" width="76" height="14" />
+          <dc:Bounds x="3187" y="615" width="76" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0x0skyi_di" bpmnElement="Screen_Category">
-        <dc:Bounds x="2732" y="419" width="100" height="80" />
+        <dc:Bounds x="2922" y="419" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0y49grp_di" bpmnElement="Validate_Category">
-        <dc:Bounds x="2732" y="582" width="100" height="80" />
+        <dc:Bounds x="2922" y="582" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1glmvvh_di" bpmnElement="Service_UpdatePrimaryCorrespondent">
-        <dc:Bounds x="709" y="419" width="100" height="80" />
+        <dc:Bounds x="899" y="419" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1wqrgqt_di" bpmnElement="Service_CaseHasPrimaryCorrespondentType">
-        <dc:Bounds x="883" y="419" width="100" height="80" />
+        <dc:Bounds x="1073" y="419" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_039b0ih_di" bpmnElement="ExclusiveGateway_039b0ih" isMarkerVisible="true">
-        <dc:Bounds x="1067" y="434" width="50" height="50" />
+        <dc:Bounds x="1257" y="434" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1wtzuhs_di" bpmnElement="Screen_InvalidCorrespondents">
-        <dc:Bounds x="709" y="582" width="100" height="80" />
+        <dc:Bounds x="899" y="582" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_1pnr1ee_di" bpmnElement="Validate_InvalidCorrespondents">
-        <dc:Bounds x="709" y="745" width="100" height="80" />
+        <dc:Bounds x="899" y="745" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_050t4qg_di" bpmnElement="ExclusiveGateway_050t4qg" isMarkerVisible="true">
-        <dc:Bounds x="914" y="760" width="50" height="50" />
+        <dc:Bounds x="1104" y="760" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0kwc2ld_di" bpmnElement="Validate_Complainant">
-        <dc:Bounds x="1291" y="582" width="100" height="80" />
+        <dc:Bounds x="1481" y="582" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1f9m56y_di" bpmnElement="ExclusiveGateway_1f9m56y" isMarkerVisible="true">
-        <dc:Bounds x="1496" y="434" width="50" height="50" />
+        <dc:Bounds x="1686" y="434" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0zjn8q1_di" bpmnElement="Screen_Complainant">
-        <dc:Bounds x="1291" y="419" width="100" height="80" />
+        <dc:Bounds x="1481" y="419" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0zxq4eq_di" bpmnElement="ExclusiveGateway_0zxq4eq" isMarkerVisible="true">
-        <dc:Bounds x="1496" y="597" width="50" height="50" />
+        <dc:Bounds x="1686" y="597" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1556" y="615" width="76" height="14" />
+          <dc:Bounds x="1746" y="615" width="76" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0pumxnf_di" bpmnElement="ServiceTask_0pumxnf">
-        <dc:Bounds x="3153" y="419" width="100" height="80" />
+        <dc:Bounds x="3343" y="419" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1nazxdv_di" bpmnElement="ExclusiveGateway_1nazxdv" isMarkerVisible="true">
-        <dc:Bounds x="3401" y="434" width="50" height="50" />
+        <dc:Bounds x="3591" y="434" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1a94ebv_di" bpmnElement="Service_UpdateTeamByStageAndTexts">
-        <dc:Bounds x="3503" y="593" width="100" height="80" />
+        <dc:Bounds x="3693" y="593" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1gs3a7d_di" bpmnElement="UpdateTeamForExGracia">
-        <dc:Bounds x="3503" y="730" width="100" height="80" />
+        <dc:Bounds x="3693" y="730" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_04zonva_di" bpmnElement="Activity_04zonva">
-        <dc:Bounds x="2246" y="80" width="100" height="80" />
+        <dc:Bounds x="2436" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_05zunym_di" bpmnElement="ExGracia_Input">
-        <dc:Bounds x="2246" y="240" width="100" height="80" />
+        <dc:Bounds x="2436" y="240" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1r5j9xc_di" bpmnElement="Gateway_1r5j9xc" isMarkerVisible="true">
-        <dc:Bounds x="2451" y="255" width="50" height="50" />
+        <dc:Bounds x="2641" y="255" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="2511" y="273" width="76" height="14" />
+          <dc:Bounds x="2701" y="273" width="76" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_17ws88r_di" bpmnElement="Gateway_17ws88r" isMarkerVisible="true">
-        <dc:Bounds x="2451" y="95" width="50" height="50" />
+        <dc:Bounds x="2641" y="95" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1rh88o9_di" bpmnElement="UpdateTeamForMinorMisconduct">
-        <dc:Bounds x="3503" y="870" width="100" height="80" />
+        <dc:Bounds x="3693" y="870" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_126rajf_di" bpmnElement="Gateway_126rajf" isMarkerVisible="true">
+        <dc:Bounds x="285" y="434" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0w7ywmi_di" bpmnElement="Validate_WebformComplaint">
+        <dc:Bounds x="260" y="240" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ziwchp_di" bpmnElement="Gateway_0ziwchp" isMarkerVisible="true">
+        <dc:Bounds x="455" y="255" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1b26ws3_di" bpmnElement="Gateway_1b26ws3" isMarkerVisible="true">
+        <dc:Bounds x="596" y="255" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/diffs/COMP-COMP2.diff
+++ b/src/test/diffs/COMP-COMP2.diff
@@ -10,239 +10,245 @@
 <         <camunda:in sourceExpression="COMP_REGISTRATION" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_REGISTRATION" target="StageType" />
-31c31
+22d21
+<         <camunda:out source="WebformComplaintInvalid" target="WebformComplaintInvalid" />
+32c31
 <     <bpmn:sequenceFlow id="SequenceFlow_0qgx3mz" sourceRef="CallActivity_COMP_SERVICE_TRIAGE" targetRef="ExclusiveGateway_0j0zx2i" />
 ---
 >     <bpmn:sequenceFlow id="SequenceFlow_0qgx3mz" sourceRef="CallActivity_COMP2_SERVICE_TRIAGE" targetRef="ExclusiveGateway_0j0zx2i" />
-35c35
+36c35
 <         <camunda:in sourceExpression="COMP_OTHER" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_OTHER" target="StageWorkFlow" />
-40c40
+41c40
 <         <camunda:in sourceExpression="COMP_OTHER" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_OTHER" target="StageType" />
-48c48
+49c48
 <     <bpmn:callActivity id="CallActivity_COMP_SERVICE_TRIAGE" name="Service Triage" calledElement="STAGE">
 ---
 >     <bpmn:callActivity id="CallActivity_COMP2_SERVICE_TRIAGE" name="Service Triage" calledElement="STAGE">
-51c51
+52c51
 <         <camunda:in sourceExpression="COMP_SERVICE_TRIAGE" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_SERVICE_TRIAGE" target="StageWorkFlow" />
-56c56
+57c56
 <         <camunda:in sourceExpression="COMP_SERVICE_TRIAGE" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_SERVICE_TRIAGE" target="StageType" />
-85c85
+86c85
 <     <bpmn:sequenceFlow id="SequenceFlow_000uqx9" sourceRef="ExclusiveGateway_11h64pd" targetRef="CallActivity_COMP_SERVICE_TRIAGE">
 ---
 >     <bpmn:sequenceFlow id="SequenceFlow_000uqx9" sourceRef="ExclusiveGateway_11h64pd" targetRef="CallActivity_COMP2_SERVICE_TRIAGE">
-104c104
+105c104
 <         <camunda:in sourceExpression="COMP_SERVICE_DRAFT" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_SERVICE_DRAFT" target="StageWorkFlow" />
-109c109
+110c109
 <         <camunda:in sourceExpression="COMP_SERVICE_DRAFT" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_SERVICE_DRAFT" target="StageType" />
-128c128
+129c128
 <         <camunda:in sourceExpression="COMP_CCH_RETURNS" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_CCH_RETURNS" target="StageWorkFlow" />
-133c133
+134c133
 <         <camunda:in sourceExpression="COMP_CCH_RETURNS" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_CCH_RETURNS" target="StageType" />
-153c153
+149c148
+<       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CompType == "Complete" || WebformComplaintInvalid == "Yes"}</bpmn:conditionExpression>
+---
+>       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CompType == "Complete"}</bpmn:conditionExpression>
+154c153
 <         <camunda:in sourceExpression="COMP_SERVICE_QA" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_SERVICE_QA" target="StageWorkFlow" />
-158c158
+159c158
 <         <camunda:in sourceExpression="COMP_SERVICE_QA" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_SERVICE_QA" target="StageType" />
-192c192
+193c192
 <         <camunda:in sourceExpression="COMP_SERVICE_SEND" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_SERVICE_SEND" target="StageWorkFlow" />
-197c197
+198c197
 <         <camunda:in sourceExpression="COMP_SERVICE_SEND" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_SERVICE_SEND" target="StageType" />
-227c227
+228c227
 <         <camunda:in sourceExpression="COMP_MINOR_CHECK" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_MINOR_CHECK" target="StageWorkFlow" />
-232c232
+233c232
 <         <camunda:in sourceExpression="COMP_MINOR_CHECK" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_MINOR_CHECK" target="StageType" />
-255c255
+256c255
 <         <camunda:in sourceExpression="COMP_MINOR_RESP" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_MINOR_RESP" target="StageWorkFlow" />
-260c260
+261c260
 <         <camunda:in sourceExpression="COMP_MINOR_RESP" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_MINOR_RESP" target="StageType" />
-272c272
+273c272
 <     <bpmn:callActivity id="CallActivity_COMP_SERVICE_ESCALATE" name="Service Escalate" calledElement="STAGE">
 ---
 >     <bpmn:callActivity id="CallActivity_COMP2_SERVICE_ESCALATE" name="Service Escalate" calledElement="STAGE">
-275c275
+276c275
 <         <camunda:in sourceExpression="COMP_SERVICE_ESCALATE" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_SERVICE_ESCALATE" target="StageWorkFlow" />
-280c280
+281c280
 <         <camunda:in sourceExpression="COMP_SERVICE_ESCALATE" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_SERVICE_ESCALATE" target="StageType" />
-292c292
+293c292
 <     <bpmn:sequenceFlow id="SequenceFlow_1y9mbjp" sourceRef="ExclusiveGateway_1hli3nx" targetRef="CallActivity_COMP_SERVICE_ESCALATE">
 ---
 >     <bpmn:sequenceFlow id="SequenceFlow_1y9mbjp" sourceRef="ExclusiveGateway_1hli3nx" targetRef="CallActivity_COMP2_SERVICE_ESCALATE">
-295c295
+296c295
 <     <bpmn:sequenceFlow id="SequenceFlow_007ooy7" sourceRef="CallActivity_COMP_SERVICE_ESCALATE" targetRef="ExclusiveGateway_1x9b5ch" />
 ---
 >     <bpmn:sequenceFlow id="SequenceFlow_007ooy7" sourceRef="CallActivity_COMP2_SERVICE_ESCALATE" targetRef="ExclusiveGateway_1x9b5ch" />
-297c297
+298c297
 <     <bpmn:sequenceFlow id="SequenceFlow_0sq468n" sourceRef="ExclusiveGateway_0j0zx2i" targetRef="CallActivity_COMP_SERVICE_ESCALATE">
 ---
 >     <bpmn:sequenceFlow id="SequenceFlow_0sq468n" sourceRef="ExclusiveGateway_0j0zx2i" targetRef="CallActivity_COMP2_SERVICE_ESCALATE">
-311c311
+312c311
 <     <bpmn:sequenceFlow id="SequenceFlow_0fjx2nt" sourceRef="ExclusiveGateway_1x9b5ch" targetRef="CallActivity_COMP_SERVICE_TRIAGE">
 ---
 >     <bpmn:sequenceFlow id="SequenceFlow_0fjx2nt" sourceRef="ExclusiveGateway_1x9b5ch" targetRef="CallActivity_COMP2_SERVICE_TRIAGE">
-314c314
+315c314
 <     <bpmn:callActivity id="CallActivity_EXGRATIA_TRIAGE" name="Ex-Gratia Triage" calledElement="STAGE">
 ---
 >     <bpmn:callActivity id="CallActivity_COMP2_EXGRATIA_TRIAGE" name="Ex-Gratia Triage" calledElement="STAGE">
-317c317
+318c317
 <         <camunda:in sourceExpression="COMP_EXGRATIA_TRIAGE" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_EXGRATIA_TRIAGE" target="StageWorkFlow" />
-322c322
+323c322
 <         <camunda:in sourceExpression="COMP_EXGRATIA_TRIAGE" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_EXGRATIA_TRIAGE" target="StageType" />
-336c336
+337c336
 <     <bpmn:sequenceFlow id="Flow_073agya" sourceRef="ExclusiveGateway_11h64pd" targetRef="CallActivity_EXGRATIA_TRIAGE">
 ---
 >     <bpmn:sequenceFlow id="Flow_073agya" sourceRef="ExclusiveGateway_11h64pd" targetRef="CallActivity_COMP2_EXGRATIA_TRIAGE">
-339c339
+340c339
 <     <bpmn:sequenceFlow id="Flow_1c2e4jd" sourceRef="CallActivity_EXGRATIA_TRIAGE" targetRef="Gateway_1wrxr8i" />
 ---
 >     <bpmn:sequenceFlow id="Flow_1c2e4jd" sourceRef="CallActivity_COMP2_EXGRATIA_TRIAGE" targetRef="Gateway_1wrxr8i" />
-354c354
+355c354
 <         <camunda:in sourceExpression="COMP_EXGRATIA_RESPONSE_DRAFT" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_EXGRATIA_RESPONSE_DRAFT" target="StageWorkFlow" />
-359c359
+360c359
 <         <camunda:in sourceExpression="COMP_EXGRATIA_RESPONSE_DRAFT" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_EXGRATIA_RESPONSE_DRAFT" target="StageType" />
-378c378
+379c378
 <         <camunda:in sourceExpression="COMP_EXGRATIA_SEND" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_EXGRATIA_SEND" target="StageWorkFlow" />
-383c383
+384c383
 <         <camunda:in sourceExpression="COMP_EXGRATIA_SEND" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_EXGRATIA_SEND" target="StageType" />
-398c398
+399c398
 <         <camunda:in sourceExpression="COMP_EXGRATIA_QA" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_EXGRATIA_QA" target="StageWorkFlow" />
-403c403
+404c403
 <         <camunda:in sourceExpression="COMP_EXGRATIA_QA" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_EXGRATIA_QA" target="StageType" />
-438c438
+439c438
 <     <bpmn:callActivity id="CallActivity_EX_GRATIA_ESCALATE" name="Ex-Gratia Escalate" calledElement="STAGE">
 ---
 >     <bpmn:callActivity id="CallActivity_COMP2_EX_GRATIA_ESCALATE" name="Ex-Gratia Escalate" calledElement="STAGE">
-441c441
+442c441
 <         <camunda:in sourceExpression="COMP_EXGRATIA_ESCALATE" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_EXGRATIA_ESCALATE" target="StageWorkFlow" />
-446c446
+447c446
 <         <camunda:in sourceExpression="COMP_EXGRATIA_ESCALATE" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_EXGRATIA_ESCALATE" target="StageType" />
-458c458
+459c458
 <     <bpmn:sequenceFlow id="Flow_08deyba" sourceRef="Gateway_1wrxr8i" targetRef="CallActivity_EX_GRATIA_ESCALATE">
 ---
 >     <bpmn:sequenceFlow id="Flow_08deyba" sourceRef="Gateway_1wrxr8i" targetRef="CallActivity_COMP2_EX_GRATIA_ESCALATE">
-461c461
+462c461
 <     <bpmn:sequenceFlow id="Flow_1rzei36" sourceRef="Gateway_12n2mzs" targetRef="CallActivity_EX_GRATIA_ESCALATE">
 ---
 >     <bpmn:sequenceFlow id="Flow_1rzei36" sourceRef="Gateway_12n2mzs" targetRef="CallActivity_COMP2_EX_GRATIA_ESCALATE">
-469c469
+470c469
 <     <bpmn:sequenceFlow id="Flow_1wxz412" sourceRef="CallActivity_EX_GRATIA_ESCALATE" targetRef="Gateway_0gfx66g" />
 ---
 >     <bpmn:sequenceFlow id="Flow_1wxz412" sourceRef="CallActivity_COMP2_EX_GRATIA_ESCALATE" targetRef="Gateway_0gfx66g" />
-473c473
+474c473
 <     <bpmn:sequenceFlow id="Flow_033e2tl" sourceRef="Gateway_0gfx66g" targetRef="CallActivity_EXGRATIA_TRIAGE">
 ---
 >     <bpmn:sequenceFlow id="Flow_033e2tl" sourceRef="Gateway_0gfx66g" targetRef="CallActivity_COMP2_EXGRATIA_TRIAGE">
-479c479
+480c479
 <         <camunda:in sourceExpression="COMP_MINORMISCONDUCT_TRIAGE" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_MINORMISCONDUCT_TRIAGE" target="StageWorkFlow" />
-484c484
+485c484
 <         <camunda:in sourceExpression="COMP_MINORMISCONDUCT_TRIAGE" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_MINORMISCONDUCT_TRIAGE" target="StageType" />
-505c505
+506c505
 <         <camunda:in sourceExpression="COMP_MINORMISCONDUCT_ESCALATE" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_MINORMISCONDUCT_ESCALATE" target="StageWorkFlow" />
-510c510
+511c510
 <         <camunda:in sourceExpression="COMP_MINORMISCONDUCT_ESCALATE" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_MINORMISCONDUCT_ESCALATE" target="StageType" />
-525c525
+526c525
 <         <camunda:in sourceExpression="COMP_MINORMISCONDUCT_RESPONSE_DRAFT" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_MINORMISCONDUCT_RESPONSE_DRAFT" target="StageWorkFlow" />
-530c530
+531c530
 <         <camunda:in sourceExpression="COMP_MINORMISCONDUCT_RESPONSE_DRAFT" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_MINORMISCONDUCT_RESPONSE_DRAFT" target="StageType" />
-549c549
+550c549
 <         <camunda:in sourceExpression="COMP_MINORMISCONDUCT_QA" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_MINORMISCONDUCT_QA" target="StageWorkFlow" />
-554c554
+555c554
 <         <camunda:in sourceExpression="COMP_MINORMISCONDUCT_QA" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_MINORMISCONDUCT_QA" target="StageType" />
-568c568
+569c568
 <         <camunda:in sourceExpression="COMP_MINORMISCONDUCT_SEND" target="StageWorkFlow" />
 ---
 >         <camunda:in sourceExpression="COMP2_MINORMISCONDUCT_SEND" target="StageWorkFlow" />
-573c573
+574c573
 <         <camunda:in sourceExpression="COMP_MINORMISCONDUCT_SEND" target="StageType" />
 ---
 >         <camunda:in sourceExpression="COMP2_MINORMISCONDUCT_SEND" target="StageType" />
-647c647
+648c647
 <     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMP">
 ---
 >     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMP2">
-973c973
+974c973
 <       <bpmndi:BPMNShape id="CallActivity_0r9oq18_di" bpmnElement="CallActivity_COMP_SERVICE_TRIAGE">
 ---
 >       <bpmndi:BPMNShape id="CallActivity_0r9oq18_di" bpmnElement="CallActivity_COMP2_SERVICE_TRIAGE">
-1012c1012
+1013c1012
 <       <bpmndi:BPMNShape id="CallActivity_0h6ptqy_di" bpmnElement="CallActivity_COMP_SERVICE_ESCALATE">
 ---
 >       <bpmndi:BPMNShape id="CallActivity_0h6ptqy_di" bpmnElement="CallActivity_COMP2_SERVICE_ESCALATE">
-1018c1018
+1019c1018
 <       <bpmndi:BPMNShape id="Activity_1gq29ro_di" bpmnElement="CallActivity_EXGRATIA_TRIAGE">
 ---
 >       <bpmndi:BPMNShape id="Activity_1gq29ro_di" bpmnElement="CallActivity_COMP2_EXGRATIA_TRIAGE">
-1039c1039
+1040c1039
 <       <bpmndi:BPMNShape id="Activity_0xruxzc_di" bpmnElement="CallActivity_EX_GRATIA_ESCALATE">
 ---
 >       <bpmndi:BPMNShape id="Activity_0xruxzc_di" bpmnElement="CallActivity_COMP2_EX_GRATIA_ESCALATE">

--- a/src/test/diffs/COMP_REGISTRATION-COMP2_REGISTRATION.diff
+++ b/src/test/diffs/COMP_REGISTRATION-COMP2_REGISTRATION.diff
@@ -2,23 +2,668 @@
 <   <bpmn:process id="COMP_REGISTRATION" isExecutable="true">
 ---
 >   <bpmn:process id="COMP2_REGISTRATION" isExecutable="true">
-216c216
+8a9
+>       <bpmn:incoming>SequenceFlow_1wght7h</bpmn:incoming>
+11,12d11
+<       <bpmn:incoming>Flow_12kxvim</bpmn:incoming>
+<       <bpmn:incoming>Flow_137x3a1</bpmn:incoming>
+34d32
+<       <bpmn:incoming>Flow_06qfv1d</bpmn:incoming>
+36c34
+<     <bpmn:sequenceFlow id="SequenceFlow_1wght7h" sourceRef="StartEvent_COMP_CREATION" targetRef="Gateway_126rajf" />
+---
+>     <bpmn:sequenceFlow id="SequenceFlow_1wght7h" sourceRef="StartEvent_COMP_CREATION" targetRef="Screen_Correspondents" />
+218c216
 <     <bpmn:serviceTask id="ServiceTask_0pumxnf" name="Set Stage to Stage1" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;Stage&#34;, &#34;Stage1&#34;)}">
 ---
 >     <bpmn:serviceTask id="ServiceTask_0pumxnf" name="Set Stage to Stage2" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;Stage&#34;, &#34;Stage2&#34;)}">
-230c230
+232c230
 <     <bpmn:serviceTask id="Service_UpdateTeamByStageAndTexts" name="Update Team for Service Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;COMP_SERVICE_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;Stage&#34;)}">
 ---
 >     <bpmn:serviceTask id="Service_UpdateTeamByStageAndTexts" name="Update Team for Service Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;COMP2_SERVICE_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;Stage&#34;)}">
-238c238
+240c238
 <     <bpmn:serviceTask id="UpdateTeamForExGracia" name="Update Team for Ex-Gratia Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;COMP_EXGRATIA_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;Stage&#34;)}">
 ---
 >     <bpmn:serviceTask id="UpdateTeamForExGracia" name="Update Team for Ex-Gratia Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;COMP2_EXGRATIA_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;Stage&#34;)}">
-280c280
+282c280
 <     <bpmn:serviceTask id="UpdateTeamForMinorMisconduct" name="Update Team for MinorMisconduct Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;COMP_MINORMISCONDUCT_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;Stage&#34;)}">
 ---
 >     <bpmn:serviceTask id="UpdateTeamForMinorMisconduct" name="Update Team for MinorMisconduct Triage" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;COMP2_MINORMISCONDUCT_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;Stage&#34;)}">
-290c290
+290,322d287
+<     <bpmn:exclusiveGateway id="Gateway_126rajf" default="Flow_12kxvim">
+<       <bpmn:incoming>SequenceFlow_1wght7h</bpmn:incoming>
+<       <bpmn:outgoing>Flow_12kxvim</bpmn:outgoing>
+<       <bpmn:outgoing>Flow_0o39lvp</bpmn:outgoing>
+<     </bpmn:exclusiveGateway>
+<     <bpmn:sequenceFlow id="Flow_12kxvim" sourceRef="Gateway_126rajf" targetRef="Screen_Correspondents" />
+<     <bpmn:userTask id="Validate_WebformComplaint" name="Validate Webform Complaint" camunda:formKey="COMP_REGISTRATION_WEBFORM_VALID">
+<       <bpmn:incoming>Flow_0o39lvp</bpmn:incoming>
+<       <bpmn:incoming>Flow_0t13050</bpmn:incoming>
+<       <bpmn:outgoing>Flow_196fu1d</bpmn:outgoing>
+<     </bpmn:userTask>
+<     <bpmn:sequenceFlow id="Flow_0o39lvp" sourceRef="Gateway_126rajf" targetRef="Validate_WebformComplaint">
+<       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${execution.hasVariable("Channel") &amp;&amp; Channel == "Webform"}</bpmn:conditionExpression>
+<     </bpmn:sequenceFlow>
+<     <bpmn:exclusiveGateway id="Gateway_0ziwchp" default="Flow_0t13050">
+<       <bpmn:incoming>Flow_196fu1d</bpmn:incoming>
+<       <bpmn:outgoing>Flow_0t13050</bpmn:outgoing>
+<       <bpmn:outgoing>Flow_14b4wts</bpmn:outgoing>
+<     </bpmn:exclusiveGateway>
+<     <bpmn:sequenceFlow id="Flow_0t13050" sourceRef="Gateway_0ziwchp" targetRef="Validate_WebformComplaint" />
+<     <bpmn:sequenceFlow id="Flow_196fu1d" sourceRef="Validate_WebformComplaint" targetRef="Gateway_0ziwchp" />
+<     <bpmn:exclusiveGateway id="Gateway_1b26ws3" default="Flow_137x3a1">
+<       <bpmn:incoming>Flow_14b4wts</bpmn:incoming>
+<       <bpmn:outgoing>Flow_137x3a1</bpmn:outgoing>
+<       <bpmn:outgoing>Flow_06qfv1d</bpmn:outgoing>
+<     </bpmn:exclusiveGateway>
+<     <bpmn:sequenceFlow id="Flow_14b4wts" sourceRef="Gateway_0ziwchp" targetRef="Gateway_1b26ws3">
+<       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
+<     </bpmn:sequenceFlow>
+<     <bpmn:sequenceFlow id="Flow_137x3a1" sourceRef="Gateway_1b26ws3" targetRef="Screen_Correspondents" />
+<     <bpmn:sequenceFlow id="Flow_06qfv1d" sourceRef="Gateway_1b26ws3" targetRef="EndEvent_COMP_CREATION">
+<       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${execution.hasVariable("WebformComplaintInvalid") &amp;&amp; WebformComplaintInvalid == "Yes"}</bpmn:conditionExpression>
+<     </bpmn:sequenceFlow>
+325,357c290
 <     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMP_REGISTRATION">
+<       <bpmndi:BPMNEdge id="Flow_06qfv1d_di" bpmnElement="Flow_06qfv1d">
+<         <di:waypoint x="621" y="255" />
+<         <di:waypoint x="621" y="40" />
+<         <di:waypoint x="3957" y="60" />
+<         <di:waypoint x="3957" y="441" />
+<       </bpmndi:BPMNEdge>
+<       <bpmndi:BPMNEdge id="Flow_137x3a1_di" bpmnElement="Flow_137x3a1">
+<         <di:waypoint x="621" y="305" />
+<         <di:waypoint x="621" y="419" />
+<       </bpmndi:BPMNEdge>
+<       <bpmndi:BPMNEdge id="Flow_14b4wts_di" bpmnElement="Flow_14b4wts">
+<         <di:waypoint x="505" y="280" />
+<         <di:waypoint x="596" y="280" />
+<       </bpmndi:BPMNEdge>
+<       <bpmndi:BPMNEdge id="Flow_196fu1d_di" bpmnElement="Flow_196fu1d">
+<         <di:waypoint x="360" y="280" />
+<         <di:waypoint x="455" y="280" />
+<       </bpmndi:BPMNEdge>
+<       <bpmndi:BPMNEdge id="Flow_0t13050_di" bpmnElement="Flow_0t13050">
+<         <di:waypoint x="480" y="255" />
+<         <di:waypoint x="480" y="190" />
+<         <di:waypoint x="310" y="190" />
+<         <di:waypoint x="310" y="240" />
+<       </bpmndi:BPMNEdge>
+<       <bpmndi:BPMNEdge id="Flow_0o39lvp_di" bpmnElement="Flow_0o39lvp">
+<         <di:waypoint x="310" y="434" />
+<         <di:waypoint x="310" y="320" />
+<       </bpmndi:BPMNEdge>
+<       <bpmndi:BPMNEdge id="Flow_12kxvim_di" bpmnElement="Flow_12kxvim">
+<         <di:waypoint x="335" y="459" />
+<         <di:waypoint x="571" y="459" />
+<       </bpmndi:BPMNEdge>
 ---
 >     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMP2_REGISTRATION">
+359,361c292,294
+<         <di:waypoint x="3793" y="910" />
+<         <di:waypoint x="3957" y="910" />
+<         <di:waypoint x="3957" y="477" />
+---
+>         <di:waypoint x="3603" y="910" />
+>         <di:waypoint x="3767" y="910" />
+>         <di:waypoint x="3767" y="477" />
+364,366c297,299
+<         <di:waypoint x="3616" y="484" />
+<         <di:waypoint x="3616" y="910" />
+<         <di:waypoint x="3693" y="910" />
+---
+>         <di:waypoint x="3426" y="484" />
+>         <di:waypoint x="3426" y="910" />
+>         <di:waypoint x="3503" y="910" />
+369,372c302,305
+<         <di:waypoint x="2666" y="305" />
+<         <di:waypoint x="2666" y="360" />
+<         <di:waypoint x="2016" y="360" />
+<         <di:waypoint x="2016" y="419" />
+---
+>         <di:waypoint x="2476" y="305" />
+>         <di:waypoint x="2476" y="360" />
+>         <di:waypoint x="1826" y="360" />
+>         <di:waypoint x="1826" y="419" />
+375,377c308,310
+<         <di:waypoint x="2691" y="120" />
+<         <di:waypoint x="3393" y="120" />
+<         <di:waypoint x="3393" y="419" />
+---
+>         <di:waypoint x="2501" y="120" />
+>         <di:waypoint x="3203" y="120" />
+>         <di:waypoint x="3203" y="419" />
+380,381c313,314
+<         <di:waypoint x="2641" y="120" />
+<         <di:waypoint x="2536" y="120" />
+---
+>         <di:waypoint x="2451" y="120" />
+>         <di:waypoint x="2346" y="120" />
+384,385c317,318
+<         <di:waypoint x="2666" y="255" />
+<         <di:waypoint x="2666" y="145" />
+---
+>         <di:waypoint x="2476" y="255" />
+>         <di:waypoint x="2476" y="145" />
+388,389c321,322
+<         <di:waypoint x="2536" y="280" />
+<         <di:waypoint x="2641" y="280" />
+---
+>         <di:waypoint x="2346" y="280" />
+>         <di:waypoint x="2451" y="280" />
+392,393c325,326
+<         <di:waypoint x="2486" y="160" />
+<         <di:waypoint x="2486" y="240" />
+---
+>         <di:waypoint x="2296" y="160" />
+>         <di:waypoint x="2296" y="240" />
+396,398c329,331
+<         <di:waypoint x="2196" y="434" />
+<         <di:waypoint x="2196" y="120" />
+<         <di:waypoint x="2436" y="120" />
+---
+>         <di:waypoint x="2006" y="434" />
+>         <di:waypoint x="2006" y="120" />
+>         <di:waypoint x="2246" y="120" />
+401,403c334,336
+<         <di:waypoint x="3793" y="770" />
+<         <di:waypoint x="3957" y="770" />
+<         <di:waypoint x="3957" y="477" />
+---
+>         <di:waypoint x="3603" y="770" />
+>         <di:waypoint x="3767" y="770" />
+>         <di:waypoint x="3767" y="477" />
+406,408c339,341
+<         <di:waypoint x="3616" y="484" />
+<         <di:waypoint x="3616" y="770" />
+<         <di:waypoint x="3693" y="770" />
+---
+>         <di:waypoint x="3426" y="484" />
+>         <di:waypoint x="3426" y="770" />
+>         <di:waypoint x="3503" y="770" />
+411,413c344,346
+<         <di:waypoint x="3793" y="633" />
+<         <di:waypoint x="3957" y="633" />
+<         <di:waypoint x="3957" y="477" />
+---
+>         <di:waypoint x="3603" y="633" />
+>         <di:waypoint x="3767" y="633" />
+>         <di:waypoint x="3767" y="477" />
+416,418c349,351
+<         <di:waypoint x="3616" y="484" />
+<         <di:waypoint x="3616" y="633" />
+<         <di:waypoint x="3693" y="633" />
+---
+>         <di:waypoint x="3426" y="484" />
+>         <di:waypoint x="3426" y="633" />
+>         <di:waypoint x="3503" y="633" />
+421,422c354,355
+<         <di:waypoint x="3641" y="459" />
+<         <di:waypoint x="3939" y="459" />
+---
+>         <di:waypoint x="3451" y="459" />
+>         <di:waypoint x="3749" y="459" />
+425,426c358,359
+<         <di:waypoint x="3443" y="459" />
+<         <di:waypoint x="3591" y="459" />
+---
+>         <di:waypoint x="3253" y="459" />
+>         <di:waypoint x="3401" y="459" />
+429,433c362,366
+<         <di:waypoint x="1711" y="647" />
+<         <di:waypoint x="1711" y="880" />
+<         <di:waypoint x="520" y="880" />
+<         <di:waypoint x="520" y="459" />
+<         <di:waypoint x="571" y="459" />
+---
+>         <di:waypoint x="1521" y="647" />
+>         <di:waypoint x="1521" y="880" />
+>         <di:waypoint x="271" y="880" />
+>         <di:waypoint x="271" y="459" />
+>         <di:waypoint x="381" y="459" />
+436,437c369,370
+<         <di:waypoint x="1736" y="459" />
+<         <di:waypoint x="1966" y="459" />
+---
+>         <di:waypoint x="1546" y="459" />
+>         <di:waypoint x="1776" y="459" />
+440,441c373,374
+<         <di:waypoint x="1686" y="459" />
+<         <di:waypoint x="1581" y="459" />
+---
+>         <di:waypoint x="1496" y="459" />
+>         <di:waypoint x="1391" y="459" />
+443c376
+<           <dc:Bounds x="1667" y="440" width="24" height="14" />
+---
+>           <dc:Bounds x="1477" y="440" width="24" height="14" />
+447,448c380,381
+<         <di:waypoint x="1711" y="597" />
+<         <di:waypoint x="1711" y="484" />
+---
+>         <di:waypoint x="1521" y="597" />
+>         <di:waypoint x="1521" y="484" />
+451,452c384,385
+<         <di:waypoint x="1581" y="622" />
+<         <di:waypoint x="1686" y="622" />
+---
+>         <di:waypoint x="1391" y="622" />
+>         <di:waypoint x="1496" y="622" />
+455,456c388,389
+<         <di:waypoint x="1531" y="499" />
+<         <di:waypoint x="1531" y="582" />
+---
+>         <di:waypoint x="1341" y="499" />
+>         <di:waypoint x="1341" y="582" />
+459,461c392,394
+<         <di:waypoint x="1282" y="484" />
+<         <di:waypoint x="1282" y="622" />
+<         <di:waypoint x="999" y="622" />
+---
+>         <di:waypoint x="1092" y="484" />
+>         <di:waypoint x="1092" y="622" />
+>         <di:waypoint x="809" y="622" />
+464,468c397,401
+<         <di:waypoint x="1129" y="810" />
+<         <di:waypoint x="1129" y="880" />
+<         <di:waypoint x="520" y="880" />
+<         <di:waypoint x="520" y="459" />
+<         <di:waypoint x="571" y="459" />
+---
+>         <di:waypoint x="939" y="810" />
+>         <di:waypoint x="939" y="880" />
+>         <di:waypoint x="271" y="880" />
+>         <di:waypoint x="271" y="459" />
+>         <di:waypoint x="381" y="459" />
+471,472c404,405
+<         <di:waypoint x="999" y="785" />
+<         <di:waypoint x="1104" y="785" />
+---
+>         <di:waypoint x="809" y="785" />
+>         <di:waypoint x="914" y="785" />
+475,476c408,409
+<         <di:waypoint x="949" y="662" />
+<         <di:waypoint x="949" y="745" />
+---
+>         <di:waypoint x="759" y="662" />
+>         <di:waypoint x="759" y="745" />
+479,481c412,414
+<         <di:waypoint x="1129" y="760" />
+<         <di:waypoint x="1129" y="622" />
+<         <di:waypoint x="999" y="622" />
+---
+>         <di:waypoint x="939" y="760" />
+>         <di:waypoint x="939" y="622" />
+>         <di:waypoint x="809" y="622" />
+483c416
+<           <dc:Bounds x="1091" y="751" width="24" height="14" />
+---
+>           <dc:Bounds x="901" y="751" width="24" height="14" />
+487,488c420,421
+<         <di:waypoint x="1307" y="459" />
+<         <di:waypoint x="1481" y="459" />
+---
+>         <di:waypoint x="1117" y="459" />
+>         <di:waypoint x="1291" y="459" />
+491,492c424,425
+<         <di:waypoint x="1173" y="459" />
+<         <di:waypoint x="1257" y="459" />
+---
+>         <di:waypoint x="983" y="459" />
+>         <di:waypoint x="1067" y="459" />
+495,496c428,429
+<         <di:waypoint x="999" y="459" />
+<         <di:waypoint x="1073" y="459" />
+---
+>         <di:waypoint x="809" y="459" />
+>         <di:waypoint x="883" y="459" />
+499,503c432,436
+<         <di:waypoint x="3152" y="647" />
+<         <di:waypoint x="3152" y="783" />
+<         <di:waypoint x="2375" y="783" />
+<         <di:waypoint x="2375" y="459" />
+<         <di:waypoint x="2435" y="459" />
+---
+>         <di:waypoint x="2962" y="647" />
+>         <di:waypoint x="2962" y="783" />
+>         <di:waypoint x="2185" y="783" />
+>         <di:waypoint x="2185" y="459" />
+>         <di:waypoint x="2245" y="459" />
+506,507c439,440
+<         <di:waypoint x="3177" y="459" />
+<         <di:waypoint x="3343" y="459" />
+---
+>         <di:waypoint x="2987" y="459" />
+>         <di:waypoint x="3153" y="459" />
+510,511c443,444
+<         <di:waypoint x="3022" y="622" />
+<         <di:waypoint x="3127" y="622" />
+---
+>         <di:waypoint x="2832" y="622" />
+>         <di:waypoint x="2937" y="622" />
+514,515c447,448
+<         <di:waypoint x="2972" y="499" />
+<         <di:waypoint x="2972" y="582" />
+---
+>         <di:waypoint x="2782" y="499" />
+>         <di:waypoint x="2782" y="582" />
+518,519c451,452
+<         <di:waypoint x="3127" y="459" />
+<         <di:waypoint x="3022" y="459" />
+---
+>         <di:waypoint x="2937" y="459" />
+>         <di:waypoint x="2832" y="459" />
+521c454
+<           <dc:Bounds x="3110" y="436" width="24" height="14" />
+---
+>           <dc:Bounds x="2920" y="436" width="24" height="14" />
+525,526c458,459
+<         <di:waypoint x="3152" y="597" />
+<         <di:waypoint x="3152" y="484" />
+---
+>         <di:waypoint x="2962" y="597" />
+>         <di:waypoint x="2962" y="484" />
+529,533c462,466
+<         <di:waypoint x="2666" y="647" />
+<         <di:waypoint x="2666" y="814" />
+<         <di:waypoint x="1883" y="814" />
+<         <di:waypoint x="1883" y="459" />
+<         <di:waypoint x="1966" y="459" />
+---
+>         <di:waypoint x="2476" y="647" />
+>         <di:waypoint x="2476" y="814" />
+>         <di:waypoint x="1693" y="814" />
+>         <di:waypoint x="1693" y="459" />
+>         <di:waypoint x="1776" y="459" />
+536,537c469,470
+<         <di:waypoint x="2666" y="597" />
+<         <di:waypoint x="2666" y="484" />
+---
+>         <di:waypoint x="2476" y="597" />
+>         <di:waypoint x="2476" y="484" />
+540,541c473,474
+<         <di:waypoint x="2691" y="459" />
+<         <di:waypoint x="2922" y="459" />
+---
+>         <di:waypoint x="2501" y="459" />
+>         <di:waypoint x="2732" y="459" />
+544,545c477,478
+<         <di:waypoint x="2536" y="622" />
+<         <di:waypoint x="2641" y="622" />
+---
+>         <di:waypoint x="2346" y="622" />
+>         <di:waypoint x="2451" y="622" />
+548,549c481,482
+<         <di:waypoint x="2486" y="499" />
+<         <di:waypoint x="2486" y="582" />
+---
+>         <di:waypoint x="2296" y="499" />
+>         <di:waypoint x="2296" y="582" />
+552,553c485,486
+<         <di:waypoint x="2641" y="459" />
+<         <di:waypoint x="2536" y="459" />
+---
+>         <di:waypoint x="2451" y="459" />
+>         <di:waypoint x="2346" y="459" />
+555c488
+<           <dc:Bounds x="2621" y="437" width="24" height="14" />
+---
+>           <dc:Bounds x="2431" y="437" width="24" height="14" />
+559,563c492,496
+<         <di:waypoint x="2196" y="647" />
+<         <di:waypoint x="2196" y="847" />
+<         <di:waypoint x="1384" y="847" />
+<         <di:waypoint x="1384" y="459" />
+<         <di:waypoint x="1481" y="459" />
+---
+>         <di:waypoint x="2006" y="647" />
+>         <di:waypoint x="2006" y="847" />
+>         <di:waypoint x="1194" y="847" />
+>         <di:waypoint x="1194" y="459" />
+>         <di:waypoint x="1291" y="459" />
+566,567c499,500
+<         <di:waypoint x="2196" y="597" />
+<         <di:waypoint x="2196" y="484" />
+---
+>         <di:waypoint x="2006" y="597" />
+>         <di:waypoint x="2006" y="484" />
+570,571c503,504
+<         <di:waypoint x="2221" y="459" />
+<         <di:waypoint x="2436" y="459" />
+---
+>         <di:waypoint x="2031" y="459" />
+>         <di:waypoint x="2246" y="459" />
+574,575c507,508
+<         <di:waypoint x="2171" y="459" />
+<         <di:waypoint x="2066" y="459" />
+---
+>         <di:waypoint x="1981" y="459" />
+>         <di:waypoint x="1876" y="459" />
+577c510
+<           <dc:Bounds x="2151" y="440" width="24" height="14" />
+---
+>           <dc:Bounds x="1961" y="440" width="24" height="14" />
+581,582c514,515
+<         <di:waypoint x="2066" y="622" />
+<         <di:waypoint x="2171" y="622" />
+---
+>         <di:waypoint x="1876" y="622" />
+>         <di:waypoint x="1981" y="622" />
+585,586c518,519
+<         <di:waypoint x="2016" y="499" />
+<         <di:waypoint x="2016" y="582" />
+---
+>         <di:waypoint x="1826" y="499" />
+>         <di:waypoint x="1826" y="582" />
+589,590c522,523
+<         <di:waypoint x="826" y="459" />
+<         <di:waypoint x="899" y="459" />
+---
+>         <di:waypoint x="636" y="459" />
+>         <di:waypoint x="709" y="459" />
+593,594c526,527
+<         <di:waypoint x="188" y="459" />
+<         <di:waypoint x="285" y="459" />
+---
+>         <di:waypoint x="192" y="459" />
+>         <di:waypoint x="381" y="459" />
+597,599c530,532
+<         <di:waypoint x="671" y="622" />
+<         <di:waypoint x="801" y="622" />
+<         <di:waypoint x="801" y="484" />
+---
+>         <di:waypoint x="481" y="622" />
+>         <di:waypoint x="611" y="622" />
+>         <di:waypoint x="611" y="484" />
+602,603c535,536
+<         <di:waypoint x="621" y="499" />
+<         <di:waypoint x="621" y="582" />
+---
+>         <di:waypoint x="431" y="499" />
+>         <di:waypoint x="431" y="582" />
+606,607c539,540
+<         <di:waypoint x="776" y="459" />
+<         <di:waypoint x="671" y="459" />
+---
+>         <di:waypoint x="586" y="459" />
+>         <di:waypoint x="481" y="459" />
+609c542
+<           <dc:Bounds x="757" y="439" width="24" height="14" />
+---
+>           <dc:Bounds x="567" y="439" width="24" height="14" />
+613c546
+<         <dc:Bounds x="152" y="441" width="36" height="36" />
+---
+>         <dc:Bounds x="156" y="441" width="36" height="36" />
+616c549
+<         <dc:Bounds x="571" y="419" width="100" height="80" />
+---
+>         <dc:Bounds x="381" y="419" width="100" height="80" />
+619c552
+<         <dc:Bounds x="571" y="582" width="100" height="80" />
+---
+>         <dc:Bounds x="381" y="582" width="100" height="80" />
+622c555
+<         <dc:Bounds x="776" y="434" width="50" height="50" />
+---
+>         <dc:Bounds x="586" y="434" width="50" height="50" />
+625c558
+<         <dc:Bounds x="3939" y="441" width="36" height="36" />
+---
+>         <dc:Bounds x="3749" y="441" width="36" height="36" />
+628c561
+<         <dc:Bounds x="1966" y="582" width="100" height="80" />
+---
+>         <dc:Bounds x="1776" y="582" width="100" height="80" />
+631c564
+<         <dc:Bounds x="2171" y="434" width="50" height="50" />
+---
+>         <dc:Bounds x="1981" y="434" width="50" height="50" />
+634c567
+<         <dc:Bounds x="1966" y="419" width="100" height="80" />
+---
+>         <dc:Bounds x="1776" y="419" width="100" height="80" />
+637c570
+<         <dc:Bounds x="2171" y="597" width="50" height="50" />
+---
+>         <dc:Bounds x="1981" y="597" width="50" height="50" />
+639c572
+<           <dc:Bounds x="2231" y="615" width="76" height="14" />
+---
+>           <dc:Bounds x="2041" y="615" width="76" height="14" />
+643c576
+<         <dc:Bounds x="2436" y="419" width="100" height="80" />
+---
+>         <dc:Bounds x="2246" y="419" width="100" height="80" />
+646c579
+<         <dc:Bounds x="2436" y="582" width="100" height="80" />
+---
+>         <dc:Bounds x="2246" y="582" width="100" height="80" />
+649c582
+<         <dc:Bounds x="2641" y="434" width="50" height="50" />
+---
+>         <dc:Bounds x="2451" y="434" width="50" height="50" />
+652c585
+<         <dc:Bounds x="2641" y="597" width="50" height="50" />
+---
+>         <dc:Bounds x="2451" y="597" width="50" height="50" />
+654c587
+<           <dc:Bounds x="2701" y="615" width="76" height="14" />
+---
+>           <dc:Bounds x="2511" y="615" width="76" height="14" />
+658c591
+<         <dc:Bounds x="3127" y="434" width="50" height="50" />
+---
+>         <dc:Bounds x="2937" y="434" width="50" height="50" />
+661c594
+<         <dc:Bounds x="3127" y="597" width="50" height="50" />
+---
+>         <dc:Bounds x="2937" y="597" width="50" height="50" />
+663c596
+<           <dc:Bounds x="3187" y="615" width="76" height="14" />
+---
+>           <dc:Bounds x="2997" y="615" width="76" height="14" />
+667c600
+<         <dc:Bounds x="2922" y="419" width="100" height="80" />
+---
+>         <dc:Bounds x="2732" y="419" width="100" height="80" />
+670c603
+<         <dc:Bounds x="2922" y="582" width="100" height="80" />
+---
+>         <dc:Bounds x="2732" y="582" width="100" height="80" />
+673c606
+<         <dc:Bounds x="899" y="419" width="100" height="80" />
+---
+>         <dc:Bounds x="709" y="419" width="100" height="80" />
+676c609
+<         <dc:Bounds x="1073" y="419" width="100" height="80" />
+---
+>         <dc:Bounds x="883" y="419" width="100" height="80" />
+679c612
+<         <dc:Bounds x="1257" y="434" width="50" height="50" />
+---
+>         <dc:Bounds x="1067" y="434" width="50" height="50" />
+682c615
+<         <dc:Bounds x="899" y="582" width="100" height="80" />
+---
+>         <dc:Bounds x="709" y="582" width="100" height="80" />
+685c618
+<         <dc:Bounds x="899" y="745" width="100" height="80" />
+---
+>         <dc:Bounds x="709" y="745" width="100" height="80" />
+688c621
+<         <dc:Bounds x="1104" y="760" width="50" height="50" />
+---
+>         <dc:Bounds x="914" y="760" width="50" height="50" />
+691c624
+<         <dc:Bounds x="1481" y="582" width="100" height="80" />
+---
+>         <dc:Bounds x="1291" y="582" width="100" height="80" />
+694c627
+<         <dc:Bounds x="1686" y="434" width="50" height="50" />
+---
+>         <dc:Bounds x="1496" y="434" width="50" height="50" />
+697c630
+<         <dc:Bounds x="1481" y="419" width="100" height="80" />
+---
+>         <dc:Bounds x="1291" y="419" width="100" height="80" />
+700c633
+<         <dc:Bounds x="1686" y="597" width="50" height="50" />
+---
+>         <dc:Bounds x="1496" y="597" width="50" height="50" />
+702c635
+<           <dc:Bounds x="1746" y="615" width="76" height="14" />
+---
+>           <dc:Bounds x="1556" y="615" width="76" height="14" />
+706c639
+<         <dc:Bounds x="3343" y="419" width="100" height="80" />
+---
+>         <dc:Bounds x="3153" y="419" width="100" height="80" />
+709c642
+<         <dc:Bounds x="3591" y="434" width="50" height="50" />
+---
+>         <dc:Bounds x="3401" y="434" width="50" height="50" />
+712c645
+<         <dc:Bounds x="3693" y="593" width="100" height="80" />
+---
+>         <dc:Bounds x="3503" y="593" width="100" height="80" />
+715c648
+<         <dc:Bounds x="3693" y="730" width="100" height="80" />
+---
+>         <dc:Bounds x="3503" y="730" width="100" height="80" />
+718c651
+<         <dc:Bounds x="2436" y="80" width="100" height="80" />
+---
+>         <dc:Bounds x="2246" y="80" width="100" height="80" />
+721c654
+<         <dc:Bounds x="2436" y="240" width="100" height="80" />
+---
+>         <dc:Bounds x="2246" y="240" width="100" height="80" />
+724c657
+<         <dc:Bounds x="2641" y="255" width="50" height="50" />
+---
+>         <dc:Bounds x="2451" y="255" width="50" height="50" />
+726c659
+<           <dc:Bounds x="2701" y="273" width="76" height="14" />
+---
+>           <dc:Bounds x="2511" y="273" width="76" height="14" />
+730c663
+<         <dc:Bounds x="2641" y="95" width="50" height="50" />
+---
+>         <dc:Bounds x="2451" y="95" width="50" height="50" />
+733,745c666
+<         <dc:Bounds x="3693" y="870" width="100" height="80" />
+<       </bpmndi:BPMNShape>
+<       <bpmndi:BPMNShape id="Gateway_126rajf_di" bpmnElement="Gateway_126rajf" isMarkerVisible="true">
+<         <dc:Bounds x="285" y="434" width="50" height="50" />
+<       </bpmndi:BPMNShape>
+<       <bpmndi:BPMNShape id="Activity_0w7ywmi_di" bpmnElement="Validate_WebformComplaint">
+<         <dc:Bounds x="260" y="240" width="100" height="80" />
+<       </bpmndi:BPMNShape>
+<       <bpmndi:BPMNShape id="Gateway_0ziwchp_di" bpmnElement="Gateway_0ziwchp" isMarkerVisible="true">
+<         <dc:Bounds x="455" y="255" width="50" height="50" />
+<       </bpmndi:BPMNShape>
+<       <bpmndi:BPMNShape id="Gateway_1b26ws3_di" bpmnElement="Gateway_1b26ws3" isMarkerVisible="true">
+<         <dc:Bounds x="596" y="255" width="50" height="50" />
+---
+>         <dc:Bounds x="3503" y="870" width="100" height="80" />

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/COMP.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/COMP.java
@@ -15,6 +15,7 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.digital.ho.hocs.workflow.BpmnService;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.mockito.Mockito.*;
 import static uk.gov.digital.ho.hocs.workflow.util.CallActivityMockWrapper.whenAtCallActivity;
@@ -468,6 +469,22 @@ public class COMP {
         verify(processScenario, times(1)).hasCompleted("CallActivity_EXGRATIA_TRIAGE");
         verify(processScenario, times(1)).hasCompleted("ServiceTask_CompleteCase");
         verify(processScenario, times(1)).hasCompleted("EndEvent_COMP");
+    }
+
+    @Test
+    public void whenWebformClosureCompletesCase() {
+        whenAtCallActivity("COMP_REGISTRATION")
+                .thenReturn("WebformComplaintInvalid", "Yes")
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("COMP", Map.of("Channel", "Webform"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_COMP");
+        verify(processScenario).hasCompleted("CallActivity_COMP_REGISTRATION");
+        verify(processScenario).hasCompleted("ServiceTask_CompleteCase");
+        verify(processScenario).hasCompleted("EndEvent_COMP");
     }
 
     @After


### PR DESCRIPTION
This changes support the requirement for a user to be able to close a
WebForm case as early as possible if it's not deemed valid. This is done
through a check if the channel is specified as WebForm and then shows a
validation screen within COMP_REGISTRATION. The outcome of this screen
is then propagated up to the COMP workflow to complete the case as
required.

WIP change for closing Webform cases earlier in the pipeline. This
contains the core logic that works - the other parts (form design)
should be easily alterable).