### PR TITLE
HOCS-4462: alter driving variable for WebForm case

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,20 @@
 # HOCS Workflow Service
 
 [![CodeQL](https://github.com/UKHomeOffice/hocs-workflow/actions/workflows/codeql-analysis.yml/badge.svg)](https://github.com/UKHomeOffice/hocs-workflow/actions/workflows/codeql-analysis.yml)
- 
- ## Developing locally
- 
- The service will run against localstack using the `local` Spring profile and the docker-compose services in `docker/docker-compose.yml`
- 
-To start local instances run `./docker/docker-compose up`.
- 
+
 This is the Home Office Correspondence Service (HOCS) workflow service.
 
-The HOCS project is comprised of a set of micro-services:
-* [hocs-workflow](https://github.com/UKHomeOffice/hocs-workflow): models the business processes between the services
-* [hocs-frontend](https://github.com/UKHomeOffice/hocs-frontend): the UI service, implemented in Node and React.
-* [hocs-casework](https://github.com/UKHomeOffice/hocs-casework): handles the data for each correspondence case.
-* [hocs-info-service](https://github.com/UKHomeOffice/hocs-info-service): manages static data and data retrieved through external APIs
-* [hocs-docs](https://github.com/UKHomeOffice/hocs-docs): manages processing and storage of documents
-* [hocs-audit](https://github.com/UKHomeOffice/hocs-audit): receives and stores audit events.
-
-The source for this service can be found on [GitHub](https://github.com/UKHomeOffice/hocs-workflow.git).
-
+## Developing locally
+ 
+The service will run against localstack using the `local` Spring profile and the docker-compose services in `docker/docker-compose.yml`
+ 
+To start local instances run `./docker/docker-compose up`.
 
 ## Getting Started
 
 ### Prerequisites
 
-* ```Java 8```
+* ```Java 11```
 * ```Docker```
 * ```AWS SQS queues``` (document and case output) or localstack
 * ```Postgres``` 
@@ -36,7 +25,7 @@ The source for this service can be found on [GitHub](https://github.com/UKHomeOf
 In order to run the service locally, a postgres database, SQS queues, and LocalStack are required. 
 These are available through the [docker-compose.yml](docker-compose.yml) file.
 
-To start postgres, sqs, and localstack containers through Docker, from the root of the project run 
+To start the required containers through Docker, from the root of the project run 
 
 ```
  docker-compose up 
@@ -48,35 +37,16 @@ docker-compose down
 
 ### Running in an IDE
 
-If you are using an IDE, such as IntelliJ, this service can be started by running the ```HocsCaseApplication``` main class. 
-The service can then be accessed at ```http://localhost:8081```.
+If you are using an IDE, such as IntelliJ, this service can be started by running the `HocsWorkflowApplication` main class. 
+The service can then be accessed at ```http://localhost:8091```.
 
 ### Building and running without an IDE
 
-This service is built using Gradle. In order to build the project from the command line, run
-
-```
-gradle clean build
-```
-in the root of the project.
+This service is built using Gradle. In order to build the project from the command line, run `gradle clean build` from the root of the project.
 
 Alternatively, the corresponding Docker image for this service is available at [quay.io](https://quay.io/repository/ukhomeofficedigital/hocs-workflow).
 
-### Flyway and database management
-
-When changes are made to the postgres database through the service they are tracked with Flyway. Any changes which are not tracked will require the database to be restarted. 
-To restart the database, from the root of the project run
-
-```$xslt
-docker-compose stop postgres
-```
-and when stopped, restart it by running
-```$xslt
-docker-compose start postgres
-```
-and there will be a new instance of postgres.
-
-## Tests
+### Tests
 
 The suite of tests includes unit tests for the resource and services classes, and integration tests. In order to run the integration tests, an instance of postgres must be running.
 To run the unit tests in isolation (without the need for a postgres instance running), run the following:
@@ -84,30 +54,27 @@ To run the unit tests in isolation (without the need for a postgres instance run
 ./gradlew test
 ```
 
-## Deployment
+### Deployment
 
- See the [pipeline](.drone.yml) for the steps involved in the build and deployment.
+See the [pipeline](.drone.yml) for the steps involved in the build and deployment.
 
 ## Running the HOCS project
 
 The entire set of services can be run in Docker containers from the
- [hocs-frontend](https://github.com/UKHomeOffice/hocs-frontend) project. Navigate to ```/docker``` from the frontend directory, then run
- 
- ```$xslt
-./scripts/infrastructure.sh
-```
+ [hocs](https://github.com/UKHomeOffice/hocs) project. Navigate to the `/docker`  directory, then run `./scripts/infrastructure.sh`
 to initiate the infrastructure service containers. These include the postgres, SQS, and LocalStack images. 
-When the containers are set up and the services have completed starting, then run
 
-```$xslt
-./scripts/services.sh
-```
+When the containers are set up and the services have completed starting, then run `./scripts/services.sh`
 to launch the set of HOCS micro-services.
 
-To stop and clear the service containers run
-```
-./scripts/clean.sh
-```
+To stop and clear the service containers run `./scripts/clean.sh`.
+
+## Camunda Conventions
+
+### Non-modifiable fields
+
+Sometimes identifying fields are required that aren't changeable through the frontend UI to drive system behaviour within processes. To support this the convention that we use is `X[FieldName]`.
+
 ## Using the Service
 
 ### Versioning

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowConstants.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowConstants.java
@@ -25,5 +25,6 @@ public interface WorkflowConstants {
     String CASE_DATA_TYPE_FOI = "FOI";
     String CASE_DATA_TYPE_COMP = "COMP";
     String CHANNEL = "Channel";
+    String CHANNEL_COMP_ORIGINATEDFROM = "XOriginatedFrom";
     String CHANNEL_COMP_WEBFORM = "Webform";
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowService.java
@@ -81,15 +81,18 @@ public class WorkflowService {
         caseData.put(WorkflowConstants.DATE_RECEIVED, dateReceived.toString());
         caseData.put(WorkflowConstants.LAST_UPDATED_BY_USER, userUUID.toString());
 
-        if (receivedData != null && Objects.equals(caseDataType, WorkflowConstants.CASE_DATA_TYPE_FOI)) {
-            // If we have a name we have correspondent details attached to the case creation request
-            if(receivedData.containsKey(WorkflowConstants.FULL_NAME)) {
+        if (receivedData != null) {
+            // If FOI and we have a name we have correspondent details attached to the case creation reques
+            if (Objects.equals(caseDataType, WorkflowConstants.CASE_DATA_TYPE_FOI)
+                    && receivedData.containsKey(WorkflowConstants.FULL_NAME)) {
                 correspondentRequest = buildCorrespondentRequest(receivedData);
 
                 caseData.put(WorkflowConstants.KIMU_DATE_RECEIVED, receivedData.get(WorkflowConstants.KIMU_DATE_RECEIVED));
                 caseData.put(WorkflowConstants.TOPICS, receivedData.get(WorkflowConstants.TOPICS));
                 caseData.put(WorkflowConstants.ORIGINAL_CHANNEL, receivedData.get(WorkflowConstants.ORIGINAL_CHANNEL));
                 caseData.put(WorkflowConstants.REQUEST_QUESTION, receivedData.get(WorkflowConstants.REQUEST_QUESTION));
+            } else if (isCreationForCompWebformCase(caseDataType, receivedData)) {
+                caseData.putAll(receivedData);
             }
         }
 
@@ -403,7 +406,7 @@ public class WorkflowService {
 
     private boolean isCreationForCompWebformCase(String caseDataType, Map<String, String> receivedData) {
         return Objects.equals(caseDataType, WorkflowConstants.CASE_DATA_TYPE_COMP)
-                    && Objects.equals(receivedData.get(WorkflowConstants.CHANNEL), WorkflowConstants.CHANNEL_COMP_WEBFORM);
+                    && Objects.equals(receivedData.get(WorkflowConstants.CHANNEL_COMP_ORIGINATEDFROM), WorkflowConstants.CHANNEL_COMP_WEBFORM);
     }
 
 }

--- a/src/main/resources/processes/COMP_REGISTRATION.bpmn
+++ b/src/main/resources/processes/COMP_REGISTRATION.bpmn
@@ -299,7 +299,7 @@
       <bpmn:outgoing>Flow_196fu1d</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:sequenceFlow id="Flow_0o39lvp" sourceRef="Gateway_126rajf" targetRef="Validate_WebformComplaint">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${execution.hasVariable("Channel") &amp;&amp; Channel == "Webform"}</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${execution.hasVariable("XOriginatedFrom") &amp;&amp; XOriginatedFrom == "Webform"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="Gateway_0ziwchp" default="Flow_0t13050">
       <bpmn:incoming>Flow_196fu1d</bpmn:incoming>

--- a/src/test/diffs/COMP_REGISTRATION-COMP2_REGISTRATION.diff
+++ b/src/test/diffs/COMP_REGISTRATION-COMP2_REGISTRATION.diff
@@ -42,7 +42,7 @@
 <       <bpmn:outgoing>Flow_196fu1d</bpmn:outgoing>
 <     </bpmn:userTask>
 <     <bpmn:sequenceFlow id="Flow_0o39lvp" sourceRef="Gateway_126rajf" targetRef="Validate_WebformComplaint">
-<       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${execution.hasVariable("Channel") &amp;&amp; Channel == "Webform"}</bpmn:conditionExpression>
+<       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${execution.hasVariable("XOriginatedFrom") &amp;&amp; XOriginatedFrom == "Webform"}</bpmn:conditionExpression>
 <     </bpmn:sequenceFlow>
 <     <bpmn:exclusiveGateway id="Gateway_0ziwchp" default="Flow_0t13050">
 <       <bpmn:incoming>Flow_196fu1d</bpmn:incoming>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowServiceTest.java
@@ -63,6 +63,8 @@ public class WorkflowServiceTest {
     ArgumentCaptor<CreateCaseworkCorrespondentRequest> argumentCaptor;
 
     @Captor
+    ArgumentCaptor<Map<String, String>> caseDateArgumentCaptor;
+    @Captor
     ArgumentCaptor<Map<String, String>> seedDateArgumentCaptor;
 
     @Spy
@@ -163,17 +165,21 @@ public class WorkflowServiceTest {
         LocalDate dateReceived = LocalDate.EPOCH;
         List<DocumentSummary> documents =  new ArrayList<>();
         UUID userUUID = UUID.randomUUID();
-        Map<String, String> receivedData = Map.of(WorkflowConstants.CHANNEL, WorkflowConstants.CHANNEL_COMP_WEBFORM);
+        Map<String, String> receivedData = Map.of(
+                WorkflowConstants.CHANNEL, WorkflowConstants.CHANNEL_COMP_WEBFORM,
+                WorkflowConstants.CHANNEL_COMP_ORIGINATEDFROM, WorkflowConstants.CHANNEL_COMP_WEBFORM
+                );
         CreateCaseworkCaseResponse createCaseworkCaseResponse = new CreateCaseworkCaseResponse(UUID.randomUUID(), null);
 
-        when(caseworkClient.createCase(any(), any(), any(), any())).thenReturn(createCaseworkCaseResponse);
+        when(caseworkClient.createCase(any(), caseDateArgumentCaptor.capture(), any(), any())).thenReturn(createCaseworkCaseResponse);
 
         CreateCaseResponse output = workflowService.createCase(caseDataType, dateReceived, documents, userUUID,null, receivedData);
         assertThat(output.getUuid()).isNotNull();
         verify(camundaClient, times(1)).startCase(any(), any(), seedDateArgumentCaptor.capture());
         verify(caseworkClient, times(0)).saveCorrespondent(any(), any(), any());
-
-        assertThat(seedDateArgumentCaptor.getValue()).containsEntry(WorkflowConstants.CHANNEL, WorkflowConstants.CHANNEL_COMP_WEBFORM);
+        
+        assertThat(seedDateArgumentCaptor.getValue()).containsAllEntriesOf(receivedData);
+        assertThat(seedDateArgumentCaptor.getValue()).containsAllEntriesOf(receivedData);
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/COMP_REGISTRATION.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/COMP_REGISTRATION.java
@@ -84,7 +84,7 @@ public class COMP_REGISTRATION {
                 .thenReturn(task -> task.complete(withVariables("valid", true)));
 
         Scenario.run(compRegistrationProcess)
-                .startByKey("COMP_REGISTRATION", Map.of("Channel", "Webform"))
+                .startByKey("COMP_REGISTRATION", Map.of("XOriginatedFrom", "Webform"))
                 .execute();
 
         verify(compRegistrationProcess, times(2))
@@ -103,7 +103,7 @@ public class COMP_REGISTRATION {
                 .thenReturn(task -> task.complete(withVariables("valid", true, "WebformComplaintInvalid", "Yes")));
 
         Scenario.run(compRegistrationProcess)
-                .startByKey("COMP_REGISTRATION", Map.of("Channel", "Webform"))
+                .startByKey("COMP_REGISTRATION", Map.of("XOriginatedFrom", "Webform"))
                 .execute();
 
         verify(compRegistrationProcess)


### PR DESCRIPTION
To better support strictly WebForm cases for COMP in the future, 
the driving process variable has been altered to the non-modifiable
variable called `XOriginatedFrom`. 

It also supports the passing through the received data to the case 
data if it originates from the UKVI WebForm.