### PR TITLE
HOCS-4421: deployment uses point in time config

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -46,7 +46,6 @@ steps:
       registry: quay.io
       repo: quay.io/ukhomeofficedigital/hocs-workflow
       tags:
-        - build_${DRONE_BUILD_NUMBER}
         - ${DRONE_COMMIT_SHA}
         - branch-${DRONE_COMMIT_BRANCH/\//_}
     environment:
@@ -67,7 +66,6 @@ steps:
       registry: quay.io
       repo: quay.io/ukhomeofficedigital/hocs-workflow
       tags:
-        - build_${DRONE_BUILD_NUMBER}
         - ${DRONE_COMMIT_SHA}
         - latest
     environment:
@@ -105,6 +103,11 @@ environment:
   DOCKER_HOST: tcp://docker:2375
 
 steps:
+  - name: fetch and checkout
+    image: alpine/git
+    commands:
+      - git fetch --tags
+      - git checkout $${VERSION}
 
   - name: deploy to cs-dev
     image: quay.io/ukhomeofficedigital/kd
@@ -116,7 +119,9 @@ steps:
       KUBE_TOKEN:
         from_secret: hocs_workflow_cs_dev
       KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      VERSION: build_${DRONE_BUILD_NUMBER}
+      VERSION: "${DRONE_COMMIT_SHA}"
+    depends_on:
+      - fetch and checkout
     when:
       branch:
         - main
@@ -133,7 +138,9 @@ steps:
       KUBE_TOKEN:
         from_secret: hocs_workflow_wcs_dev
       KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      VERSION: build_${DRONE_BUILD_NUMBER}
+      VERSION: "${DRONE_COMMIT_SHA}"
+    depends_on:
+      - fetch and checkout
     when:
       branch:
         - main
@@ -175,6 +182,7 @@ steps:
         from_secret: GITHUB_TOKEN
     depends_on:
       - wait for docker
+      - fetch and checkout
     when:
       event:
         - promote
@@ -231,6 +239,8 @@ steps:
       KUBE_TOKEN:
         from_secret: hocs_workflow_${DRONE_DEPLOY_TO/-/_}
       KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+    depends_on:
+      - fetch and checkout
     when:
       event:
         - promote
@@ -249,6 +259,8 @@ steps:
       KUBE_TOKEN:
         from_secret: hocs_workflow_${DRONE_DEPLOY_TO/-/_}
       KUBE_SERVER: https://kube-api-prod.prod.acp.homeoffice.gov.uk
+    depends_on:
+      - fetch and checkout
     when:
       event:
         - promote


### PR DESCRIPTION
Releases that are currently handled through the pipeline use the
kubernetes configuration at the head of main and not the point in time
for that 'version'. This change includes adding a 'fetch and checkout'
step that checks out the Git commit SHA for dev deployments and the
SemVar tag for other releases. This enables us to use the config from
that point in time.