### PR TITLE
HOCS-4761 add fix to allow case to move correctly from QA and Draft

### DIFF
--- a/src/main/resources/processes/TO_DRAFT.bpmn
+++ b/src/main/resources/processes/TO_DRAFT.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0r2cloe" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0r2cloe" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="TO_DRAFT" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_03guvgo</bpmn:outgoing>
@@ -7,7 +7,6 @@
     <bpmn:endEvent id="Event_1v5mqaj">
       <bpmn:incoming>Flow_1m6v0co</bpmn:incoming>
       <bpmn:incoming>Flow_00vcxdd</bpmn:incoming>
-      <bpmn:incoming>Flow_0o5isr4</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_03guvgo" sourceRef="StartEvent_1" targetRef="TO_DRAFT_UPLOAD_DOC" />
     <bpmn:sequenceFlow id="Flow_1cmkj35" sourceRef="TO_DRAFT_UPLOAD_DOC" targetRef="DIRECTION" />
@@ -66,6 +65,7 @@
     <bpmn:serviceTask id="UPDATE_BUS_AREA_STATUS" name="Update Business Area Status: Confirmed" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;BusAreaStatus&#34;, &#34;Confirmed&#34;)}">
       <bpmn:incoming>Flow_0h4443r</bpmn:incoming>
       <bpmn:incoming>Flow_1921yjb</bpmn:incoming>
+      <bpmn:incoming>Flow_0o5isr4</bpmn:incoming>
       <bpmn:outgoing>Flow_00vcxdd</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_00vcxdd" sourceRef="UPDATE_BUS_AREA_STATUS" targetRef="Event_1v5mqaj" />
@@ -150,7 +150,7 @@
       <bpmn:outgoing>Flow_0jh4ebh</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_0vxguz9" sourceRef="Gateway_0ye1gj6" targetRef="Activity_1y2mfrq" />
-    <bpmn:sequenceFlow id="Flow_0o5isr4" sourceRef="Activity_1y2mfrq" targetRef="Event_1v5mqaj" />
+    <bpmn:sequenceFlow id="Flow_0o5isr4" sourceRef="Activity_1y2mfrq" targetRef="UPDATE_BUS_AREA_STATUS" />
     <bpmn:sequenceFlow id="Flow_0u9hm4s" sourceRef="TO_CLOSE_CASE" targetRef="Gateway_0ye1gj6" />
     <bpmn:sequenceFlow id="Flow_0jh4ebh" sourceRef="Gateway_0ye1gj6" targetRef="TO_DRAFT_UPLOAD_DOC">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
@@ -170,8 +170,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0o5isr4_di" bpmnElement="Flow_0o5isr4">
         <di:waypoint x="1380" y="570" />
-        <di:waypoint x="1610" y="570" />
-        <di:waypoint x="1610" y="385" />
+        <di:waypoint x="1480" y="570" />
+        <di:waypoint x="1480" y="410" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0vxguz9_di" bpmnElement="Flow_0vxguz9">
         <di:waypoint x="1055" y="570" />

--- a/src/main/resources/processes/TO_QA.bpmn
+++ b/src/main/resources/processes/TO_QA.bpmn
@@ -1,12 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0f1wfnj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0f1wfnj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="TO_QA" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0flmj05</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:endEvent id="Event_0nlva02" name="End Stage">
-      <bpmn:incoming>Flow_15zn9g3</bpmn:incoming>
-      <bpmn:incoming>Flow_1tgyxfj</bpmn:incoming>
       <bpmn:incoming>Flow_1bhksxl</bpmn:incoming>
       <bpmn:incoming>Flow_1eovvna</bpmn:incoming>
     </bpmn:endEvent>
@@ -55,7 +53,7 @@
       <bpmn:outgoing>Flow_1dptjqe</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:sequenceFlow id="Flow_0rvjo1x" sourceRef="Activity_1e5czwh" targetRef="UPDATE_BUS_AREA_STATUS" />
-    <bpmn:sequenceFlow id="Flow_15zn9g3" sourceRef="Activity_0k5qv30" targetRef="Event_0nlva02" />
+    <bpmn:sequenceFlow id="Flow_15zn9g3" sourceRef="Activity_0k5qv30" targetRef="UPDATE_BUS_AREA_STATUS" />
     <bpmn:exclusiveGateway id="Gateway_1mpvidq" name="Direction?" default="Flow_06rqbxb">
       <bpmn:incoming>Flow_1dptjqe</bpmn:incoming>
       <bpmn:outgoing>Flow_06rqbxb</bpmn:outgoing>
@@ -73,7 +71,7 @@
     <bpmn:sequenceFlow id="Flow_0ni3gfo" name="SendToStopList" sourceRef="Gateway_0vour6f" targetRef="Activity_0rehwcp">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${QaStatus == "SendToStopList" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1tgyxfj" sourceRef="Activity_0xe7z8s" targetRef="Event_0nlva02" />
+    <bpmn:sequenceFlow id="Flow_1tgyxfj" sourceRef="Activity_0xe7z8s" targetRef="UPDATE_BUS_AREA_STATUS" />
     <bpmn:sequenceFlow id="Flow_13wetct" sourceRef="Activity_0extn6g" targetRef="Activity_1e5czwh" />
     <bpmn:serviceTask id="Activity_0extn6g" name="Clear Rejection Note" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;RejectionNote&#34;)}">
       <bpmn:incoming>Flow_0je25my</bpmn:incoming>
@@ -143,6 +141,8 @@
     <bpmn:serviceTask id="UPDATE_BUS_AREA_STATUS" name="Update Business Area Status: Confirmed" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;BusAreaStatus&#34;, &#34;Confirmed&#34;)}">
       <bpmn:incoming>Flow_0rvjo1x</bpmn:incoming>
       <bpmn:incoming>Flow_1mxikgo</bpmn:incoming>
+      <bpmn:incoming>Flow_1tgyxfj</bpmn:incoming>
+      <bpmn:incoming>Flow_15zn9g3</bpmn:incoming>
       <bpmn:outgoing>Flow_1eovvna</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_1eovvna" sourceRef="UPDATE_BUS_AREA_STATUS" targetRef="Event_0nlva02" />
@@ -211,7 +211,7 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1mxikgo_di" bpmnElement="Flow_1mxikgo">
         <di:waypoint x="1400" y="447" />
-        <di:waypoint x="1470" y="447" />
+        <di:waypoint x="1580" y="447" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1tc8et8_di" bpmnElement="Flow_1tc8et8">
         <di:waypoint x="1100" y="447" />
@@ -233,8 +233,8 @@
         <di:waypoint x="1185" y="320" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1eovvna_di" bpmnElement="Flow_1eovvna">
-        <di:waypoint x="1570" y="447" />
-        <di:waypoint x="1622" y="447" />
+        <di:waypoint x="1680" y="447" />
+        <di:waypoint x="1732" y="447" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_00wjrub_di" bpmnElement="Flow_00wjrub">
         <di:waypoint x="555" y="447" />
@@ -242,8 +242,8 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1bhksxl_di" bpmnElement="Flow_1bhksxl">
         <di:waypoint x="1235" y="850" />
-        <di:waypoint x="1640" y="850" />
-        <di:waypoint x="1640" y="465" />
+        <di:waypoint x="1750" y="850" />
+        <di:waypoint x="1750" y="465" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0tgrwo7_di" bpmnElement="Flow_0tgrwo7">
         <di:waypoint x="660" y="730" />
@@ -306,9 +306,10 @@
         <di:waypoint x="1470" y="580" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1tgyxfj_di" bpmnElement="Flow_1tgyxfj">
-        <di:waypoint x="1570" y="320" />
-        <di:waypoint x="1640" y="320" />
-        <di:waypoint x="1640" y="429" />
+        <di:waypoint x="1520" y="360" />
+        <di:waypoint x="1520" y="384" />
+        <di:waypoint x="1630" y="384" />
+        <di:waypoint x="1630" y="407" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ni3gfo_di" bpmnElement="Flow_0ni3gfo">
         <di:waypoint x="742" y="434" />
@@ -331,12 +332,14 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_15zn9g3_di" bpmnElement="Flow_15zn9g3">
         <di:waypoint x="1570" y="690" />
-        <di:waypoint x="1640" y="690" />
-        <di:waypoint x="1640" y="465" />
+        <di:waypoint x="1660" y="690" />
+        <di:waypoint x="1660" y="490" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0rvjo1x_di" bpmnElement="Flow_0rvjo1x">
         <di:waypoint x="1520" y="540" />
-        <di:waypoint x="1520" y="487" />
+        <di:waypoint x="1520" y="514" />
+        <di:waypoint x="1630" y="514" />
+        <di:waypoint x="1630" y="487" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_06o8nsd_di" bpmnElement="Flow_06o8nsd">
         <di:waypoint x="1400" y="690" />
@@ -369,12 +372,6 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="152" y="429" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0nlva02_di" bpmnElement="Event_0nlva02">
-        <dc:Bounds x="1622" y="429" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1674" y="440" width="52" height="14" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_10cuzi3_di" bpmnElement="TO_QA_OUTCOME">
         <dc:Bounds x="250" y="407" width="100" height="80" />
@@ -436,9 +433,6 @@
           <dc:Bounds x="1145" y="873" width="50" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0e048yc_di" bpmnElement="UPDATE_BUS_AREA_STATUS">
-        <dc:Bounds x="1470" y="407" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0rehwcp_di" bpmnElement="Activity_0rehwcp">
         <dc:Bounds x="1000" y="280" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -459,6 +453,15 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="1185" y="482" width="50" height="14" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0nlva02_di" bpmnElement="Event_0nlva02">
+        <dc:Bounds x="1732" y="429" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1784" y="440" width="52" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0e048yc_di" bpmnElement="UPDATE_BUS_AREA_STATUS">
+        <dc:Bounds x="1580" y="407" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/to/TO_DRAFT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/to/TO_DRAFT.java
@@ -221,5 +221,8 @@ public class TO_DRAFT {
         verify(TOProcess, times(1))
                 .hasCompleted(SAVE_CLOSE_CASE_NOTE);
 
+        verify(TOProcess, times(1))
+                .hasCompleted(UPDATE_BUS_AREA_STATUS);
+
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/to/TO_QA.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/to/TO_QA.java
@@ -112,6 +112,9 @@ public class TO_QA {
 
         verify(TOProcess, times(0))
                 .hasCompleted(SAVE_CLOSE_CASE_NOTE);
+
+        verify(TOProcess, times(1))
+                .hasCompleted(UPDATE_BUS_AREA_STATUS);
     }
 
 
@@ -188,6 +191,9 @@ public class TO_QA {
         verify(TOProcess, times(0))
                 .hasCompleted(SAVE_CLOSE_CASE_NOTE);
 
+        verify(TOProcess, times(1))
+                .hasCompleted(UPDATE_BUS_AREA_STATUS);
+
     }
 
     @Test
@@ -232,6 +238,9 @@ public class TO_QA {
 
         verify(TOProcess, times(0))
                 .hasCompleted(SAVE_CLOSE_CASE_NOTE);
+
+        verify(TOProcess, times(1))
+                .hasCompleted(UPDATE_BUS_AREA_STATUS);
     }
 
     @Test
@@ -276,6 +285,9 @@ public class TO_QA {
 
         verify(TOProcess, times(0))
                 .hasCompleted(SAVE_CLOSE_CASE_NOTE);
+
+        verify(TOProcess, times(1))
+                .hasCompleted(UPDATE_BUS_AREA_STATUS);
     }
 
     @Test
@@ -317,6 +329,9 @@ public class TO_QA {
 
         verify(TOProcess, times(0))
                 .hasCompleted(SAVE_CLOSE_CASE_NOTE);
+
+        verify(TOProcess, times(1))
+                .hasCompleted(UPDATE_BUS_AREA_STATUS);
     }
 
     @Test
@@ -360,5 +375,8 @@ public class TO_QA {
 
         verify(TOProcess, times(0))
                 .hasCompleted(TO_QA_REJECTION_NOTE);
+
+        verify(TOProcess, times(1))
+                .hasCompleted(UPDATE_BUS_AREA_STATUS);
     }
 }


### PR DESCRIPTION
Added a fix to QA and Draft stages to allow cases to transfer to Stop List and Campaign and reject to earlier stages.