### PR TITLE
HOCS-4703: add correspondents flow for POGR

### DIFF
--- a/src/main/resources/processes/POGR/POGR_REGISTRATION.bpmn
+++ b/src/main/resources/processes/POGR/POGR_REGISTRATION.bpmn
@@ -6,7 +6,7 @@
     </bpmn:endEvent>
     <bpmn:userTask id="Screen_BusinessAreaSelect" name="Specify Business Area" camunda:formKey="POGR_BUSINESS_AREA">
       <bpmn:incoming>Flow_0e5zero</bpmn:incoming>
-      <bpmn:incoming>Flow_1icrh8u</bpmn:incoming>
+      <bpmn:incoming>Flow_1xag00p</bpmn:incoming>
       <bpmn:outgoing>Flow_1m6ppjm</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:startEvent id="StartEvent_BusinessSelect">
@@ -18,7 +18,7 @@
       <bpmn:outgoing>Flow_08yg89l</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:exclusiveGateway id="Gateway_02t74c2">
-      <bpmn:incoming>Flow_0z9w73r</bpmn:incoming>
+      <bpmn:incoming>Flow_1pjw6dz</bpmn:incoming>
       <bpmn:outgoing>Flow_1smdms3</bpmn:outgoing>
       <bpmn:outgoing>Flow_1dz65xk</bpmn:outgoing>
     </bpmn:exclusiveGateway>
@@ -41,7 +41,7 @@
     <bpmn:sequenceFlow id="Flow_1smdms3" sourceRef="Gateway_02t74c2" targetRef="Screen_Hmpo_DataInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ BusinessArea == "HMPO" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0z9w73r" sourceRef="Service_UpdateCaseDeadline" targetRef="Gateway_02t74c2" />
+    <bpmn:sequenceFlow id="Flow_0z9w73r" sourceRef="Service_UpdateCaseDeadline" targetRef="CallActivity_CorrespondentInput" />
     <bpmn:sequenceFlow id="Flow_1dz65xk" sourceRef="Gateway_02t74c2" targetRef="Screen_Gro_DataInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ BusinessArea == "GRO" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -54,43 +54,72 @@
     <bpmn:sequenceFlow id="Flow_0p2fc9m" sourceRef="Gateway_0hpz69o" targetRef="EndEvent_BusinessSelect">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DIRECTION == "FORWARD" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1icrh8u" sourceRef="Gateway_0hpz69o" targetRef="Screen_BusinessAreaSelect" />
+    <bpmn:sequenceFlow id="Flow_1icrh8u" sourceRef="Gateway_0hpz69o" targetRef="CallActivity_CorrespondentInput" />
+    <bpmn:callActivity id="CallActivity_CorrespondentInput" name="Correspondent Input" calledElement="COMPLAINT_CORRESPONDENT">
+      <bpmn:extensionElements>
+        <camunda:out source="DIRECTION" target="DIRECTION" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in source="CaseUUID" target="CaseUUID" />
+        <camunda:in sourceExpression="POGR_CORRESPONDENT_INVALID" target="CORRESPONDENT_INVALID_SCREEN" local="true" />
+        <camunda:in sourceExpression="POGR_CORRESPONDENT_INPUT" target="CORRESPONDENT_INPUT_SCREEN" local="true" />
+        <camunda:inputOutput>
+          <camunda:inputParameter name="CORRESPONDENT_INVALID">POGR_CORRESPONDENT_INVALID</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0z9w73r</bpmn:incoming>
+      <bpmn:incoming>Flow_1icrh8u</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ng48wh</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_1ng48wh" sourceRef="CallActivity_CorrespondentInput" targetRef="Gateway_05nveue" />
+    <bpmn:exclusiveGateway id="Gateway_05nveue" default="Flow_1xag00p">
+      <bpmn:incoming>Flow_1ng48wh</bpmn:incoming>
+      <bpmn:outgoing>Flow_1pjw6dz</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1xag00p</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1pjw6dz" sourceRef="Gateway_05nveue" targetRef="Gateway_02t74c2">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DIRECTION == "FORWARD" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1xag00p" sourceRef="Gateway_05nveue" targetRef="Screen_BusinessAreaSelect" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR_REGISTRATION">
+      <bpmndi:BPMNEdge id="Flow_1ng48wh_di" bpmnElement="Flow_1ng48wh">
+        <di:waypoint x="670" y="279" />
+        <di:waypoint x="709" y="279" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1icrh8u_di" bpmnElement="Flow_1icrh8u">
-        <di:waypoint x="810" y="255" />
-        <di:waypoint x="810" y="80" />
-        <di:waypoint x="340" y="80" />
-        <di:waypoint x="340" y="239" />
+        <di:waypoint x="1080" y="255" />
+        <di:waypoint x="1080" y="60" />
+        <di:waypoint x="620" y="60" />
+        <di:waypoint x="620" y="239" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0p2fc9m_di" bpmnElement="Flow_0p2fc9m">
-        <di:waypoint x="835" y="280" />
-        <di:waypoint x="911" y="280" />
+        <di:waypoint x="1105" y="280" />
+        <di:waypoint x="1152" y="280" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1dz65xk_di" bpmnElement="Flow_1dz65xk">
-        <di:waypoint x="590" y="304" />
-        <di:waypoint x="590" y="380" />
-        <di:waypoint x="630" y="380" />
+        <di:waypoint x="820" y="304" />
+        <di:waypoint x="820" y="380" />
+        <di:waypoint x="910" y="380" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0z9w73r_di" bpmnElement="Flow_0z9w73r">
         <di:waypoint x="530" y="279" />
-        <di:waypoint x="565" y="279" />
+        <di:waypoint x="570" y="279" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1smdms3_di" bpmnElement="Flow_1smdms3">
-        <di:waypoint x="590" y="254" />
-        <di:waypoint x="590" y="170" />
-        <di:waypoint x="630" y="170" />
+        <di:waypoint x="820" y="254" />
+        <di:waypoint x="820" y="170" />
+        <di:waypoint x="910" y="170" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0b2rneo_di" bpmnElement="Flow_0b2rneo">
-        <di:waypoint x="680" y="340" />
-        <di:waypoint x="680" y="280" />
-        <di:waypoint x="785" y="280" />
+        <di:waypoint x="960" y="340" />
+        <di:waypoint x="960" y="280" />
+        <di:waypoint x="1055" y="280" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_08yg89l_di" bpmnElement="Flow_08yg89l">
-        <di:waypoint x="680" y="210" />
-        <di:waypoint x="680" y="281" />
-        <di:waypoint x="786" y="281" />
+        <di:waypoint x="960" y="210" />
+        <di:waypoint x="960" y="281" />
+        <di:waypoint x="1056" y="281" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1m6ppjm_di" bpmnElement="Flow_1m6ppjm">
         <di:waypoint x="390" y="279" />
@@ -100,6 +129,22 @@
         <di:waypoint x="208" y="279" />
         <di:waypoint x="290" y="279" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1pjw6dz_di" bpmnElement="Flow_1pjw6dz">
+        <di:waypoint x="759" y="279" />
+        <di:waypoint x="795" y="279" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xag00p_di" bpmnElement="Flow_1xag00p">
+        <di:waypoint x="734" y="254" />
+        <di:waypoint x="734" y="150" />
+        <di:waypoint x="340" y="150" />
+        <di:waypoint x="340" y="239" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_BusinessSelect">
+        <dc:Bounds x="1152" y="262" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="797" y="92" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0qfkwvq_di" bpmnElement="Screen_BusinessAreaSelect">
         <dc:Bounds x="290" y="239" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -107,25 +152,25 @@
         <dc:Bounds x="172" y="261" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0j3nawz_di" bpmnElement="Screen_Hmpo_DataInput">
-        <dc:Bounds x="630" y="130" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_02t74c2_di" bpmnElement="Gateway_02t74c2" isMarkerVisible="true">
-        <dc:Bounds x="565" y="254" width="50" height="50" />
+        <dc:Bounds x="910" y="130" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0d914h5_di" bpmnElement="Screen_Gro_DataInput">
-        <dc:Bounds x="630" y="340" width="100" height="80" />
+        <dc:Bounds x="910" y="340" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0qjd5b9_di" bpmnElement="Service_UpdateCaseDeadline">
         <dc:Bounds x="430" y="239" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0hpz69o_di" bpmnElement="Gateway_0hpz69o" isMarkerVisible="true">
-        <dc:Bounds x="785" y="255" width="50" height="50" />
+        <dc:Bounds x="1055" y="255" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_BusinessSelect">
-        <dc:Bounds x="911" y="262" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="797" y="92" width="49" height="14" />
-        </bpmndi:BPMNLabel>
+      <bpmndi:BPMNShape id="Activity_041oil2_di" bpmnElement="CallActivity_CorrespondentInput">
+        <dc:Bounds x="570" y="239" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_02t74c2_di" bpmnElement="Gateway_02t74c2" isMarkerVisible="true">
+        <dc:Bounds x="795" y="254" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_05nveue_di" bpmnElement="Gateway_05nveue" isMarkerVisible="true">
+        <dc:Bounds x="709" y="254" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/SHARED/COMPLAINT_CORRESPONDENT.bpmn
+++ b/src/main/resources/processes/SHARED/COMPLAINT_CORRESPONDENT.bpmn
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+  <bpmn:process id="COMPLAINT_CORRESPONDENT" isExecutable="true">
+    <bpmn:endEvent id="EndEvent_ComplaintCorrespondent">
+      <bpmn:incoming>Flow_155ejuv</bpmn:incoming>
+      <bpmn:incoming>Flow_0hl9l16</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:startEvent id="StartEvent_ComplaintCorrespondent">
+      <bpmn:outgoing>Flow_1t67pyh</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:userTask id="Screen_CorrespondentsInput" name="Correspondents Input" camunda:formKey="${ CORRESPONDENT_INPUT_SCREEN  }">
+      <bpmn:incoming>Flow_1t67pyh</bpmn:incoming>
+      <bpmn:incoming>Flow_15qp1ka</bpmn:incoming>
+      <bpmn:outgoing>Flow_1kluyyd</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:serviceTask id="Service_UpdatePrimaryCorrespondent" name="Save Primary Correspondent" camunda:expression="${bpmnService.updatePrimaryCorrespondent(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;Correspondents&#34;))}">
+      <bpmn:incoming>Flow_1k1x2ck</bpmn:incoming>
+      <bpmn:outgoing>Flow_1ug06zp</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="Service_CaseHasPrimaryCorrespondentType" name="Validate Correspondents List" camunda:expression="${bpmnService.caseHasPrimaryCorrespondentType(execution.getVariable(&#34;CaseUUID&#34;),&#34;COMPLAINANT&#34;)}" camunda:resultVariable="validCorrespondents">
+      <bpmn:incoming>Flow_1ug06zp</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mxdajm</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:exclusiveGateway id="Gateway_0ihr13k">
+      <bpmn:incoming>Flow_0mxdajm</bpmn:incoming>
+      <bpmn:outgoing>Flow_09mzmrx</bpmn:outgoing>
+      <bpmn:outgoing>Flow_155ejuv</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:userTask id="Screen_CorrespondentsInvalid" name="Invalid Primary Correspondent" camunda:formKey="${ CORRESPONDENT_INVALID_SCREEN }">
+      <bpmn:incoming>Flow_09mzmrx</bpmn:incoming>
+      <bpmn:outgoing>Flow_15qp1ka</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1ug06zp" sourceRef="Service_UpdatePrimaryCorrespondent" targetRef="Service_CaseHasPrimaryCorrespondentType" />
+    <bpmn:sequenceFlow id="Flow_0mxdajm" sourceRef="Service_CaseHasPrimaryCorrespondentType" targetRef="Gateway_0ihr13k" />
+    <bpmn:sequenceFlow id="Flow_09mzmrx" sourceRef="Gateway_0ihr13k" targetRef="Screen_CorrespondentsInvalid">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${validCorrespondents == false}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_15qp1ka" sourceRef="Screen_CorrespondentsInvalid" targetRef="Screen_CorrespondentsInput" />
+    <bpmn:sequenceFlow id="Flow_155ejuv" sourceRef="Gateway_0ihr13k" targetRef="EndEvent_ComplaintCorrespondent" />
+    <bpmn:sequenceFlow id="Flow_1t67pyh" sourceRef="StartEvent_ComplaintCorrespondent" targetRef="Screen_CorrespondentsInput" />
+    <bpmn:sequenceFlow id="Flow_1kluyyd" sourceRef="Screen_CorrespondentsInput" targetRef="Gateway_0gubl6c" />
+    <bpmn:exclusiveGateway id="Gateway_0gubl6c" default="Flow_0hl9l16">
+      <bpmn:incoming>Flow_1kluyyd</bpmn:incoming>
+      <bpmn:outgoing>Flow_1k1x2ck</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0hl9l16</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1k1x2ck" sourceRef="Gateway_0gubl6c" targetRef="Service_UpdatePrimaryCorrespondent">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DIRECTION == "FORWARD" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0hl9l16" sourceRef="Gateway_0gubl6c" targetRef="EndEvent_ComplaintCorrespondent" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMPLAINT_CORRESPONDENT">
+      <bpmndi:BPMNEdge id="Flow_0hl9l16_di" bpmnElement="Flow_0hl9l16">
+        <di:waypoint x="400" y="165" />
+        <di:waypoint x="400" y="80" />
+        <di:waypoint x="880" y="80" />
+        <di:waypoint x="880" y="172" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1k1x2ck_di" bpmnElement="Flow_1k1x2ck">
+        <di:waypoint x="425" y="190" />
+        <di:waypoint x="470" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1kluyyd_di" bpmnElement="Flow_1kluyyd">
+        <di:waypoint x="330" y="190" />
+        <di:waypoint x="375" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1t67pyh_di" bpmnElement="Flow_1t67pyh">
+        <di:waypoint x="188" y="190" />
+        <di:waypoint x="230" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_155ejuv_di" bpmnElement="Flow_155ejuv">
+        <di:waypoint x="795" y="190" />
+        <di:waypoint x="862" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15qp1ka_di" bpmnElement="Flow_15qp1ka">
+        <di:waypoint x="720" y="310" />
+        <di:waypoint x="280" y="310" />
+        <di:waypoint x="280" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09mzmrx_di" bpmnElement="Flow_09mzmrx">
+        <di:waypoint x="770" y="215" />
+        <di:waypoint x="770" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mxdajm_di" bpmnElement="Flow_0mxdajm">
+        <di:waypoint x="700" y="190" />
+        <di:waypoint x="745" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ug06zp_di" bpmnElement="Flow_1ug06zp">
+        <di:waypoint x="570" y="190" />
+        <di:waypoint x="600" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_ComplaintCorrespondent">
+        <dc:Bounds x="862" y="172" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="797" y="92" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1q1dr52_di" bpmnElement="StartEvent_ComplaintCorrespondent">
+        <dc:Bounds x="152" y="172" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1j2b0em_di" bpmnElement="Screen_CorrespondentsInput">
+        <dc:Bounds x="230" y="150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_089a4hg_di" bpmnElement="Service_UpdatePrimaryCorrespondent">
+        <dc:Bounds x="470" y="150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0k5u6dn_di" bpmnElement="Service_CaseHasPrimaryCorrespondentType">
+        <dc:Bounds x="600" y="150" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ihr13k_di" bpmnElement="Gateway_0ihr13k" isMarkerVisible="true">
+        <dc:Bounds x="745" y="165" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cathwz_di" bpmnElement="Screen_CorrespondentsInvalid">
+        <dc:Bounds x="720" y="270" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0gubl6c_di" bpmnElement="Gateway_0gubl6c" isMarkerVisible="true">
+        <dc:Bounds x="375" y="165" width="50" height="50" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR.java
@@ -23,7 +23,6 @@ import static uk.gov.digital.ho.hocs.workflow.util.CallActivityMockWrapper.whenA
 @RunWith(MockitoJUnitRunner.class)
 @Deployment(resources = {
         "processes/POGR/POGR.bpmn",
-        "processes/POGR/POGR_REGISTRATION.bpmn",
         "processes/STAGE.bpmn"})
 public class POGR {
 

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_REGISTRATION.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_REGISTRATION.java
@@ -30,7 +30,7 @@ public class POGR_REGISTRATION {
 
     @Rule
     @ClassRule
-    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create().assertClassCoverageAtLeast(0.1).build();
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create().assertClassCoverageAtLeast(1).build();
 
     @Rule
     public ProcessEngineRule processEngineRule = new ProcessEngineRule();
@@ -55,17 +55,23 @@ public class POGR_REGISTRATION {
                 .thenReturn(task -> task.complete(withVariables("DIRECTION", "BACKWARD")))
                 .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD")));
 
+        whenAtCallActivity("COMPLAINT_CORRESPONDENT")
+                .thenReturn("DIRECTION", "FORWARD")
+                .thenReturn("DIRECTION", "FORWARD")
+                .deploy(rule);
+
         Scenario.run(processScenario)
                 .startByKey("POGR_REGISTRATION")
                 .execute();
 
         verify(processScenario).hasCompleted("StartEvent_BusinessSelect");
-        verify(processScenario, times(2)).hasCompleted("Screen_BusinessAreaSelect");
-        verify(processScenario, times(2)).hasCompleted("Service_UpdateCaseDeadline");
+        verify(processScenario).hasCompleted("Screen_BusinessAreaSelect");
+        verify(processScenario).hasCompleted("Service_UpdateCaseDeadline");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_CorrespondentInput");
         verify(processScenario, times(2)).hasCompleted("Screen_Hmpo_DataInput");
         verify(processScenario).hasCompleted("EndEvent_BusinessSelect");
 
-        verify(bpmnService, times(2)).updateDeadlineDays(any(), any(), eq("10"));
+        verify(bpmnService).updateDeadlineDays(any(), any(), eq("10"));
     }
 
     @Test
@@ -77,18 +83,23 @@ public class POGR_REGISTRATION {
                 .thenReturn(task -> task.complete(withVariables("DIRECTION", "BACKWARD")))
                 .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD")));
 
+        whenAtCallActivity("COMPLAINT_CORRESPONDENT")
+                .thenReturn("DIRECTION", "FORWARD")
+                .thenReturn("DIRECTION", "FORWARD")
+                .deploy(rule);
+
         Scenario.run(processScenario)
                 .startByKey("POGR_REGISTRATION")
                 .execute();
 
         verify(processScenario).hasCompleted("StartEvent_BusinessSelect");
-        verify(processScenario, times(2)).hasCompleted("Screen_BusinessAreaSelect");
-        verify(processScenario, times(2)).hasCompleted("Service_UpdateCaseDeadline");
+        verify(processScenario).hasCompleted("Screen_BusinessAreaSelect");
+        verify(processScenario).hasCompleted("Service_UpdateCaseDeadline");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_CorrespondentInput");
         verify(processScenario, times(2)).hasCompleted("Screen_Gro_DataInput");
         verify(processScenario).hasCompleted("EndEvent_BusinessSelect");
 
-        verify(bpmnService, times(2)).updateDeadlineDays(any(), any(), eq("5"));
-
+        verify(bpmnService).updateDeadlineDays(any(), any(), eq("5"));
     }
 
     @Test
@@ -97,8 +108,10 @@ public class POGR_REGISTRATION {
                 .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD", "BusinessArea", "GRO")))
                 .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD", "BusinessArea", "HMPO")));
 
-        when(processScenario.waitsAtUserTask("Screen_Gro_DataInput"))
-                .thenReturn(task -> task.complete(withVariables("DIRECTION", "BACKWARD")));
+        whenAtCallActivity("COMPLAINT_CORRESPONDENT")
+                .thenReturn("DIRECTION", "BACKWARD")
+                .thenReturn("DIRECTION", "FORWARD")
+                .deploy(rule);
 
         when(processScenario.waitsAtUserTask("Screen_Hmpo_DataInput"))
                 .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD")));
@@ -110,13 +123,12 @@ public class POGR_REGISTRATION {
         verify(processScenario).hasCompleted("StartEvent_BusinessSelect");
         verify(processScenario, times(2)).hasCompleted("Screen_BusinessAreaSelect");
         verify(processScenario, times(2)).hasCompleted("Service_UpdateCaseDeadline");
-        verify(processScenario).hasCompleted("Screen_Gro_DataInput");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_CorrespondentInput");
         verify(processScenario).hasCompleted("Screen_Hmpo_DataInput");
         verify(processScenario).hasCompleted("EndEvent_BusinessSelect");
 
         verify(bpmnService).updateDeadlineDays(any(), any(), eq("5"));
         verify(bpmnService).updateDeadlineDays(any(), any(), eq("10"));
     }
-
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/shared/COMPLAINT_CORRESPONDENT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/shared/COMPLAINT_CORRESPONDENT.java
@@ -1,0 +1,139 @@
+package uk.gov.digital.ho.hocs.workflow.processes.shared;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRule;
+import org.camunda.bpm.extension.process_test_coverage.junit.rules.TestCoverageProcessEngineRuleBuilder;
+import org.camunda.bpm.scenario.ProcessScenario;
+import org.camunda.bpm.scenario.Scenario;
+import org.camunda.bpm.scenario.delegate.TaskDelegate;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+
+import java.util.Map;
+import java.util.UUID;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.withVariables;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+@Deployment(resources = { "processes/SHARED/COMPLAINT_CORRESPONDENT.bpmn" })
+public class COMPLAINT_CORRESPONDENT {
+
+    @Rule
+    @ClassRule
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create().assertClassCoverageAtLeast(1).build();
+
+    @Rule
+    public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+
+    @Mock
+    BpmnService bpmnService;
+
+    @Mock
+    private ProcessScenario processScenario;
+
+    @Before
+    public void setup() {
+        Mocks.register("bpmnService", bpmnService);
+    }
+
+    @Test
+    public void testHappyPath() {
+        when(processScenario.waitsAtUserTask("Screen_CorrespondentsInput"))
+                .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD")));
+
+        when(bpmnService.caseHasPrimaryCorrespondentType(any(), any())).thenReturn(true);
+
+        Scenario.run(processScenario)
+                .startByKey("COMPLAINT_CORRESPONDENT",
+                        Map.of("CORRESPONDENT_INPUT_SCREEN", "COMPLAINT_INPUT_SCREEN",
+                        "CORRESPONDENT_INVALID_SCREEN", "COMPLAINT_INVALID_SCREEN",
+                        "CaseUUID", UUID.randomUUID().toString()))
+                .execute();
+
+        verify(processScenario)
+                .hasCompleted("StartEvent_ComplaintCorrespondent");
+        verify(processScenario)
+                .hasCompleted("Screen_CorrespondentsInput");
+        verify(processScenario)
+                .hasCompleted("Service_UpdatePrimaryCorrespondent");
+        verify(processScenario)
+                .hasCompleted("Service_CaseHasPrimaryCorrespondentType");
+        verify(processScenario)
+                .hasCompleted("EndEvent_ComplaintCorrespondent");
+
+        verify(bpmnService).updatePrimaryCorrespondent(any(), any(), any());
+        verify(bpmnService).caseHasPrimaryCorrespondentType(any(), any());
+
+    }
+
+    @Test
+    public void testBackwardsDirectionFromInput() {
+        when(processScenario.waitsAtUserTask("Screen_CorrespondentsInput"))
+                .thenReturn(task -> task.complete(withVariables("DIRECTION", "BACKWARD")));
+
+        Scenario.run(processScenario)
+                .startByKey("COMPLAINT_CORRESPONDENT",
+                        Map.of("CORRESPONDENT_INPUT_SCREEN", "COMPLAINT_INPUT_SCREEN",
+                                "CORRESPONDENT_INVALID_SCREEN", "COMPLAINT_INVALID_SCREEN",
+                                "CaseUUID", UUID.randomUUID().toString()))
+                .execute();
+
+        verify(processScenario)
+                .hasCompleted("StartEvent_ComplaintCorrespondent");
+        verify(processScenario)
+                .hasCompleted("Screen_CorrespondentsInput");
+        verify(processScenario)
+                .hasCompleted("EndEvent_ComplaintCorrespondent");
+
+        verify(bpmnService, times(0)).updatePrimaryCorrespondent(any(), any(), any());
+    }
+
+    @Test
+    public void testPrimaryCorrespondentNotComplaint() {
+        when(processScenario.waitsAtUserTask("Screen_CorrespondentsInput"))
+                .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD")));
+        when(processScenario.waitsAtUserTask("Screen_CorrespondentsInvalid"))
+                .thenReturn(TaskDelegate::complete);
+
+        when(bpmnService.caseHasPrimaryCorrespondentType(any(), any()))
+                .thenReturn(false)
+                .thenReturn(true);
+
+        Scenario.run(processScenario)
+                .startByKey("COMPLAINT_CORRESPONDENT",
+                        Map.of("CORRESPONDENT_INPUT_SCREEN", "COMPLAINT_INPUT_SCREEN",
+                                "CORRESPONDENT_INVALID_SCREEN", "COMPLAINT_INVALID_SCREEN",
+                                "CaseUUID", UUID.randomUUID().toString()))
+                .execute();
+
+        verify(processScenario)
+                .hasCompleted("StartEvent_ComplaintCorrespondent");
+
+        verify(processScenario, times(2))
+                .hasCompleted("Screen_CorrespondentsInput");
+        verify(processScenario, times(2))
+                .hasCompleted("Service_UpdatePrimaryCorrespondent");
+        verify(processScenario, times(2))
+                .hasCompleted("Service_CaseHasPrimaryCorrespondentType");
+        verify(processScenario)
+                .hasCompleted("Screen_CorrespondentsInvalid");
+        verify(processScenario)
+                .hasCompleted("EndEvent_ComplaintCorrespondent");
+
+        verify(bpmnService, times(2)).updatePrimaryCorrespondent(any(), any(), any());
+        verify(bpmnService, times(2)).caseHasPrimaryCorrespondentType(any(), any());
+    }
+
+}


### PR DESCRIPTION
Add the process for a shared complaint correspondent flow. This flow
shows takes a user specified screen for input and invalid alongside the
case to validate correspondents to ensure the primary correspondent is a
Complainant.

Add the shared correspondent flow to the POGR_REGISTRATION screen.