### PR TITLE
HOCS-4773: add backwards flow post data input

### DIFF
--- a/src/main/resources/processes/POGR/POGR_REGISTRATION.bpmn
+++ b/src/main/resources/processes/POGR/POGR_REGISTRATION.bpmn
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <bpmn:process id="POGR_REGISTRATION" isExecutable="true">
     <bpmn:endEvent id="EndEvent_BusinessSelect">
       <bpmn:incoming>Flow_0p2fc9m</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:userTask id="Screen_BusinessAreaSelect" name="Specify Business Area" camunda:formKey="POGR_BUSINESS_AREA">
       <bpmn:incoming>Flow_0e5zero</bpmn:incoming>
-      <bpmn:incoming>Flow_1xag00p</bpmn:incoming>
+      <bpmn:incoming>Flow_04n1vrl</bpmn:incoming>
       <bpmn:outgoing>Flow_1m6ppjm</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:startEvent id="StartEvent_BusinessSelect">
@@ -15,7 +15,7 @@
     <bpmn:sequenceFlow id="Flow_0e5zero" sourceRef="StartEvent_BusinessSelect" targetRef="Screen_BusinessAreaSelect" />
     <bpmn:userTask id="Screen_Hmpo_DataInput" name="HMPO Data Input" camunda:formKey="POGR_HMPO_DATA_INPUT">
       <bpmn:incoming>Flow_1smdms3</bpmn:incoming>
-      <bpmn:outgoing>Flow_08yg89l</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0z6nk44</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:exclusiveGateway id="Gateway_02t74c2">
       <bpmn:incoming>Flow_1pjw6dz</bpmn:incoming>
@@ -36,7 +36,6 @@
       <bpmn:incoming>Flow_1m6ppjm</bpmn:incoming>
       <bpmn:outgoing>Flow_0z9w73r</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_08yg89l" sourceRef="Screen_Hmpo_DataInput" targetRef="Gateway_0hpz69o" />
     <bpmn:sequenceFlow id="Flow_0b2rneo" sourceRef="Screen_Gro_DataInput" targetRef="Gateway_0hpz69o" />
     <bpmn:sequenceFlow id="Flow_1smdms3" sourceRef="Gateway_02t74c2" targetRef="Screen_Hmpo_DataInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ BusinessArea == "HMPO" }</bpmn:conditionExpression>
@@ -46,8 +45,8 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ BusinessArea == "GRO" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="Gateway_0hpz69o" default="Flow_1icrh8u">
-      <bpmn:incoming>Flow_08yg89l</bpmn:incoming>
       <bpmn:incoming>Flow_0b2rneo</bpmn:incoming>
+      <bpmn:incoming>Flow_0z6nk44</bpmn:incoming>
       <bpmn:outgoing>Flow_0p2fc9m</bpmn:outgoing>
       <bpmn:outgoing>Flow_1icrh8u</bpmn:outgoing>
     </bpmn:exclusiveGateway>
@@ -68,109 +67,143 @@
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0z9w73r</bpmn:incoming>
       <bpmn:incoming>Flow_1icrh8u</bpmn:incoming>
+      <bpmn:incoming>Flow_1pxy7h7</bpmn:incoming>
       <bpmn:outgoing>Flow_1ng48wh</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="Flow_1ng48wh" sourceRef="CallActivity_CorrespondentInput" targetRef="Gateway_05nveue" />
-    <bpmn:exclusiveGateway id="Gateway_05nveue" default="Flow_1xag00p">
+    <bpmn:exclusiveGateway id="Gateway_05nveue" default="Flow_19l78rb">
       <bpmn:incoming>Flow_1ng48wh</bpmn:incoming>
       <bpmn:outgoing>Flow_1pjw6dz</bpmn:outgoing>
-      <bpmn:outgoing>Flow_1xag00p</bpmn:outgoing>
+      <bpmn:outgoing>Flow_19l78rb</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_1pjw6dz" sourceRef="Gateway_05nveue" targetRef="Gateway_02t74c2">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DIRECTION == "FORWARD" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1xag00p" sourceRef="Gateway_05nveue" targetRef="Screen_BusinessAreaSelect" />
+    <bpmn:exclusiveGateway id="Gateway_1tx1cgz" default="Flow_1sa08e7">
+      <bpmn:incoming>Flow_19l78rb</bpmn:incoming>
+      <bpmn:outgoing>Flow_1sa08e7</bpmn:outgoing>
+      <bpmn:outgoing>Flow_04n1vrl</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_19l78rb" sourceRef="Gateway_05nveue" targetRef="Gateway_1tx1cgz" />
+    <bpmn:userTask id="Screen_BusinessAreaSelectPostDataInput" name="Specify Business Area Post Data Input" camunda:formKey="POGR_BUSINESS_AREA_POST_DATA_INPUT">
+      <bpmn:incoming>Flow_1sa08e7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1pxy7h7</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1pxy7h7" sourceRef="Screen_BusinessAreaSelectPostDataInput" targetRef="CallActivity_CorrespondentInput" />
+    <bpmn:sequenceFlow id="Flow_1sa08e7" sourceRef="Gateway_1tx1cgz" targetRef="Screen_BusinessAreaSelectPostDataInput" />
+    <bpmn:sequenceFlow id="Flow_04n1vrl" sourceRef="Gateway_1tx1cgz" targetRef="Screen_BusinessAreaSelect">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ !execution.hasVariable("XPogrPostDataInput") }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0z6nk44" sourceRef="Screen_Hmpo_DataInput" targetRef="Gateway_0hpz69o" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR_REGISTRATION">
+      <bpmndi:BPMNEdge id="Flow_1pjw6dz_di" bpmnElement="Flow_1pjw6dz">
+        <di:waypoint x="759" y="329" />
+        <di:waypoint x="795" y="329" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1ng48wh_di" bpmnElement="Flow_1ng48wh">
-        <di:waypoint x="670" y="279" />
-        <di:waypoint x="709" y="279" />
+        <di:waypoint x="670" y="329" />
+        <di:waypoint x="709" y="329" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1icrh8u_di" bpmnElement="Flow_1icrh8u">
-        <di:waypoint x="1080" y="255" />
-        <di:waypoint x="1080" y="60" />
-        <di:waypoint x="620" y="60" />
-        <di:waypoint x="620" y="239" />
+        <di:waypoint x="1090" y="305" />
+        <di:waypoint x="1090" y="150" />
+        <di:waypoint x="620" y="150" />
+        <di:waypoint x="620" y="289" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0p2fc9m_di" bpmnElement="Flow_0p2fc9m">
-        <di:waypoint x="1105" y="280" />
-        <di:waypoint x="1152" y="280" />
+        <di:waypoint x="1115" y="330" />
+        <di:waypoint x="1162" y="330" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1dz65xk_di" bpmnElement="Flow_1dz65xk">
-        <di:waypoint x="820" y="304" />
-        <di:waypoint x="820" y="380" />
-        <di:waypoint x="910" y="380" />
+        <di:waypoint x="820" y="354" />
+        <di:waypoint x="820" y="430" />
+        <di:waypoint x="910" y="430" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0z9w73r_di" bpmnElement="Flow_0z9w73r">
-        <di:waypoint x="530" y="279" />
-        <di:waypoint x="570" y="279" />
+        <di:waypoint x="530" y="329" />
+        <di:waypoint x="570" y="329" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1smdms3_di" bpmnElement="Flow_1smdms3">
-        <di:waypoint x="820" y="254" />
-        <di:waypoint x="820" y="170" />
-        <di:waypoint x="910" y="170" />
+        <di:waypoint x="820" y="304" />
+        <di:waypoint x="820" y="220" />
+        <di:waypoint x="910" y="220" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0b2rneo_di" bpmnElement="Flow_0b2rneo">
-        <di:waypoint x="960" y="340" />
-        <di:waypoint x="960" y="280" />
-        <di:waypoint x="1055" y="280" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_08yg89l_di" bpmnElement="Flow_08yg89l">
-        <di:waypoint x="960" y="210" />
-        <di:waypoint x="960" y="281" />
-        <di:waypoint x="1056" y="281" />
+        <di:waypoint x="960" y="390" />
+        <di:waypoint x="960" y="330" />
+        <di:waypoint x="1065" y="330" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1m6ppjm_di" bpmnElement="Flow_1m6ppjm">
-        <di:waypoint x="390" y="279" />
-        <di:waypoint x="430" y="279" />
+        <di:waypoint x="390" y="329" />
+        <di:waypoint x="430" y="329" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0e5zero_di" bpmnElement="Flow_0e5zero">
-        <di:waypoint x="208" y="279" />
-        <di:waypoint x="290" y="279" />
+        <di:waypoint x="208" y="329" />
+        <di:waypoint x="290" y="329" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1pjw6dz_di" bpmnElement="Flow_1pjw6dz">
-        <di:waypoint x="759" y="279" />
-        <di:waypoint x="795" y="279" />
+      <bpmndi:BPMNEdge id="Flow_19l78rb_di" bpmnElement="Flow_19l78rb">
+        <di:waypoint x="734" y="304" />
+        <di:waypoint x="734" y="210" />
+        <di:waypoint x="365" y="210" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xag00p_di" bpmnElement="Flow_1xag00p">
-        <di:waypoint x="734" y="254" />
-        <di:waypoint x="734" y="150" />
-        <di:waypoint x="340" y="150" />
-        <di:waypoint x="340" y="239" />
+      <bpmndi:BPMNEdge id="Flow_1pxy7h7_di" bpmnElement="Flow_1pxy7h7" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="390" y="100" />
+        <di:waypoint x="620" y="100" />
+        <di:waypoint x="620" y="289" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1sa08e7_di" bpmnElement="Flow_1sa08e7" bioc:stroke="#000000" color:border-color="#000000">
+        <di:waypoint x="340" y="185" />
+        <di:waypoint x="340" y="140" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04n1vrl_di" bpmnElement="Flow_04n1vrl">
+        <di:waypoint x="340" y="235" />
+        <di:waypoint x="340" y="289" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0z6nk44_di" bpmnElement="Flow_0z6nk44">
+        <di:waypoint x="960" y="260" />
+        <di:waypoint x="960" y="331" />
+        <di:waypoint x="1066" y="331" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0qfkwvq_di" bpmnElement="Screen_BusinessAreaSelect">
+        <dc:Bounds x="290" y="289" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1q1dr52_di" bpmnElement="StartEvent_BusinessSelect">
+        <dc:Bounds x="172" y="311" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0j3nawz_di" bpmnElement="Screen_Hmpo_DataInput">
+        <dc:Bounds x="910" y="180" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_02t74c2_di" bpmnElement="Gateway_02t74c2" isMarkerVisible="true">
+        <dc:Bounds x="795" y="304" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0d914h5_di" bpmnElement="Screen_Gro_DataInput">
+        <dc:Bounds x="910" y="390" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0qjd5b9_di" bpmnElement="Service_UpdateCaseDeadline">
+        <dc:Bounds x="430" y="289" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_041oil2_di" bpmnElement="CallActivity_CorrespondentInput">
+        <dc:Bounds x="570" y="289" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_05nveue_di" bpmnElement="Gateway_05nveue" isMarkerVisible="true">
+        <dc:Bounds x="709" y="304" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1tx1cgz_di" bpmnElement="Gateway_1tx1cgz" isMarkerVisible="true">
+        <dc:Bounds x="315" y="185" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ekoyqn_di" bpmnElement="Screen_BusinessAreaSelectPostDataInput">
+        <dc:Bounds x="290" y="60" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0hpz69o_di" bpmnElement="Gateway_0hpz69o" isMarkerVisible="true">
+        <dc:Bounds x="1065" y="305" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_BusinessSelect">
-        <dc:Bounds x="1152" y="262" width="36" height="36" />
+        <dc:Bounds x="1162" y="312" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="797" y="92" width="49" height="14" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0qfkwvq_di" bpmnElement="Screen_BusinessAreaSelect">
-        <dc:Bounds x="290" y="239" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1q1dr52_di" bpmnElement="StartEvent_BusinessSelect">
-        <dc:Bounds x="172" y="261" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0j3nawz_di" bpmnElement="Screen_Hmpo_DataInput">
-        <dc:Bounds x="910" y="130" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0d914h5_di" bpmnElement="Screen_Gro_DataInput">
-        <dc:Bounds x="910" y="340" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0qjd5b9_di" bpmnElement="Service_UpdateCaseDeadline">
-        <dc:Bounds x="430" y="239" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0hpz69o_di" bpmnElement="Gateway_0hpz69o" isMarkerVisible="true">
-        <dc:Bounds x="1055" y="255" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_041oil2_di" bpmnElement="CallActivity_CorrespondentInput">
-        <dc:Bounds x="570" y="239" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_02t74c2_di" bpmnElement="Gateway_02t74c2" isMarkerVisible="true">
-        <dc:Bounds x="795" y="254" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_05nveue_di" bpmnElement="Gateway_05nveue" isMarkerVisible="true">
-        <dc:Bounds x="709" y="254" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/SHARED/COMPLAINT_CORRESPONDENT.bpmn
+++ b/src/main/resources/processes/SHARED/COMPLAINT_CORRESPONDENT.bpmn
@@ -21,7 +21,7 @@
       <bpmn:incoming>Flow_1ug06zp</bpmn:incoming>
       <bpmn:outgoing>Flow_0mxdajm</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:exclusiveGateway id="Gateway_0ihr13k">
+    <bpmn:exclusiveGateway id="Gateway_0ihr13k" default="Flow_09mzmrx">
       <bpmn:incoming>Flow_0mxdajm</bpmn:incoming>
       <bpmn:outgoing>Flow_09mzmrx</bpmn:outgoing>
       <bpmn:outgoing>Flow_155ejuv</bpmn:outgoing>
@@ -32,11 +32,11 @@
     </bpmn:userTask>
     <bpmn:sequenceFlow id="Flow_1ug06zp" sourceRef="Service_UpdatePrimaryCorrespondent" targetRef="Service_CaseHasPrimaryCorrespondentType" />
     <bpmn:sequenceFlow id="Flow_0mxdajm" sourceRef="Service_CaseHasPrimaryCorrespondentType" targetRef="Gateway_0ihr13k" />
-    <bpmn:sequenceFlow id="Flow_09mzmrx" sourceRef="Gateway_0ihr13k" targetRef="Screen_CorrespondentsInvalid">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${validCorrespondents == false}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_09mzmrx" sourceRef="Gateway_0ihr13k" targetRef="Screen_CorrespondentsInvalid" />
     <bpmn:sequenceFlow id="Flow_15qp1ka" sourceRef="Screen_CorrespondentsInvalid" targetRef="Screen_CorrespondentsInput" />
-    <bpmn:sequenceFlow id="Flow_155ejuv" sourceRef="Gateway_0ihr13k" targetRef="EndEvent_ComplaintCorrespondent" />
+    <bpmn:sequenceFlow id="Flow_155ejuv" sourceRef="Gateway_0ihr13k" targetRef="EndEvent_ComplaintCorrespondent">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${validCorrespondents == true}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1t67pyh" sourceRef="StartEvent_ComplaintCorrespondent" targetRef="Screen_CorrespondentsInput" />
     <bpmn:sequenceFlow id="Flow_1kluyyd" sourceRef="Screen_CorrespondentsInput" targetRef="Gateway_0gubl6c" />
     <bpmn:exclusiveGateway id="Gateway_0gubl6c" default="Flow_0hl9l16">

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_REGISTRATION.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_REGISTRATION.java
@@ -131,4 +131,37 @@ public class POGR_REGISTRATION {
         verify(bpmnService).updateDeadlineDays(any(), any(), eq("10"));
     }
 
+    @Test
+    public void testBackwardAfterDataInputSubmission() {
+        when(processScenario.waitsAtUserTask("Screen_BusinessAreaSelect"))
+                .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD", "BusinessArea", "HMPO")));
+
+        whenAtCallActivity("COMPLAINT_CORRESPONDENT")
+                .thenReturn("DIRECTION", "FORWARD","BusinessArea", "HMPO")
+                .thenReturn("DIRECTION", "BACKWARD","BusinessArea", "HMPO", "XPogrPostDataInput", "TRUE")
+                .thenReturn("DIRECTION", "FORWARD","BusinessArea", "HMPO", "XPogrPostDataInput", "TRUE")
+                .deploy(rule);
+
+        when(processScenario.waitsAtUserTask("Screen_Hmpo_DataInput"))
+                .thenReturn(task -> task.complete(withVariables("DIRECTION", "BACKWARD", "BusinessArea", "HMPO", "XPogrPostDataInput", "TRUE")))
+                .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD", "BusinessArea", "HMPO", "XPogrPostDataInput", "TRUE")));
+
+        when(processScenario.waitsAtUserTask("Screen_BusinessAreaSelectPostDataInput"))
+                .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD", "BusinessArea", "HMPO", "XPogrPostDataInput", "TRUE")));
+
+        Scenario.run(processScenario)
+                .startByKey("POGR_REGISTRATION")
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_BusinessSelect");
+        verify(processScenario).hasCompleted("Screen_BusinessAreaSelect");
+        verify(processScenario).hasCompleted("Service_UpdateCaseDeadline");
+        verify(processScenario, times(3)).hasCompleted("CallActivity_CorrespondentInput");
+        verify(processScenario, times(2)).hasCompleted("Screen_Hmpo_DataInput");
+        verify(processScenario).hasCompleted("Screen_BusinessAreaSelectPostDataInput");
+        verify(processScenario).hasCompleted("EndEvent_BusinessSelect");
+
+        verify(bpmnService, times(1)).updateDeadlineDays(any(), any(), eq("10"));
+    }
+
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/shared/COMPLAINT_CORRESPONDENT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/shared/COMPLAINT_CORRESPONDENT.java
@@ -101,7 +101,7 @@ public class COMPLAINT_CORRESPONDENT {
     }
 
     @Test
-    public void testPrimaryCorrespondentNotComplaint() {
+    public void testPrimaryCorrespondentNotComplainant() {
         when(processScenario.waitsAtUserTask("Screen_CorrespondentsInput"))
                 .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD")));
         when(processScenario.waitsAtUserTask("Screen_CorrespondentsInvalid"))


### PR DESCRIPTION
After the Data Input stage has completed if you go backwards then a
different screen should be shown. This is to enable a restriction
whereby the Business Area cannot be changed.

After checking if the primary correspondent is of type `COMPLAINANT` a
default backward flow is added whereby if `validCorrespondents` is not
true.