### PR TITLE
HOCS-4632: support GRO triaging allocation

### DIFF
--- a/src/main/resources/processes/POGR/POGR.bpmn
+++ b/src/main/resources/processes/POGR/POGR.bpmn
@@ -9,7 +9,8 @@
       <bpmn:incoming>SequenceFlow_1tml3pn</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:serviceTask id="ServiceTask_CompleteCase" name="Complete Case" camunda:expression="${bpmnService.completeCase(execution.processBusinessKey)}">
-      <bpmn:incoming>Flow_1mlb41f</bpmn:incoming>
+      <bpmn:incoming>Flow_0k2fqv3</bpmn:incoming>
+      <bpmn:incoming>Flow_04g2xm7</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1tml3pn</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_1tml3pn" sourceRef="ServiceTask_CompleteCase" targetRef="EndEvent_POGR" />
@@ -31,39 +32,102 @@
       <bpmn:incoming>SequenceFlow_0tsx10b</bpmn:incoming>
       <bpmn:outgoing>Flow_1mlb41f</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:sequenceFlow id="Flow_1mlb41f" sourceRef="CallActivity_RegistrationStage" targetRef="ServiceTask_CompleteCase" />
+    <bpmn:callActivity id="CallActivity_PogrHmpo" name="HMPO" calledElement="POGR_HMPO">
+      <bpmn:extensionElements>
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_07628hf</bpmn:incoming>
+      <bpmn:outgoing>Flow_0k2fqv3</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_1mlb41f" sourceRef="CallActivity_RegistrationStage" targetRef="Gateway_0zegw89" />
+    <bpmn:sequenceFlow id="Flow_0k2fqv3" sourceRef="CallActivity_PogrHmpo" targetRef="ServiceTask_CompleteCase" />
+    <bpmn:exclusiveGateway id="Gateway_0zegw89">
+      <bpmn:incoming>Flow_1mlb41f</bpmn:incoming>
+      <bpmn:outgoing>Flow_07628hf</bpmn:outgoing>
+      <bpmn:outgoing>Flow_15fzkke</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_07628hf" sourceRef="Gateway_0zegw89" targetRef="CallActivity_PogrHmpo">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ BusinessArea == "HMPO" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:callActivity id="CallActivity_PogrGro" name="GRO" calledElement="POGR_GRO">
+      <bpmn:extensionElements>
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_15fzkke</bpmn:incoming>
+      <bpmn:outgoing>Flow_04g2xm7</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_15fzkke" sourceRef="Gateway_0zegw89" targetRef="CallActivity_PogrGro">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ BusinessArea == "GRO" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_04g2xm7" sourceRef="CallActivity_PogrGro" targetRef="ServiceTask_CompleteCase" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR">
+      <bpmndi:BPMNEdge id="Flow_1mlb41f_di" bpmnElement="Flow_1mlb41f">
+        <di:waypoint x="330" y="199" />
+        <di:waypoint x="385" y="199" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1tml3pn_di" bpmnElement="SequenceFlow_1tml3pn">
-        <di:waypoint x="850" y="119" />
-        <di:waypoint x="932" y="119" />
+        <di:waypoint x="740" y="199" />
+        <di:waypoint x="782" y="199" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0tsx10b_di" bpmnElement="SequenceFlow_0tsx10b">
-        <di:waypoint x="215" y="119" />
-        <di:waypoint x="400" y="119" />
+        <di:waypoint x="168" y="199" />
+        <di:waypoint x="230" y="199" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1mlb41f_di" bpmnElement="Flow_1mlb41f">
-        <di:waypoint x="500" y="119" />
-        <di:waypoint x="750" y="119" />
+      <bpmndi:BPMNEdge id="Flow_0k2fqv3_di" bpmnElement="Flow_0k2fqv3">
+        <di:waypoint x="550" y="120" />
+        <di:waypoint x="589" y="120" />
+        <di:waypoint x="589" y="199" />
+        <di:waypoint x="640" y="199" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_POGR">
-        <dc:Bounds x="179" y="101" width="36" height="36" />
+      <bpmndi:BPMNEdge id="Flow_07628hf_di" bpmnElement="Flow_07628hf">
+        <di:waypoint x="410" y="174" />
+        <di:waypoint x="410" y="120" />
+        <di:waypoint x="450" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15fzkke_di" bpmnElement="Flow_15fzkke">
+        <di:waypoint x="410" y="224" />
+        <di:waypoint x="410" y="290" />
+        <di:waypoint x="450" y="290" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04g2xm7_di" bpmnElement="Flow_04g2xm7">
+        <di:waypoint x="550" y="290" />
+        <di:waypoint x="589" y="290" />
+        <di:waypoint x="589" y="199" />
+        <di:waypoint x="640" y="199" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_POGR">
+        <dc:Bounds x="782" y="181" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="172" y="144" width="50" height="14" />
+          <dc:Bounds x="827" y="192" width="49" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1umfuu0_di" bpmnElement="ServiceTask_CompleteCase">
-        <dc:Bounds x="750" y="79" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_POGR">
-        <dc:Bounds x="932" y="101" width="36" height="36" />
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_POGR">
+        <dc:Bounds x="132" y="181" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="977" y="112" width="49" height="14" />
+          <dc:Bounds x="125" y="224" width="50" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0uj8tv0_di" bpmnElement="CallActivity_RegistrationStage">
-        <dc:Bounds x="400" y="79" width="100" height="80" />
+        <dc:Bounds x="230" y="159" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0zegw89_di" bpmnElement="Gateway_0zegw89" isMarkerVisible="true">
+        <dc:Bounds x="385" y="174" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="395" y="95" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1umfuu0_di" bpmnElement="ServiceTask_CompleteCase">
+        <dc:Bounds x="640" y="159" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1g5x2cm_di" bpmnElement="CallActivity_PogrHmpo">
+        <dc:Bounds x="450" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ctmie4_di" bpmnElement="CallActivity_PogrGro">
+        <dc:Bounds x="450" y="250" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/POGR/POGR_GRO.bpmn
+++ b/src/main/resources/processes/POGR/POGR_GRO.bpmn
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+  <bpmn:process id="POGR_GRO" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_POGR">
+      <bpmn:outgoing>Flow_1twhwzx</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_POGR">
+      <bpmn:incoming>Flow_0c34qe7</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1twhwzx" sourceRef="StartEvent_POGR" targetRef="Activity_0aric96" />
+    <bpmn:callActivity id="Activity_0aric96" name="Triage" calledElement="STAGE">
+      <bpmn:extensionElements>
+        <camunda:in source="TriageUUID" target="StageUUID" />
+        <camunda:in sourceExpression="POGR_GRO_TRIAGE" target="StageWorkFlow" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+        <camunda:out source="StageUUID" target="TriageUUID" />
+        <camunda:in sourceExpression="POGR_GRO_TRIAGE" target="StageType" />
+        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
+        <camunda:out source="BusinessArea" target="BusinessArea" />
+        <camunda:out source="Stage" target="Stage" />
+        <camunda:in source="QueueTeamUUID" target="AllocationTeamUUID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1twhwzx</bpmn:incoming>
+      <bpmn:outgoing>Flow_0c34qe7</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0c34qe7" sourceRef="Activity_0aric96" targetRef="EndEvent_POGR" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR_GRO">
+      <bpmndi:BPMNEdge id="Flow_0c34qe7_di" bpmnElement="Flow_0c34qe7">
+        <di:waypoint x="380" y="119" />
+        <di:waypoint x="432" y="119" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1twhwzx_di" bpmnElement="Flow_1twhwzx">
+        <di:waypoint x="215" y="119" />
+        <di:waypoint x="280" y="119" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_POGR">
+        <dc:Bounds x="179" y="101" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="172" y="254" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_POGR">
+        <dc:Bounds x="432" y="101" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="477" y="222" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0aric96_di" bpmnElement="Activity_0aric96">
+        <dc:Bounds x="280" y="79" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR/POGR_GRO_TRIAGE.bpmn
+++ b/src/main/resources/processes/POGR/POGR_GRO_TRIAGE.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+  <bpmn:process id="POGR_GRO_TRIAGE" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_POGR">
+      <bpmn:outgoing>Flow_1ap3yp0</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_POGR">
+      <bpmn:incoming>Flow_1picyoq</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1ap3yp0" sourceRef="StartEvent_POGR" targetRef="Activity_0y5o65f" />
+    <bpmn:userTask id="Activity_0y5o65f" name="Specify Business Area Post Data Input" camunda:formKey="POGR_BUSINESS_AREA_POST_DATA_INPUT">
+      <bpmn:incoming>Flow_1ap3yp0</bpmn:incoming>
+      <bpmn:outgoing>Flow_1picyoq</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1picyoq" sourceRef="Activity_0y5o65f" targetRef="EndEvent_POGR" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR_GRO_TRIAGE">
+      <bpmndi:BPMNEdge id="Flow_1picyoq_di" bpmnElement="Flow_1picyoq">
+        <di:waypoint x="420" y="119" />
+        <di:waypoint x="532" y="119" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ap3yp0_di" bpmnElement="Flow_1ap3yp0">
+        <di:waypoint x="215" y="119" />
+        <di:waypoint x="320" y="119" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_POGR">
+        <dc:Bounds x="179" y="101" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="172" y="144" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_POGR">
+        <dc:Bounds x="532" y="101" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="467" y="112" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0y5o65f_di" bpmnElement="Activity_0y5o65f">
+        <dc:Bounds x="320" y="79" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR/POGR_HMPO.bpmn
+++ b/src/main/resources/processes/POGR/POGR_HMPO.bpmn
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+  <bpmn:process id="POGR_HMPO" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_POGR">
+      <bpmn:outgoing>Flow_1m1w4pf</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_POGR">
+      <bpmn:incoming>Flow_0mp9wnv</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1m1w4pf" sourceRef="StartEvent_POGR" targetRef="Activity_1kj7g9i" />
+    <bpmn:callActivity id="Activity_1kj7g9i" name="Triage" calledElement="STAGE">
+      <bpmn:extensionElements>
+        <camunda:in source="TriageUUID" target="StageUUID" />
+        <camunda:in sourceExpression="POGR_HMPO_TRIAGE" target="StageWorkFlow" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+        <camunda:out source="StageUUID" target="TriageUUID" />
+        <camunda:in sourceExpression="POGR_HMPO_TRIAGE" target="StageType" />
+        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
+        <camunda:out source="BusinessArea" target="BusinessArea" />
+        <camunda:out source="Stage" target="Stage" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1m1w4pf</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mp9wnv</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0mp9wnv" sourceRef="Activity_1kj7g9i" targetRef="EndEvent_POGR" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR_HMPO">
+      <bpmndi:BPMNEdge id="Flow_1m1w4pf_di" bpmnElement="Flow_1m1w4pf">
+        <di:waypoint x="215" y="119" />
+        <di:waypoint x="320" y="119" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mp9wnv_di" bpmnElement="Flow_0mp9wnv">
+        <di:waypoint x="420" y="119" />
+        <di:waypoint x="532" y="119" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_POGR">
+        <dc:Bounds x="179" y="101" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="172" y="144" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_POGR">
+        <dc:Bounds x="532" y="101" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="467" y="112" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kj7g9i_di" bpmnElement="Activity_1kj7g9i">
+        <dc:Bounds x="320" y="79" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR/POGR_HMPO_TRIAGE.bpmn
+++ b/src/main/resources/processes/POGR/POGR_HMPO_TRIAGE.bpmn
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+  <bpmn:process id="POGR_HMPO_TRIAGE" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_POGR">
+      <bpmn:outgoing>Flow_1ap3yp0</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_POGR">
+      <bpmn:incoming>Flow_1picyoq</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:userTask id="Activity_0y5o65f" name="Specify Business Area Post Data Input" camunda:formKey="POGR_BUSINESS_AREA_POST_DATA_INPUT">
+      <bpmn:incoming>Flow_1ap3yp0</bpmn:incoming>
+      <bpmn:outgoing>Flow_1picyoq</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1ap3yp0" sourceRef="StartEvent_POGR" targetRef="Activity_0y5o65f" />
+    <bpmn:sequenceFlow id="Flow_1picyoq" sourceRef="Activity_0y5o65f" targetRef="EndEvent_POGR" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR_HMPO_TRIAGE">
+      <bpmndi:BPMNEdge id="Flow_1ap3yp0_di" bpmnElement="Flow_1ap3yp0">
+        <di:waypoint x="215" y="119" />
+        <di:waypoint x="320" y="119" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1picyoq_di" bpmnElement="Flow_1picyoq">
+        <di:waypoint x="420" y="119" />
+        <di:waypoint x="532" y="119" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_POGR">
+        <dc:Bounds x="179" y="101" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="172" y="144" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_POGR">
+        <dc:Bounds x="532" y="101" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="467" y="112" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0y5o65f_di" bpmnElement="Activity_0y5o65f">
+        <dc:Bounds x="320" y="79" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR/POGR_REGISTRATION.bpmn
+++ b/src/main/resources/processes/POGR/POGR_REGISTRATION.bpmn
@@ -2,7 +2,8 @@
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <bpmn:process id="POGR_REGISTRATION" isExecutable="true">
     <bpmn:endEvent id="EndEvent_BusinessSelect">
-      <bpmn:incoming>Flow_069b3sc</bpmn:incoming>
+      <bpmn:incoming>Flow_0m8fo58</bpmn:incoming>
+      <bpmn:incoming>Flow_1fzpw0q</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:userTask id="Screen_BusinessAreaSelect" name="Specify Business Area" camunda:formKey="POGR_BUSINESS_AREA">
       <bpmn:incoming>Flow_0e5zero</bpmn:incoming>
@@ -99,6 +100,7 @@
     <bpmn:sequenceFlow id="Flow_0z6nk44" sourceRef="Screen_Hmpo_DataInput" targetRef="Gateway_0hpz69o" />
     <bpmn:userTask id="Screen_SendInterimLetter" name="Send Interim Letter" camunda:formKey="POGR_SEND_INTERIM_LETTER">
       <bpmn:incoming>Flow_0p2fc9m</bpmn:incoming>
+      <bpmn:incoming>Flow_0q1lw66</bpmn:incoming>
       <bpmn:outgoing>Flow_1ix4lia</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:sequenceFlow id="Flow_1ix4lia" sourceRef="Screen_SendInterimLetter" targetRef="Gateway_17gsdwh" />
@@ -107,7 +109,7 @@
       <bpmn:outgoing>Flow_069b3sc</bpmn:outgoing>
       <bpmn:outgoing>Flow_1xp81wc</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_069b3sc" sourceRef="Gateway_17gsdwh" targetRef="EndEvent_BusinessSelect">
+    <bpmn:sequenceFlow id="Flow_069b3sc" sourceRef="Gateway_17gsdwh" targetRef="Gateway_0bct3y6">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DIRECTION == "FORWARD" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:exclusiveGateway id="Gateway_1yq3rs5">
@@ -122,9 +124,83 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ BusinessArea == "GRO" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1xp81wc" sourceRef="Gateway_17gsdwh" targetRef="Gateway_1yq3rs5" />
+    <bpmn:exclusiveGateway id="Gateway_0bct3y6" default="Flow_0m8fo58">
+      <bpmn:incoming>Flow_069b3sc</bpmn:incoming>
+      <bpmn:outgoing>Flow_0m8fo58</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1i93l05</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0m8fo58" sourceRef="Gateway_0bct3y6" targetRef="EndEvent_BusinessSelect" />
+    <bpmn:userTask id="Screen_GroAllocateTeam" name="Allocate to GRO Team" camunda:formKey="POGR_GRO_ALLOCATE_TEAM">
+      <bpmn:incoming>Flow_1i93l05</bpmn:incoming>
+      <bpmn:outgoing>Flow_0l90vyi</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0l90vyi" sourceRef="Screen_GroAllocateTeam" targetRef="Gateway_1pmc3bt" />
+    <bpmn:sequenceFlow id="Flow_1i93l05" sourceRef="Gateway_0bct3y6" targetRef="Screen_GroAllocateTeam">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ BusinessArea == "GRO" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="Gateway_1pmc3bt" default="Flow_0q1lw66">
+      <bpmn:incoming>Flow_0l90vyi</bpmn:incoming>
+      <bpmn:outgoing>Flow_0q1lw66</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1cib5mq</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0q1lw66" sourceRef="Gateway_1pmc3bt" targetRef="Screen_SendInterimLetter" />
+    <bpmn:serviceTask id="Service_SetGroTriageTeam" name="Update Triage Team" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;POGR_GRO_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;GroInvestigatingTeamSelection&#34;)}">
+      <bpmn:extensionElements>
+        <camunda:inputOutput>
+          <camunda:inputParameter name="DeadlineDays">${ BusinessArea == 'GRO' ? 5 : 10 }</camunda:inputParameter>
+        </camunda:inputOutput>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1cib5mq</bpmn:incoming>
+      <bpmn:outgoing>Flow_1fzpw0q</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1cib5mq" sourceRef="Gateway_1pmc3bt" targetRef="Service_SetGroTriageTeam">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DIRECTION == "FORWARD" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1fzpw0q" sourceRef="Service_SetGroTriageTeam" targetRef="EndEvent_BusinessSelect" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR_REGISTRATION">
+      <bpmndi:BPMNEdge id="Flow_0q1lw66_di" bpmnElement="Flow_0q1lw66">
+        <di:waypoint x="1590" y="455" />
+        <di:waypoint x="1590" y="510" />
+        <di:waypoint x="1220" y="510" />
+        <di:waypoint x="1220" y="371" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1i93l05_di" bpmnElement="Flow_1i93l05">
+        <di:waypoint x="1470" y="357" />
+        <di:waypoint x="1470" y="390" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0l90vyi_di" bpmnElement="Flow_0l90vyi">
+        <di:waypoint x="1520" y="430" />
+        <di:waypoint x="1565" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0m8fo58_di" bpmnElement="Flow_0m8fo58">
+        <di:waypoint x="1495" y="332" />
+        <di:waypoint x="1772" y="332" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xp81wc_di" bpmnElement="Flow_1xp81wc">
+        <di:waypoint x="1360" y="306" />
+        <di:waypoint x="1360" y="220" />
+        <di:waypoint x="1245" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hqar82_di" bpmnElement="Flow_1hqar82" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="1195" y="220" />
+        <di:waypoint x="1120" y="220" />
+        <di:waypoint x="1120" y="430" />
+        <di:waypoint x="1010" y="430" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19zg0z2_di" bpmnElement="Flow_19zg0z2">
+        <di:waypoint x="1195" y="220" />
+        <di:waypoint x="1010" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_069b3sc_di" bpmnElement="Flow_069b3sc">
+        <di:waypoint x="1385" y="331" />
+        <di:waypoint x="1446" y="331" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ix4lia_di" bpmnElement="Flow_1ix4lia">
+        <di:waypoint x="1270" y="331" />
+        <di:waypoint x="1335" y="331" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0z6nk44_di" bpmnElement="Flow_0z6nk44">
         <di:waypoint x="960" y="260" />
         <di:waypoint x="960" y="332" />
@@ -193,28 +269,14 @@
         <di:waypoint x="208" y="329" />
         <di:waypoint x="290" y="329" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ix4lia_di" bpmnElement="Flow_1ix4lia">
-        <di:waypoint x="1270" y="331" />
-        <di:waypoint x="1335" y="331" />
+      <bpmndi:BPMNEdge id="Flow_1cib5mq_di" bpmnElement="Flow_1cib5mq">
+        <di:waypoint x="1615" y="430" />
+        <di:waypoint x="1660" y="430" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_069b3sc_di" bpmnElement="Flow_069b3sc">
-        <di:waypoint x="1385" y="331" />
-        <di:waypoint x="1462" y="331" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19zg0z2_di" bpmnElement="Flow_19zg0z2">
-        <di:waypoint x="1195" y="220" />
-        <di:waypoint x="1010" y="220" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1hqar82_di" bpmnElement="Flow_1hqar82" bioc:stroke="#e53935" color:border-color="#e53935">
-        <di:waypoint x="1195" y="220" />
-        <di:waypoint x="1120" y="220" />
-        <di:waypoint x="1120" y="430" />
-        <di:waypoint x="1010" y="430" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1xp81wc_di" bpmnElement="Flow_1xp81wc">
-        <di:waypoint x="1360" y="306" />
-        <di:waypoint x="1360" y="220" />
-        <di:waypoint x="1245" y="220" />
+      <bpmndi:BPMNEdge id="Flow_1fzpw0q_di" bpmnElement="Flow_1fzpw0q">
+        <di:waypoint x="1760" y="430" />
+        <di:waypoint x="1790" y="430" />
+        <di:waypoint x="1790" y="350" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0qfkwvq_di" bpmnElement="Screen_BusinessAreaSelect">
         <dc:Bounds x="290" y="289" width="100" height="80" />
@@ -234,6 +296,9 @@
       <bpmndi:BPMNShape id="Activity_0qjd5b9_di" bpmnElement="Service_UpdateCaseDeadline">
         <dc:Bounds x="430" y="289" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0hpz69o_di" bpmnElement="Gateway_0hpz69o" isMarkerVisible="true">
+        <dc:Bounds x="1035" y="306" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_041oil2_di" bpmnElement="CallActivity_CorrespondentInput">
         <dc:Bounds x="570" y="289" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -246,23 +311,32 @@
       <bpmndi:BPMNShape id="Activity_0ekoyqn_di" bpmnElement="Screen_BusinessAreaSelectPostDataInput">
         <dc:Bounds x="290" y="60" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0hpz69o_di" bpmnElement="Gateway_0hpz69o" isMarkerVisible="true">
-        <dc:Bounds x="1035" y="306" width="50" height="50" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_06j90mr_di" bpmnElement="Screen_SendInterimLetter">
         <dc:Bounds x="1170" y="291" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_BusinessSelect">
-        <dc:Bounds x="1462" y="313" width="36" height="36" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="797" y="92" width="49" height="14" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_17gsdwh_di" bpmnElement="Gateway_17gsdwh" isMarkerVisible="true">
         <dc:Bounds x="1335" y="306" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1yq3rs5_di" bpmnElement="Gateway_1yq3rs5" isMarkerVisible="true">
         <dc:Bounds x="1195" y="195" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0bct3y6_di" bpmnElement="Gateway_0bct3y6" isMarkerVisible="true">
+        <dc:Bounds x="1445" y="307" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kvkb25_di" bpmnElement="Screen_GroAllocateTeam">
+        <dc:Bounds x="1420" y="390" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1pmc3bt_di" bpmnElement="Gateway_1pmc3bt" isMarkerVisible="true">
+        <dc:Bounds x="1565" y="405" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_BusinessSelect">
+        <dc:Bounds x="1772" y="314" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="797" y="92" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0n0dcir_di" bpmnElement="Service_SetGroTriageTeam">
+        <dc:Bounds x="1660" y="390" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR.java
@@ -50,12 +50,17 @@ public class POGR {
                 .thenReturn("BusinessArea", "HMPO")
                 .deploy(rule);
 
+        whenAtCallActivity("POGR_HMPO")
+                .thenReturn("", "")
+                .deploy(rule);
+
         Scenario.run(processScenario)
                 .startByKey("POGR")
                 .execute();
 
         verify(processScenario).hasCompleted("StartEvent_POGR");
         verify(processScenario).hasCompleted("CallActivity_RegistrationStage");
+        verify(processScenario).hasCompleted("CallActivity_PogrHmpo");
         verify(processScenario).hasCompleted("ServiceTask_CompleteCase");
         verify(processScenario).hasCompleted("EndEvent_POGR");
     }
@@ -66,12 +71,17 @@ public class POGR {
                 .thenReturn("BusinessArea", "GRO")
                 .deploy(rule);
 
+        whenAtCallActivity("POGR_GRO")
+                .thenReturn("", "")
+                .deploy(rule);
+
         Scenario.run(processScenario)
                 .startByKey("POGR")
                 .execute();
 
         verify(processScenario).hasCompleted("StartEvent_POGR");
         verify(processScenario).hasCompleted("CallActivity_RegistrationStage");
+        verify(processScenario).hasCompleted("CallActivity_PogrGro");
         verify(processScenario).hasCompleted("ServiceTask_CompleteCase");
         verify(processScenario).hasCompleted("EndEvent_POGR");
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_REGISTRATION.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_REGISTRATION.java
@@ -80,7 +80,7 @@ public class POGR_REGISTRATION {
     }
 
     @Test
-    public void testGroHappyPath() {
+    public void testHappyGroPath() {
         when(processScenario.waitsAtUserTask("Screen_BusinessAreaSelect"))
                 .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD", "BusinessArea", "GRO")));
 
@@ -91,6 +91,11 @@ public class POGR_REGISTRATION {
         when(processScenario.waitsAtUserTask("Screen_SendInterimLetter"))
                 .thenReturn(task -> task.complete(withVariables("DIRECTION", "BACKWARD", "BusinessArea", "GRO", "XPogrPostDataInput", "TRUE")))
                 .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD", "BusinessArea", "GRO", "XPogrPostDataInput", "TRUE")));
+
+        when(processScenario.waitsAtUserTask("Screen_GroAllocateTeam"))
+                .thenReturn(task -> task.complete(withVariables("DIRECTION", "BACKWARD", "BusinessArea", "GRO", "XPogrPostDataInput", "TRUE")))
+                .thenReturn(task -> task.complete(withVariables("DIRECTION", "FORWARD", "BusinessArea", "GRO", "XPogrPostDataInput", "TRUE")));
+
 
         whenAtCallActivity("COMPLAINT_CORRESPONDENT")
                 .thenReturn("DIRECTION", "FORWARD", "BusinessArea", "GRO")
@@ -106,8 +111,9 @@ public class POGR_REGISTRATION {
         verify(processScenario).hasCompleted("Service_UpdateCaseDeadline");
         verify(processScenario, times(2)).hasCompleted("CallActivity_CorrespondentInput");
         verify(processScenario, times(3)).hasCompleted("Screen_Gro_DataInput");
-        verify(processScenario, times(2)).hasCompleted("Screen_SendInterimLetter");
-
+        verify(processScenario, times(3)).hasCompleted("Screen_SendInterimLetter");
+        verify(processScenario, times(2)).hasCompleted("Screen_GroAllocateTeam");
+        verify(processScenario).hasCompleted("Service_SetGroTriageTeam");
         verify(processScenario).hasCompleted("EndEvent_BusinessSelect");
 
         verify(bpmnService).updateDeadlineDays(any(), any(), eq("5"));


### PR DESCRIPTION
Changes to the POGR and the POGR_REGISTRATION flows to support the
movement of a case through to the triaging stages. For GRO cases a new
screen is shown that allows for the selection of a triaging team.