### PR TITLE
HOCS-4799: update build image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,7 +18,7 @@ services:
 
 steps:
   - name: test project
-    image: quay.io/ukhomeofficedigital/hocs-base-image-build:1.0.0
+    image: quay.io/ukhomeofficedigital/hocs-base-image-build:1.0.2
     environment:
       SPRING_PROFILES_ACTIVE: "development, local"
       DOCS_QUEUE_NAME: document-queue
@@ -154,7 +154,7 @@ services:
 
 steps:
   - name: test project
-    image: quay.io/ukhomeofficedigital/openjdk11:v11.0.5_10
+    image: quay.io/ukhomeofficedigital/hocs-base-image-build:1.0.2
     environment:
       SPRING_PROFILES_ACTIVE: "development, local"
       DOCS_QUEUE_NAME: document-queue


### PR DESCRIPTION
This commit pegs the build images version within the drone pipeline to
use the latest iteration.