### PR TITLE
HOCS-4635: change the telephone flow to use radio

### DIFF
--- a/src/main/resources/processes/POGR/POGR_GRO_DRAFT.bpmn
+++ b/src/main/resources/processes/POGR/POGR_GRO_DRAFT.bpmn
@@ -60,7 +60,7 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("TelephoneResponse") == "Yes" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0ns4v5z" sourceRef="Gateway_08xe206" targetRef="CallActivity_DraftInput">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.hasVariable("TelephoneResponse") != true }</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("TelephoneResponse") == "No" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">

--- a/src/main/resources/processes/POGR/POGR_HMPO_DRAFT.bpmn
+++ b/src/main/resources/processes/POGR/POGR_HMPO_DRAFT.bpmn
@@ -53,7 +53,7 @@
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1mfn8rb" sourceRef="CallActivity_TelephoneResponse" targetRef="Gateway_0ethfwm" />
     <bpmn:sequenceFlow id="Flow_197gv7u" sourceRef="Gateway_0ethfwm" targetRef="Screen_DraftInput">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.hasVariable("TelephoneResponse") != true }</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("TelephoneResponse") == "No" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0mz6qcv" sourceRef="Gateway_0ethfwm" targetRef="CallActivity_TelephoneResponse" />
   </bpmn:process>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_GRO_DRAFT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_GRO_DRAFT.java
@@ -91,7 +91,7 @@ public class POGR_GRO_DRAFT {
                 .deploy(rule);
 
         whenAtCallActivity("POGR_TELEPHONE_RESPONSE")
-                .thenReturn("", "")
+                .thenReturn("TelephoneResponse", "No")
                 .deploy(rule);
 
         Scenario.run(processScenario)

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_HMPO_DRAFT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_HMPO_DRAFT.java
@@ -88,7 +88,7 @@ public class POGR_HMPO_DRAFT {
                 .thenReturn(task -> task.complete(withVariables("DraftOutcome", "QA")));
 
         whenAtCallActivity("POGR_TELEPHONE_RESPONSE")
-                .thenReturn("", "")
+                .thenReturn("TelephoneResponse", "No")
                 .deploy(rule);
 
         Scenario.run(processScenario)


### PR DESCRIPTION
The telephone response flow from draft now supports a radio option
whereby a 'No' value drives it back to the previous screen.