### PR TITLE
HOCS-5161: move away from custom 'name' endpoint

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/client/documentclient/DocumentClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/client/documentclient/DocumentClient.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import uk.gov.digital.ho.hocs.workflow.application.RestHelper;
 import uk.gov.digital.ho.hocs.workflow.client.documentclient.dto.CreateCaseworkDocumentRequest;
+import uk.gov.digital.ho.hocs.workflow.client.documentclient.dto.DocumentDto;
 
 import java.util.UUID;
 
@@ -33,8 +34,7 @@ public class DocumentClient {
     }
 
     public String getDocumentName(UUID documentUUID) {
-        final String response = restHelper.get(serviceBaseURL, String.format("/document/%s/name", documentUUID), String.class);
-        log.info("Get Document Name: {} for UUID {}", response, documentUUID);
-        return response;
+        DocumentDto documentDto = restHelper.get(serviceBaseURL, String.format("/document/%s", documentUUID), DocumentDto.class);
+        return documentDto.getDisplayName();
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/client/documentclient/dto/DocumentDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/client/documentclient/dto/DocumentDto.java
@@ -1,0 +1,13 @@
+package uk.gov.digital.ho.hocs.workflow.client.documentclient.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor()
+@Getter
+public class DocumentDto {
+
+    @JsonProperty("displayName")
+    private String displayName;
+}


### PR DESCRIPTION
Move away from custom endpoint to help docs service handle database access in a consistent way