### PR TITLE
HOCS-5224 bug fix for DocumentDTO

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/client/documentclient/dto/DocumentDto.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/client/documentclient/dto/DocumentDto.java
@@ -3,8 +3,10 @@ package uk.gov.digital.ho.hocs.workflow.client.documentclient.dto;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @AllArgsConstructor()
+@NoArgsConstructor
 @Getter
 public class DocumentDto {
 


### PR DESCRIPTION
Bug fix for the DocumentDTO causing problems with Jackson object mapping when extracting json response from document service.