### PR TITLE
HOCS-5323: add back behaviour for GRO Draft

### DIFF
--- a/src/main/resources/processes/POGR/POGR_GRO_DRAFT.bpmn
+++ b/src/main/resources/processes/POGR/POGR_GRO_DRAFT.bpmn
@@ -60,7 +60,7 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("TelephoneResponse") == "Yes" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0ns4v5z" sourceRef="Gateway_08xe206" targetRef="CallActivity_DraftInput">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("TelephoneResponse") == "No" }</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("TelephoneResponse") == "No" || execution.getVariable("DIRECTION") == "BACKWARD" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_GRO_DRAFT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_GRO_DRAFT.java
@@ -88,10 +88,12 @@ public class POGR_GRO_DRAFT {
     public void testNotTelephoneResponse() {
         whenAtCallActivity("POGR_GRO_PRIORITY_CHANGE_SCREEN")
                 .thenReturn("DraftOutcome", "TelephoneResponse")
+                .thenReturn("DraftOutcome", "TelephoneResponse")
                 .thenReturn("DraftOutcome", "QA")
                 .deploy(rule);
 
         whenAtCallActivity("POGR_TELEPHONE_RESPONSE")
+                .thenReturn("DIRECTION", "BACKWARD")
                 .thenReturn("TelephoneResponse", "No")
                 .deploy(rule);
 
@@ -100,8 +102,8 @@ public class POGR_GRO_DRAFT {
                 .execute();
 
         verify(processScenario).hasCompleted("StartEvent_GroDraft");
-        verify(processScenario, times(2)).hasCompleted("CallActivity_DraftInput");
-        verify(processScenario).hasCompleted("CallActivity_TelephoneResponse");
+        verify(processScenario, times(3)).hasCompleted("CallActivity_DraftInput");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_TelephoneResponse");
         verify(processScenario).hasCompleted("EndEvent_GroDraft");
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_HMPO_DRAFT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_HMPO_DRAFT.java
@@ -86,9 +86,11 @@ public class POGR_HMPO_DRAFT {
     public void testNotTelephoneResponse() {
         when(processScenario.waitsAtUserTask("Screen_DraftInput"))
                 .thenReturn(task -> task.complete(withVariables("DraftOutcome", "TelephoneResponse")))
+                .thenReturn(task -> task.complete(withVariables("DraftOutcome", "TelephoneResponse")))
                 .thenReturn(task -> task.complete(withVariables("DraftOutcome", "QA")));
 
         whenAtCallActivity("POGR_TELEPHONE_RESPONSE")
+                .thenReturn("DIRECTION", "BACKWARD")
                 .thenReturn("TelephoneResponse", "No")
                 .deploy(rule);
 
@@ -97,8 +99,8 @@ public class POGR_HMPO_DRAFT {
                 .execute();
 
         verify(processScenario).hasCompleted("StartEvent_HmpoDraft");
-        verify(processScenario, times(2)).hasCompleted("Screen_DraftInput");
-        verify(processScenario).hasCompleted("CallActivity_TelephoneResponse");
+        verify(processScenario, times(3)).hasCompleted("Screen_DraftInput");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_TelephoneResponse");
         verify(processScenario).hasCompleted("EndEvent_HmpoDraft");
     }
 


### PR DESCRIPTION
Add missing back button handling for GRO draft cases. There is also an
addition of a couple of missing tests that let this slip through the net
last time.