### PR TITLE
HOCS-5391: fix internal gro team transfer

### DIFF
--- a/src/main/resources/processes/POGR/POGR_GRO.bpmn
+++ b/src/main/resources/processes/POGR/POGR_GRO.bpmn
@@ -25,6 +25,7 @@
         <camunda:out source="InvestigationOutcome" target="InvestigationOutcome" />
         <camunda:out source="LastUpdatedByUserUUID" target="DraftUserUUID" />
         <camunda:in source="DraftUserUUID" target="AllocatedUserUUID" />
+        <camunda:out source="DraftTeamUUID" target="DraftTeamUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1twhwzx</bpmn:incoming>
       <bpmn:incoming>Flow_1pe6gam</bpmn:incoming>

--- a/src/main/resources/processes/POGR/POGR_GRO_TRIAGE.bpmn
+++ b/src/main/resources/processes/POGR/POGR_GRO_TRIAGE.bpmn
@@ -31,12 +31,12 @@
       <bpmn:incoming>Flow_0pml1a7</bpmn:incoming>
       <bpmn:outgoing>Flow_1s53jai</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:serviceTask id="Activity_CloseCaseNote" name="Save Reject Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_TriageReject&#34;), &#34;REJECT&#34;)}">
+    <bpmn:serviceTask id="Activity_RejectCaseNote" name="Save Reject Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_TriageReject&#34;), &#34;REJECT&#34;)}">
       <bpmn:incoming>Flow_0tyht9a</bpmn:incoming>
       <bpmn:outgoing>Flow_0axdze3</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_1h6zo9j" sourceRef="StartEvent_POGR_GRO_TRIAGE" targetRef="Screen_TriageAcceptCase" />
-    <bpmn:sequenceFlow id="Flow_0axdze3" sourceRef="Activity_CloseCaseNote" targetRef="Gateway_1pqstvp" />
+    <bpmn:sequenceFlow id="Flow_0axdze3" sourceRef="Activity_RejectCaseNote" targetRef="Gateway_1pqstvp" />
     <bpmn:sequenceFlow id="Flow_1jv3ybg" sourceRef="Gateway_1lzp3ot" targetRef="CallActivity_TriageInvestigation">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ TriageAccept == "Accept" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -45,7 +45,7 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ TriageAccept == "Reject" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1s53jai" sourceRef="Screen_GroTransferScreen" targetRef="Gateway_13l1v6m" />
-    <bpmn:serviceTask id="Activity_UpdateTriageTeam" name="Update Triage Team" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;POGR_GRO_TRIAGE&#34;,&#34;QueueTeamUUID&#34;,&#34;QueueTeamName&#34;,&#34;TriageRejectGroInvestigatingTeamSelection&#34;)}">
+    <bpmn:serviceTask id="Activity_UpdateTriageTeam" name="Update Triage Team" camunda:expression="${bpmnService.updateTeamByStageAndTexts(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;POGR_GRO_TRIAGE&#34;,&#34;DraftTeamUUID&#34;,&#34;DraftTeamName&#34;,&#34;TriageRejectGroInvestigatingTeamSelection&#34;)}">
       <bpmn:incoming>Flow_1wq5pys</bpmn:incoming>
       <bpmn:outgoing>Flow_0314kt6</bpmn:outgoing>
     </bpmn:serviceTask>
@@ -64,7 +64,7 @@
       <bpmn:outgoing>Flow_0tyht9a</bpmn:outgoing>
       <bpmn:outgoing>Flow_0sfm1n3</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_0tyht9a" sourceRef="Gateway_13l1v6m" targetRef="Activity_CloseCaseNote">
+    <bpmn:sequenceFlow id="Flow_0tyht9a" sourceRef="Gateway_13l1v6m" targetRef="Activity_RejectCaseNote">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DIRECTION == "FORWARD" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0sfm1n3" sourceRef="Gateway_13l1v6m" targetRef="Screen_TriageAcceptCase" />
@@ -228,7 +228,7 @@
       <bpmndi:BPMNShape id="Activity_1u560h2_di" bpmnElement="Screen_GroTransferScreen">
         <dc:Bounds x="353" y="361" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_06synm6_di" bpmnElement="Activity_CloseCaseNote">
+      <bpmndi:BPMNShape id="Activity_06synm6_di" bpmnElement="Activity_RejectCaseNote">
         <dc:Bounds x="580" y="361" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_023rcf1_di" bpmnElement="Activity_UpdateTriageTeam">

--- a/src/main/resources/processes/POGR/POGR_HMPO_TRIAGE.bpmn
+++ b/src/main/resources/processes/POGR/POGR_HMPO_TRIAGE.bpmn
@@ -42,14 +42,14 @@
     </bpmn:userTask>
     <bpmn:sequenceFlow id="Flow_1ksuddr" sourceRef="StartEvent_POGR_HMPO_TRIAGE" targetRef="Screen_TriageAcceptCase" />
     <bpmn:sequenceFlow id="Flow_0smh5v3" sourceRef="Screen_TriageAcceptCase" targetRef="Gateway_19v9xyf" />
-    <bpmn:sequenceFlow id="Flow_01v1eua" sourceRef="Gateway_19v9xyf" targetRef="Activity_CloseCaseNote">
+    <bpmn:sequenceFlow id="Flow_01v1eua" sourceRef="Gateway_19v9xyf" targetRef="Activity_RejectCaseNote">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ TriageAccept == "Reject" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="Activity_CloseCaseNote" name="Save Reject Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_TriageReject&#34;), &#34;REJECT&#34;)}">
+    <bpmn:serviceTask id="Activity_RejectCaseNote" name="Save Reject Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_TriageReject&#34;), &#34;REJECT&#34;)}">
       <bpmn:incoming>Flow_01v1eua</bpmn:incoming>
       <bpmn:outgoing>Flow_1e5l22s</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_1e5l22s" sourceRef="Activity_CloseCaseNote" targetRef="EndEvent_POGR_HMPO_TRIAGE" />
+    <bpmn:sequenceFlow id="Flow_1e5l22s" sourceRef="Activity_RejectCaseNote" targetRef="EndEvent_POGR_HMPO_TRIAGE" />
     <bpmn:sequenceFlow id="Flow_0zsm3ym" sourceRef="Gateway_19v9xyf" targetRef="Screen_TriageAcceptCase" />
     <bpmn:exclusiveGateway id="Gateway_1yz3uf5" default="Flow_0m2j2de">
       <bpmn:incoming>Flow_1picyoq</bpmn:incoming>
@@ -167,7 +167,7 @@
       <bpmndi:BPMNShape id="Activity_0ndtiwv_di" bpmnElement="Screen_TriageAcceptCase">
         <dc:Bounds x="250" y="219" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0wjraoq_di" bpmnElement="Activity_CloseCaseNote">
+      <bpmndi:BPMNShape id="Activity_0wjraoq_di" bpmnElement="Activity_RejectCaseNote">
         <dc:Bounds x="540" y="340" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1yz3uf5_di" bpmnElement="Gateway_1yz3uf5" isMarkerVisible="true">

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_GRO_TRIAGE.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_GRO_TRIAGE.java
@@ -70,7 +70,7 @@ public class POGR_GRO_TRIAGE {
     }
 
     @Test
-    public void testTriageExternalCloseCase() {
+    public void testTriageExternalRejection() {
         when(processScenario.waitsAtUserTask("Screen_TriageAcceptCase"))
                 .thenReturn(task -> task.complete(withVariables("TriageAccept", "Reject")));
 
@@ -85,15 +85,15 @@ public class POGR_GRO_TRIAGE {
         verify(processScenario).hasCompleted("StartEvent_POGR_GRO_TRIAGE");
         verify(processScenario, times(2)).hasCompleted("Screen_TriageAcceptCase");
         verify(processScenario, times(2)).hasCompleted("Screen_GroTransferScreen");
-        verify(processScenario).hasCompleted("Activity_CloseCaseNote");
+        verify(processScenario).hasCompleted("Activity_RejectCaseNote");
         verify(processScenario).hasCompleted("EndEvent_POGR_GRO_TRIAGE");
 
         verify(bpmnService).updateAllocationNote(any(), any(), any(), eq("REJECT"));
-        verify(bpmnService, times(0)).updateTeamByStageAndTexts(any(), any(), eq("POGR_GRO_TRIAGE"), any(), any());
+        verify(bpmnService, times(0)).updateTeamByStageAndTexts(any(), any(), eq("POGR_GRO_TRIAGE"), any(), any(), any());
     }
 
     @Test
-    public void testTriageInternalCloseCase() {
+    public void testTriageInternalRejection() {
         when(processScenario.waitsAtUserTask("Screen_TriageAcceptCase"))
                 .thenReturn(task -> task.complete(withVariables("TriageAccept", "Reject")));
 
@@ -108,12 +108,11 @@ public class POGR_GRO_TRIAGE {
         verify(processScenario).hasCompleted("StartEvent_POGR_GRO_TRIAGE");
         verify(processScenario, times(2)).hasCompleted("Screen_TriageAcceptCase");
         verify(processScenario, times(2)).hasCompleted("Screen_GroTransferScreen");
-        verify(processScenario).hasCompleted("Activity_CloseCaseNote");
+        verify(processScenario).hasCompleted("Activity_RejectCaseNote");
         verify(processScenario).hasCompleted("EndEvent_POGR_GRO_TRIAGE");
 
         verify(bpmnService).updateAllocationNote(any(), any(), any(), eq("REJECT"));
-        verify(bpmnService).updateTeamByStageAndTexts(any(), any(), eq("POGR_GRO_TRIAGE"), any(), any(), any());
-
+        verify(bpmnService).updateTeamByStageAndTexts(any(), any(), eq("POGR_GRO_TRIAGE"), eq("DraftTeamUUID"), eq("DraftTeamName"), eq("TriageRejectGroInvestigatingTeamSelection"));
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_HMPO_TRIAGE.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_HMPO_TRIAGE.java
@@ -77,7 +77,7 @@ public class POGR_HMPO_TRIAGE {
 
         verify(processScenario).hasCompleted("StartEvent_POGR_HMPO_TRIAGE");
         verify(processScenario).hasCompleted("Screen_TriageAcceptCase");
-        verify(processScenario).hasCompleted("Activity_CloseCaseNote");
+        verify(processScenario).hasCompleted("Activity_RejectCaseNote");
         verify(processScenario).hasCompleted("EndEvent_POGR_HMPO_TRIAGE");
     }
 


### PR DESCRIPTION
There is currently no export from the POGR GRO Triage stage for an
internal transfer. This is causing the team not to be changing on the
next entry to this stage. This change amends this call to update
`DraftTeamUUID` and `DraftTeamName`.

This also amends the tests and activity to not be a `close` but a
`reject`.