### PR TITLE
HOCS-5433: fix draft case closure note

### DIFF
--- a/src/main/resources/processes/POGR/POGR_GRO_DRAFT.bpmn
+++ b/src/main/resources/processes/POGR/POGR_GRO_DRAFT.bpmn
@@ -153,7 +153,7 @@
     <bpmn:sequenceFlow id="Flow_0yxyh71" name="Back" sourceRef="Gateway_0ub6sm6" targetRef="CallActivity_DraftInput">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DIRECTION == "BACKWARD" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="ServiceTask_SaveCloseNote" name="Save Close Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;HMPOGRODraftRCloseCaseNote&#34;), &#34;Closed&#34;)}">
+    <bpmn:serviceTask id="ServiceTask_SaveCloseNote" name="Save Close Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;HMPODraftCloseCaseNote&#34;), &#34;CLOSE&#34;)}">
       <bpmn:incoming>Flow_1keqymi</bpmn:incoming>
       <bpmn:outgoing>Flow_0ktfowy</bpmn:outgoing>
     </bpmn:serviceTask>
@@ -165,6 +165,12 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR_GRO_DRAFT">
+      <bpmndi:BPMNEdge id="Flow_1uhndcx_di" bpmnElement="Flow_1uhndcx" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="740" y="195" />
+        <di:waypoint x="740" y="140" />
+        <di:waypoint x="600" y="140" />
+        <di:waypoint x="600" y="180" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0ktfowy_di" bpmnElement="Flow_0ktfowy">
         <di:waypoint x="960" y="220" />
         <di:waypoint x="1040" y="220" />
@@ -301,14 +307,11 @@
         <di:waypoint x="188" y="570" />
         <di:waypoint x="270" y="570" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1uhndcx_di" bpmnElement="Flow_1uhndcx" bioc:stroke="#e53935" color:border-color="#e53935">
-        <di:waypoint x="740" y="195" />
-        <di:waypoint x="740" y="140" />
-        <di:waypoint x="600" y="140" />
-        <di:waypoint x="600" y="180" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0pid86l_di" bpmnElement="StartEvent_GroDraft">
         <dc:Bounds x="152" y="552" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04tmesu_di" bpmnElement="EndEvent_GroDraft">
+        <dc:Bounds x="1022" y="552" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_17jc4vl_di" bpmnElement="CallActivity_DraftInput">
         <dc:Bounds x="270" y="530" width="100" height="80" />
@@ -351,9 +354,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0lu2vpr_di" bpmnElement="ServiceTask_SaveCloseNote">
         <dc:Bounds x="860" y="180" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_04tmesu_di" bpmnElement="EndEvent_GroDraft">
-        <dc:Bounds x="1022" y="552" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/POGR/POGR_HMPO_DRAFT.bpmn
+++ b/src/main/resources/processes/POGR/POGR_HMPO_DRAFT.bpmn
@@ -143,7 +143,7 @@
       <bpmn:outgoing>Flow_0odqfkg</bpmn:outgoing>
       <bpmn:outgoing>Flow_01beylb</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="ServiceTask_SaveCloseNote" name="Save Close Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;HMPOGRODraftRCloseCaseNote&#34;), &#34;Closed&#34;)}">
+    <bpmn:serviceTask id="ServiceTask_SaveCloseNote" name="Save Close Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;HMPODraftCloseCaseNote&#34;), &#34;CLOSE&#34;)}">
       <bpmn:incoming>Flow_1ikvaaj</bpmn:incoming>
       <bpmn:outgoing>Flow_1bdlmcc</bpmn:outgoing>
     </bpmn:serviceTask>
@@ -159,6 +159,12 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR_HMPO_DRAFT">
+      <bpmndi:BPMNEdge id="Flow_01beylb_di" bpmnElement="Flow_01beylb" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="720" y="205" />
+        <di:waypoint x="720" y="150" />
+        <di:waypoint x="600" y="150" />
+        <di:waypoint x="600" y="190" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0odqfkg_di" bpmnElement="Flow_0odqfkg">
         <di:waypoint x="720" y="205" />
         <di:waypoint x="720" y="100" />
@@ -295,14 +301,11 @@
         <di:waypoint x="208" y="580" />
         <di:waypoint x="270" y="580" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_01beylb_di" bpmnElement="Flow_01beylb" bioc:stroke="#e53935" color:border-color="#e53935">
-        <di:waypoint x="720" y="205" />
-        <di:waypoint x="720" y="150" />
-        <di:waypoint x="600" y="150" />
-        <di:waypoint x="600" y="190" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Event_0pid86l_di" bpmnElement="StartEvent_HmpoDraft">
         <dc:Bounds x="172" y="562" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04tmesu_di" bpmnElement="EndEvent_HmpoDraft">
+        <dc:Bounds x="962" y="562" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0ie5w7n_di" bpmnElement="Screen_DraftInput">
         <dc:Bounds x="270" y="540" width="100" height="80" />
@@ -345,9 +348,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0c37ujt_di" bpmnElement="ServiceTask_SaveCloseNote">
         <dc:Bounds x="800" y="190" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_04tmesu_di" bpmnElement="EndEvent_HmpoDraft">
-        <dc:Bounds x="962" y="562" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_GRO_DRAFT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_GRO_DRAFT.java
@@ -185,7 +185,7 @@ public class POGR_GRO_DRAFT {
         verify(processScenario, times(2)).hasCompleted("CallActivity_DraftInput");
         verify(processScenario, times(3)).hasCompleted("UserActivity_CloseCase");
         verify(processScenario).hasCompleted("ServiceTask_SaveCloseNote");
-        verify(bpmnService).updateAllocationNote(any(), any(), any(), eq("Closed"));
+        verify(bpmnService).updateAllocationNote(any(), any(), any(), eq("CLOSE"));
         verify(processScenario).hasCompleted("EndEvent_GroDraft");
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_HMPO_DRAFT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_HMPO_DRAFT.java
@@ -180,7 +180,7 @@ public class POGR_HMPO_DRAFT {
         verify(processScenario, times(2)).hasCompleted("Screen_DraftInput");
         verify(processScenario, times(3)).hasCompleted("UserActivity_CloseCase");
         verify(processScenario).hasCompleted("ServiceTask_SaveCloseNote");
-        verify(bpmnService).updateAllocationNote(any(), any(), any(), eq("Closed"));
+        verify(bpmnService).updateAllocationNote(any(), any(), any(), eq("CLOSE"));
         verify(processScenario).hasCompleted("EndEvent_HmpoDraft");
     }
 


### PR DESCRIPTION
Fix the addition of a case note at the POGR draft stage for both HMPO
and GRO. This includes correcting the field name to point to the correct
one on the screen and also changing the type in the BPMN to indicate
`CLOSE` rather than `Closed`.