### PR TITLE
HOCS-5456: fix BF triage payment null exception

### DIFF
--- a/src/main/resources/processes/BF/BF_TRIAGE.bpmn
+++ b/src/main/resources/processes/BF/BF_TRIAGE.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0a8virv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" id="Definitions_0a8virv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <bpmn:process id="BF_TRIAGE" isExecutable="true">
     <bpmn:endEvent id="EndEvent_BF_TRIAGE">
       <bpmn:incoming>Flow_0pawikq</bpmn:incoming>
@@ -184,45 +184,33 @@
     <bpmn:sequenceFlow id="Flow_1wx1rxx" sourceRef="Gateway_1h4oewh" targetRef="Transfer_Case">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1iabpn0" sourceRef="CALCULATE_TOTAL_PAYMENT" targetRef="Gateway_075jzz1" />
-    <bpmn:serviceTask id="CALCULATE_TOTAL_PAYMENT" name="Calculate Payment Offer Totals" camunda:expression="${bpmnService.calculateTotals(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;BF_TOTAL_PAYMENT_OFFER&#34;)}">
-      <bpmn:incoming>Flow_1rvj6q7</bpmn:incoming>
-      <bpmn:incoming>Flow_0pac256</bpmn:incoming>
-      <bpmn:incoming>Flow_1cnnymc</bpmn:incoming>
-      <bpmn:outgoing>Flow_1iabpn0</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:exclusiveGateway id="Gateway_0mav3nh" name="Payment Calculation Required?">
+    <bpmn:exclusiveGateway id="Gateway_0mav3nh" name="Payment Calculation Required?" default="Flow_0j3inrp">
       <bpmn:incoming>Flow_0tijz6t</bpmn:incoming>
       <bpmn:outgoing>Flow_0j3inrp</bpmn:outgoing>
       <bpmn:outgoing>Flow_15hu0g2</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_0j3inrp" name="No" sourceRef="Gateway_0mav3nh" targetRef="CLEAR_PAYMENT_VALS">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ !"Yes".equals(PaymentTypeConsolatory) &amp;&amp; !"Yes".equals(PaymentTypeExGratia) }</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0j3inrp" sourceRef="Gateway_0mav3nh" targetRef="CLEAR_PAYMENT_VALS" />
     <bpmn:sequenceFlow id="Flow_15hu0g2" name="Yes" sourceRef="Gateway_0mav3nh" targetRef="Gateway_0a5g615">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "Yes".equals(PaymentTypeConsolatory) || "Yes".equals(PaymentTypeExGratia) }</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "Yes" == execution.getVariable("PaymentTypeConsolatory") || "Yes" == execution.getVariable("PaymentTypeExGratia") }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_0lgnzwm" sourceRef="CLEAR_PAYMENT_VALS" targetRef="Gateway_075jzz1" />
     <bpmn:serviceTask id="CLEAR_PAYMENT_VALS" name="Clear Payment Values" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;TotalOfferSentToComplainant&#34;, &#34;ConsolatoryOfferSentToComplainant&#34;, &#34;ExGratiaOfferSentToComplainant&#34;)}">
       <bpmn:incoming>Flow_0j3inrp</bpmn:incoming>
       <bpmn:outgoing>Flow_0lgnzwm</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:exclusiveGateway id="Gateway_0a5g615" name="Payment type Consolatory applied?">
+    <bpmn:exclusiveGateway id="Gateway_0a5g615" name="Payment type Consolatory applied?" default="Flow_0dl1z3h">
       <bpmn:incoming>Flow_15hu0g2</bpmn:incoming>
       <bpmn:outgoing>Flow_12a8sub</bpmn:outgoing>
       <bpmn:outgoing>Flow_0dl1z3h</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_12a8sub" name="Yes" sourceRef="Gateway_0a5g615" targetRef="Gateway_0pdtuba">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "Yes".equals(PaymentTypeConsolatory) }</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "Yes" == execution.getVariable("PaymentTypeConsolatory") }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="Gateway_0pdtuba" name="Payment type Ex-Gratia applied?">
+    <bpmn:exclusiveGateway id="Gateway_0pdtuba" name="Payment type Ex-Gratia applied?" default="Flow_00fuf4i">
       <bpmn:incoming>Flow_12a8sub</bpmn:incoming>
-      <bpmn:outgoing>Flow_1rvj6q7</bpmn:outgoing>
       <bpmn:outgoing>Flow_00fuf4i</bpmn:outgoing>
+      <bpmn:outgoing>Flow_15zv8ue</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_1rvj6q7" name="Yes" sourceRef="Gateway_0pdtuba" targetRef="CALCULATE_TOTAL_PAYMENT">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "Yes".equals(PaymentTypeExGratia) }</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
     <bpmn:serviceTask id="CLEAR_CONSOL_VAL" name="Clear Consolatory Payment Offer Value" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;ConsolatoryOfferSentToComplainant&#34;)}">
       <bpmn:incoming>Flow_0dl1z3h</bpmn:incoming>
       <bpmn:outgoing>Flow_1cnnymc</bpmn:outgoing>
@@ -231,17 +219,11 @@
       <bpmn:incoming>Flow_00fuf4i</bpmn:incoming>
       <bpmn:outgoing>Flow_0pac256</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0dl1z3h" name="No" sourceRef="Gateway_0a5g615" targetRef="CLEAR_CONSOL_VAL">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "No".equals(PaymentTypeConsolatory) }</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_00fuf4i" name="No" sourceRef="Gateway_0pdtuba" targetRef="CLEAR_EXGRATIA_VAL">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "No".equals(PaymentTypeExGratia) }</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0pac256" sourceRef="CLEAR_EXGRATIA_VAL" targetRef="CALCULATE_TOTAL_PAYMENT" />
-    <bpmn:sequenceFlow id="Flow_1cnnymc" sourceRef="CLEAR_CONSOL_VAL" targetRef="CALCULATE_TOTAL_PAYMENT" />
+    <bpmn:sequenceFlow id="Flow_0dl1z3h" sourceRef="Gateway_0a5g615" targetRef="CLEAR_CONSOL_VAL" />
+    <bpmn:sequenceFlow id="Flow_00fuf4i" sourceRef="Gateway_0pdtuba" targetRef="CLEAR_EXGRATIA_VAL" />
     <bpmn:exclusiveGateway id="Gateway_075jzz1" name="Complaint Requested Payment?">
-      <bpmn:incoming>Flow_1iabpn0</bpmn:incoming>
       <bpmn:incoming>Flow_0lgnzwm</bpmn:incoming>
+      <bpmn:incoming>Flow_1iabpn0</bpmn:incoming>
       <bpmn:outgoing>Flow_07pln74</bpmn:outgoing>
       <bpmn:outgoing>Flow_11a4rcc</bpmn:outgoing>
     </bpmn:exclusiveGateway>
@@ -256,48 +238,69 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ !"Yes".equals(PaymentRequested) &amp;&amp; !"Yes".equals(PaymentRequested) }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_13mhm9i" sourceRef="CLEAR_REQUESTED_AMOUNT" targetRef="Gateway_0tf16js" />
+    <bpmn:serviceTask id="CALCULATE_TOTAL_PAYMENT" name="Calculate Payment Offer Totals" camunda:expression="${bpmnService.calculateTotals(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;BF_TOTAL_PAYMENT_OFFER&#34;)}">
+      <bpmn:incoming>Flow_1cnnymc</bpmn:incoming>
+      <bpmn:incoming>Flow_15zv8ue</bpmn:incoming>
+      <bpmn:incoming>Flow_0pac256</bpmn:incoming>
+      <bpmn:outgoing>Flow_1iabpn0</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1iabpn0" sourceRef="CALCULATE_TOTAL_PAYMENT" targetRef="Gateway_075jzz1" />
+    <bpmn:sequenceFlow id="Flow_1cnnymc" sourceRef="CLEAR_CONSOL_VAL" targetRef="CALCULATE_TOTAL_PAYMENT" />
+    <bpmn:sequenceFlow id="Flow_15zv8ue" name="Yes" sourceRef="Gateway_0pdtuba" targetRef="CALCULATE_TOTAL_PAYMENT">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "Yes" == execution.getVariable("PaymentTypeExGratia") }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0pac256" sourceRef="CLEAR_EXGRATIA_VAL" targetRef="CALCULATE_TOTAL_PAYMENT" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="BF_TRIAGE">
-      <bpmndi:BPMNEdge id="Flow_1cnnymc_di" bpmnElement="Flow_1cnnymc">
-        <di:waypoint x="1180" y="720" />
-        <di:waypoint x="1225" y="720" />
-        <di:waypoint x="1225" y="923" />
-        <di:waypoint x="1270" y="923" />
+      <bpmndi:BPMNEdge id="Flow_13mhm9i_di" bpmnElement="Flow_13mhm9i">
+        <di:waypoint x="1510" y="700" />
+        <di:waypoint x="1510" y="645" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11a4rcc_di" bpmnElement="Flow_11a4rcc">
+        <di:waypoint x="1332" y="633" />
+        <di:waypoint x="1430" y="740" />
+        <di:waypoint x="1460" y="740" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1352" y="676" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07pln74_di" bpmnElement="Flow_07pln74">
+        <di:waypoint x="1345" y="620" />
+        <di:waypoint x="1485" y="620" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1361" y="602" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1cnnymc_di" bpmnElement="Flow_1cnnymc" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="1180" y="740" />
+        <di:waypoint x="1220" y="740" />
+        <di:waypoint x="1220" y="870" />
+        <di:waypoint x="1270" y="870" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0pac256_di" bpmnElement="Flow_0pac256">
-        <di:waypoint x="1180" y="820" />
-        <di:waypoint x="1225" y="820" />
-        <di:waypoint x="1225" y="923" />
-        <di:waypoint x="1270" y="923" />
+        <di:waypoint x="1180" y="870" />
+        <di:waypoint x="1270" y="870" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_00fuf4i_di" bpmnElement="Flow_00fuf4i">
-        <di:waypoint x="935" y="820" />
-        <di:waypoint x="1080" y="820" />
+        <di:waypoint x="935" y="870" />
+        <di:waypoint x="1080" y="870" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="962" y="802" width="15" height="14" />
+          <dc:Bounds x="992" y="863" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0dl1z3h_di" bpmnElement="Flow_0dl1z3h">
-        <di:waypoint x="935" y="720" />
-        <di:waypoint x="1080" y="720" />
+        <di:waypoint x="935" y="740" />
+        <di:waypoint x="1080" y="740" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="962" y="702" width="15" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1rvj6q7_di" bpmnElement="Flow_1rvj6q7">
-        <di:waypoint x="910" y="845" />
-        <di:waypoint x="910" y="923" />
-        <di:waypoint x="1270" y="923" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="916" y="863" width="18" height="14" />
+          <dc:Bounds x="1017" y="722" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_12a8sub_di" bpmnElement="Flow_12a8sub">
-        <di:waypoint x="910" y="745" />
-        <di:waypoint x="910" y="795" />
+        <di:waypoint x="910" y="765" />
+        <di:waypoint x="910" y="845" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="916" y="753" width="18" height="14" />
+          <dc:Bounds x="921" y="771" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0lgnzwm_di" bpmnElement="Flow_0lgnzwm">
@@ -306,20 +309,20 @@
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_15hu0g2_di" bpmnElement="Flow_15hu0g2">
         <di:waypoint x="910" y="645" />
-        <di:waypoint x="910" y="695" />
+        <di:waypoint x="910" y="715" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="921" y="643" width="18" height="14" />
+          <dc:Bounds x="921" y="645" width="18" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0j3inrp_di" bpmnElement="Flow_0j3inrp">
         <di:waypoint x="935" y="620" />
         <di:waypoint x="1080" y="620" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="962" y="602" width="15" height="14" />
+          <dc:Bounds x="961" y="602" width="15" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1iabpn0_di" bpmnElement="Flow_1iabpn0">
-        <di:waypoint x="1320" y="883" />
+        <di:waypoint x="1320" y="830" />
         <di:waypoint x="1320" y="645" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1wx1rxx_di" bpmnElement="Flow_1wx1rxx">
@@ -390,46 +393,6 @@
         <di:waypoint x="630" y="340" />
         <di:waypoint x="630" y="580" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0nvtbw4_di" bpmnElement="Flow_0nvtbw4">
-        <di:waypoint x="1950" y="928" />
-        <di:waypoint x="1950" y="1060" />
-        <di:waypoint x="620" y="1060" />
-        <di:waypoint x="620" y="660" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1bnsbkw_di" bpmnElement="Flow_1bnsbkw">
-        <di:waypoint x="2130" y="740" />
-        <di:waypoint x="2180" y="740" />
-        <di:waypoint x="2180" y="638" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1k4hd8y_di" bpmnElement="Flow_1k4hd8y">
-        <di:waypoint x="1523" y="633" />
-        <di:waypoint x="1630" y="740" />
-        <di:waypoint x="1750" y="740" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1586" y="663" width="48" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0yqamon_di" bpmnElement="Flow_0yqamon">
-        <di:waypoint x="1498" y="607" />
-        <di:waypoint x="1310" y="410" />
-        <di:waypoint x="610" y="410" />
-        <di:waypoint x="610" y="580" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1409" y="565" width="41" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0tijz6t_di" bpmnElement="Flow_0tijz6t">
-        <di:waypoint x="745" y="620" />
-        <di:waypoint x="885" y="620" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0nritne_di" bpmnElement="Flow_0nritne">
-        <di:waypoint x="670" y="620" />
-        <di:waypoint x="695" y="620" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0pawikq_di" bpmnElement="Flow_0pawikq">
-        <di:waypoint x="1535" y="620" />
-        <di:waypoint x="2162" y="620" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hvxas2_di" bpmnElement="Flow_1hvxas2">
         <di:waypoint x="1850" y="440" />
         <di:waypoint x="2180" y="440" />
@@ -442,57 +405,23 @@
           <dc:Bounds x="1518" y="562" width="43" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1lgnaji_di" bpmnElement="Flow_1lgnaji">
-        <di:waypoint x="1700" y="415" />
-        <di:waypoint x="1700" y="370" />
-        <di:waypoint x="1510" y="370" />
-        <di:waypoint x="1510" y="400" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1jtzjzy_di" bpmnElement="Flow_1jtzjzy">
-        <di:waypoint x="1560" y="440" />
-        <di:waypoint x="1585" y="440" />
+      <bpmndi:BPMNEdge id="Flow_17hpetn_di" bpmnElement="Flow_17hpetn">
+        <di:waypoint x="1635" y="440" />
+        <di:waypoint x="1675" y="440" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_07vvmye_di" bpmnElement="Flow_07vvmye">
         <di:waypoint x="1725" y="440" />
         <di:waypoint x="1750" y="440" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17hpetn_di" bpmnElement="Flow_17hpetn">
-        <di:waypoint x="1635" y="440" />
-        <di:waypoint x="1675" y="440" />
+      <bpmndi:BPMNEdge id="Flow_1jtzjzy_di" bpmnElement="Flow_1jtzjzy">
+        <di:waypoint x="1560" y="440" />
+        <di:waypoint x="1585" y="440" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_07pln74_di" bpmnElement="Flow_07pln74">
-        <di:waypoint x="1345" y="620" />
-        <di:waypoint x="1485" y="620" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1361" y="602" width="18" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_11a4rcc_di" bpmnElement="Flow_11a4rcc">
-        <di:waypoint x="1332" y="633" />
-        <di:waypoint x="1430" y="740" />
-        <di:waypoint x="1460" y="740" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1352" y="676" width="15" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_13mhm9i_di" bpmnElement="Flow_13mhm9i">
-        <di:waypoint x="1510" y="700" />
-        <di:waypoint x="1510" y="645" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ogj4fu_di" bpmnElement="Flow_1ogj4fu">
-        <di:waypoint x="1950" y="878" />
-        <di:waypoint x="1950" y="765" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19x2wtx_di" bpmnElement="Flow_19x2wtx">
-        <di:waypoint x="1925" y="740" />
-        <di:waypoint x="1850" y="740" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="989" y="311" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0qvdnyq_di" bpmnElement="Flow_0qvdnyq">
-        <di:waypoint x="1975" y="740" />
-        <di:waypoint x="2030" y="740" />
+      <bpmndi:BPMNEdge id="Flow_1lgnaji_di" bpmnElement="Flow_1lgnaji">
+        <di:waypoint x="1700" y="415" />
+        <di:waypoint x="1700" y="370" />
+        <di:waypoint x="1510" y="370" />
+        <di:waypoint x="1510" y="400" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1twhx74_di" bpmnElement="Flow_1twhx74">
         <di:waypoint x="1850" y="903" />
@@ -502,11 +431,114 @@
         <di:waypoint x="1800" y="780" />
         <di:waypoint x="1800" y="863" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nvtbw4_di" bpmnElement="Flow_0nvtbw4">
+        <di:waypoint x="1950" y="928" />
+        <di:waypoint x="1950" y="1060" />
+        <di:waypoint x="620" y="1060" />
+        <di:waypoint x="620" y="660" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bnsbkw_di" bpmnElement="Flow_1bnsbkw">
+        <di:waypoint x="2130" y="740" />
+        <di:waypoint x="2180" y="740" />
+        <di:waypoint x="2180" y="638" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qvdnyq_di" bpmnElement="Flow_0qvdnyq">
+        <di:waypoint x="1975" y="740" />
+        <di:waypoint x="2030" y="740" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1k4hd8y_di" bpmnElement="Flow_1k4hd8y">
+        <di:waypoint x="1523" y="633" />
+        <di:waypoint x="1630" y="740" />
+        <di:waypoint x="1750" y="740" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1586" y="663" width="48" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19x2wtx_di" bpmnElement="Flow_19x2wtx">
+        <di:waypoint x="1925" y="740" />
+        <di:waypoint x="1850" y="740" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="989" y="311" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ogj4fu_di" bpmnElement="Flow_1ogj4fu">
+        <di:waypoint x="1950" y="878" />
+        <di:waypoint x="1950" y="765" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0yqamon_di" bpmnElement="Flow_0yqamon">
+        <di:waypoint x="1498" y="607" />
+        <di:waypoint x="1310" y="410" />
+        <di:waypoint x="610" y="410" />
+        <di:waypoint x="610" y="580" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1409" y="565" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0pawikq_di" bpmnElement="Flow_0pawikq">
+        <di:waypoint x="1535" y="620" />
+        <di:waypoint x="2162" y="620" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0tijz6t_di" bpmnElement="Flow_0tijz6t">
+        <di:waypoint x="745" y="620" />
+        <di:waypoint x="885" y="620" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nritne_di" bpmnElement="Flow_0nritne">
+        <di:waypoint x="670" y="620" />
+        <di:waypoint x="695" y="620" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15zv8ue_di" bpmnElement="Flow_15zv8ue">
+        <di:waypoint x="910" y="895" />
+        <di:waypoint x="910" y="970" />
+        <di:waypoint x="1320" y="970" />
+        <di:waypoint x="1320" y="910" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="921" y="928" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0pmmumb_di" bpmnElement="EndEvent_BF_TRIAGE">
+        <dc:Bounds x="2162" y="602" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_11s75w3_di" bpmnElement="Validate_Capture_Reason">
         <dc:Bounds x="570" y="580" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1xii2tv_di" bpmnElement="Gateway_1xii2tv" isMarkerVisible="true">
         <dc:Bounds x="695" y="595" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0tf16js_di" bpmnElement="Gateway_0tf16js" isMarkerVisible="true">
+        <dc:Bounds x="1485" y="595" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1425" y="643" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0drd59m_di" bpmnElement="Gateway_0drd59m" isMarkerVisible="true">
+        <dc:Bounds x="1925" y="715" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1g7b2fa_di" bpmnElement="Gateway_1g7b2fa" isMarkerVisible="true">
+        <dc:Bounds x="1925" y="878" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1065" y="486" width="76" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ui0b1l_di" bpmnElement="Complete_Reason">
+        <dc:Bounds x="1750" y="700" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0yi6phj_di" bpmnElement="Validate_Complete_Reason">
+        <dc:Bounds x="1750" y="863" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_13taydb_di" bpmnElement="Activity_13taydb">
+        <dc:Bounds x="2030" y="700" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09xwkjb_di" bpmnElement="Validate_Escalate">
+        <dc:Bounds x="1460" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hn5mnb_di" bpmnElement="Save_Note">
+        <dc:Bounds x="1750" y="400" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_01ihebc_di" bpmnElement="Gateway_01ihebc" isMarkerVisible="true">
+        <dc:Bounds x="1585" y="415" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_05ok60y_di" bpmnElement="Gateway_05ok60y" isMarkerVisible="true">
+        <dc:Bounds x="1675" y="415" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0jggixz_di" bpmnElement="Event_0jggixz">
         <dc:Bounds x="152" y="602" width="36" height="36" />
@@ -532,53 +564,11 @@
       <bpmndi:BPMNShape id="Gateway_1h4oewh_di" bpmnElement="Gateway_1h4oewh" isMarkerVisible="true">
         <dc:Bounds x="795" y="215" width="50" height="50" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0t10w0i_di" bpmnElement="CALCULATE_TOTAL_PAYMENT">
-        <dc:Bounds x="1270" y="883" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_0mav3nh_di" bpmnElement="Gateway_0mav3nh" isMarkerVisible="true">
         <dc:Bounds x="885" y="595" width="50" height="50" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="882" y="551" width="55" height="40" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0cgphdc_di" bpmnElement="CLEAR_PAYMENT_VALS">
-        <dc:Bounds x="1080" y="580" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0a5g615_di" bpmnElement="Gateway_0a5g615" isMarkerVisible="true">
-        <dc:Bounds x="885" y="695" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="816" y="700" width="68" height="40" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0pdtuba_di" bpmnElement="Gateway_0pdtuba" isMarkerVisible="true">
-        <dc:Bounds x="885" y="795" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="806" y="836" width="87" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0ezmc9t_di" bpmnElement="CLEAR_CONSOL_VAL">
-        <dc:Bounds x="1080" y="680" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0hcqj37_di" bpmnElement="CLEAR_EXGRATIA_VAL">
-        <dc:Bounds x="1080" y="780" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0tf16js_di" bpmnElement="Gateway_0tf16js" isMarkerVisible="true">
-        <dc:Bounds x="1485" y="595" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1425" y="643" width="69" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_09xwkjb_di" bpmnElement="Validate_Escalate">
-        <dc:Bounds x="1460" y="400" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0hn5mnb_di" bpmnElement="Save_Note">
-        <dc:Bounds x="1750" y="400" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_01ihebc_di" bpmnElement="Gateway_01ihebc" isMarkerVisible="true">
-        <dc:Bounds x="1585" y="415" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_05ok60y_di" bpmnElement="Gateway_05ok60y" isMarkerVisible="true">
-        <dc:Bounds x="1675" y="415" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_075jzz1_di" bpmnElement="Gateway_075jzz1" isMarkerVisible="true">
         <dc:Bounds x="1295" y="595" width="50" height="50" />
@@ -589,26 +579,29 @@
       <bpmndi:BPMNShape id="Activity_0onep8q_di" bpmnElement="CLEAR_REQUESTED_AMOUNT">
         <dc:Bounds x="1460" y="700" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_0pmmumb_di" bpmnElement="EndEvent_BF_TRIAGE">
-        <dc:Bounds x="2162" y="602" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_0ezmc9t_di" bpmnElement="CLEAR_CONSOL_VAL">
+        <dc:Bounds x="1080" y="700" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_13taydb_di" bpmnElement="Activity_13taydb">
-        <dc:Bounds x="2030" y="700" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0drd59m_di" bpmnElement="Gateway_0drd59m" isMarkerVisible="true">
-        <dc:Bounds x="1925" y="715" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1g7b2fa_di" bpmnElement="Gateway_1g7b2fa" isMarkerVisible="true">
-        <dc:Bounds x="1925" y="878" width="50" height="50" />
+      <bpmndi:BPMNShape id="Gateway_0a5g615_di" bpmnElement="Gateway_0a5g615" isMarkerVisible="true">
+        <dc:Bounds x="885" y="715" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1065" y="486" width="76" height="14" />
+          <dc:Bounds x="816" y="720" width="68" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0ui0b1l_di" bpmnElement="Complete_Reason">
-        <dc:Bounds x="1750" y="700" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_0cgphdc_di" bpmnElement="CLEAR_PAYMENT_VALS">
+        <dc:Bounds x="1080" y="580" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0yi6phj_di" bpmnElement="Validate_Complete_Reason">
-        <dc:Bounds x="1750" y="863" width="100" height="80" />
+      <bpmndi:BPMNShape id="Gateway_0pdtuba_di" bpmnElement="Gateway_0pdtuba" isMarkerVisible="true">
+        <dc:Bounds x="885" y="845" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="806" y="886" width="87" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hcqj37_di" bpmnElement="CLEAR_EXGRATIA_VAL">
+        <dc:Bounds x="1080" y="830" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0t10w0i_di" bpmnElement="CALCULATE_TOTAL_PAYMENT">
+        <dc:Bounds x="1270" y="830" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/BF2/BF2_TRIAGE.bpmn
+++ b/src/main/resources/processes/BF2/BF2_TRIAGE.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_0a8virv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.8.1">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" id="Definitions_0a8virv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <bpmn:process id="BF2_TRIAGE" isExecutable="true">
     <bpmn:endEvent id="EndEvent_BF2_TRIAGE">
       <bpmn:incoming>Flow_1bnsbkw</bpmn:incoming>
@@ -184,14 +184,12 @@
     <bpmn:sequenceFlow id="Flow_1wx1rxx" sourceRef="Gateway_1h4oewh" targetRef="Transfer_Case">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="Gateway_15ofe6q" name="Payment Calculation Required? ">
+    <bpmn:exclusiveGateway id="Gateway_15ofe6q" name="Payment Calculation Required? " default="Flow_0d9fah3">
       <bpmn:incoming>Flow_0tijz6t</bpmn:incoming>
       <bpmn:outgoing>Flow_0d9fah3</bpmn:outgoing>
       <bpmn:outgoing>Flow_19yumih</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="Flow_0d9fah3" name="No" sourceRef="Gateway_15ofe6q" targetRef="CLEAR_PAYMENT_VALS">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ !"Yes".equals(PaymentTypeConsolatory) &amp;&amp; !"Yes".equals(PaymentTypeExGratia) }</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0d9fah3" sourceRef="Gateway_15ofe6q" targetRef="CLEAR_PAYMENT_VALS" />
     <bpmn:serviceTask id="CLEAR_PAYMENT_VALS" name="Clear Payment Values" camunda:expression="${bpmnService.blankCaseValues(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, &#34;TotalOfferSentToComplainant&#34;, &#34;ConsolatoryOfferSentToComplainant&#34;, &#34;ExGratiaOfferSentToComplainant&#34;)}">
       <bpmn:incoming>Flow_0d9fah3</bpmn:incoming>
       <bpmn:outgoing>Flow_0oimwgq</bpmn:outgoing>
@@ -213,30 +211,26 @@
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="Flow_13cge8n" sourceRef="CALCULATE_TOTAL_PAYMENT" targetRef="Gateway_1se1mck" />
     <bpmn:sequenceFlow id="Flow_19yumih" name="Yes" sourceRef="Gateway_15ofe6q" targetRef="Gateway_1v2cm5i">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "Yes".equals(PaymentTypeConsolatory) || "Yes".equals(PaymentTypeExGratia) }</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "Yes" == execution.getVariable("PaymentTypeConsolatory") || "Yes" == execution.getVariable("PaymentTypeExGratia") }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="Gateway_1v2cm5i" name="Payment type Consolatory applied?">
+    <bpmn:exclusiveGateway id="Gateway_1v2cm5i" name="Payment type Consolatory applied?" default="Flow_11ccb1y">
       <bpmn:incoming>Flow_19yumih</bpmn:incoming>
       <bpmn:outgoing>Flow_1631hev</bpmn:outgoing>
       <bpmn:outgoing>Flow_11ccb1y</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_1631hev" name="Yes" sourceRef="Gateway_1v2cm5i" targetRef="Gateway_0hfb2hq">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "Yes".equals(PaymentTypeConsolatory) }</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "Yes" == execution.getVariable("PaymentTypeConsolatory") }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="Gateway_0hfb2hq" name="Payment type Ex-Gratia applied?">
+    <bpmn:exclusiveGateway id="Gateway_0hfb2hq" name="Payment type Ex-Gratia applied?" default="Flow_06ua4oq">
       <bpmn:incoming>Flow_1631hev</bpmn:incoming>
       <bpmn:outgoing>Flow_1f9bk3n</bpmn:outgoing>
       <bpmn:outgoing>Flow_06ua4oq</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_1f9bk3n" name="Yes" sourceRef="Gateway_0hfb2hq" targetRef="CALCULATE_TOTAL_PAYMENT">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "Yes".equals(PaymentTypeExGratia) }</bpmn:conditionExpression>
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "Yes" == execution.getVariable("PaymentTypeExGratia") }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_11ccb1y" name="No" sourceRef="Gateway_1v2cm5i" targetRef="CLEAR_CONSOL_VAL">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "No".equals(PaymentTypeConsolatory) }</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_06ua4oq" name="No" sourceRef="Gateway_0hfb2hq" targetRef="CLEAR_EXGRATIA_VAL">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ "No".equals(PaymentTypeExGratia) }</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_11ccb1y" sourceRef="Gateway_1v2cm5i" targetRef="CLEAR_CONSOL_VAL" />
+    <bpmn:sequenceFlow id="Flow_06ua4oq" sourceRef="Gateway_0hfb2hq" targetRef="CLEAR_EXGRATIA_VAL" />
     <bpmn:sequenceFlow id="Flow_1p419fd" sourceRef="CLEAR_EXGRATIA_VAL" targetRef="CALCULATE_TOTAL_PAYMENT" />
     <bpmn:sequenceFlow id="Flow_0d0eket" sourceRef="CLEAR_CONSOL_VAL" targetRef="CALCULATE_TOTAL_PAYMENT" />
     <bpmn:exclusiveGateway id="Gateway_1se1mck" name="Complaint Requested Payment?">
@@ -259,7 +253,26 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="BF2_TRIAGE">
-      <bpmndi:BPMNEdge id="Flow_0d0eket_di" bpmnElement="Flow_0d0eket">
+      <bpmndi:BPMNEdge id="Flow_01qhktf_di" bpmnElement="Flow_01qhktf">
+        <di:waypoint x="1620" y="670" />
+        <di:waypoint x="1620" y="595" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0l246b7_di" bpmnElement="Flow_0l246b7">
+        <di:waypoint x="1402" y="583" />
+        <di:waypoint x="1520" y="710" />
+        <di:waypoint x="1570" y="710" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1422" y="623" width="15" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0kr6hjo_di" bpmnElement="Flow_0kr6hjo">
+        <di:waypoint x="1415" y="570" />
+        <di:waypoint x="1595" y="570" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1451" y="552" width="18" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0d0eket_di" bpmnElement="Flow_0d0eket" bioc:stroke="#e53935" color:border-color="#e53935">
         <di:waypoint x="1200" y="670" />
         <di:waypoint x="1270" y="670" />
         <di:waypoint x="1270" y="890" />
@@ -390,46 +403,6 @@
         <di:waypoint x="640" y="290" />
         <di:waypoint x="640" y="530" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0nvtbw4_di" bpmnElement="Flow_0nvtbw4">
-        <di:waypoint x="2080" y="898" />
-        <di:waypoint x="2080" y="990" />
-        <di:waypoint x="620" y="990" />
-        <di:waypoint x="620" y="610" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1bnsbkw_di" bpmnElement="Flow_1bnsbkw">
-        <di:waypoint x="2240" y="710" />
-        <di:waypoint x="2320" y="710" />
-        <di:waypoint x="2320" y="588" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1k4hd8y_di" bpmnElement="Flow_1k4hd8y">
-        <di:waypoint x="1632" y="583" />
-        <di:waypoint x="1740" y="710" />
-        <di:waypoint x="1900" y="710" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1686" y="623" width="48" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0yqamon_di" bpmnElement="Flow_0yqamon">
-        <di:waypoint x="1608" y="557" />
-        <di:waypoint x="1440" y="370" />
-        <di:waypoint x="620" y="370" />
-        <di:waypoint x="620" y="530" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1529" y="515" width="41" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0tijz6t_di" bpmnElement="Flow_0tijz6t">
-        <di:waypoint x="755" y="570" />
-        <di:waypoint x="935" y="570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0nritne_di" bpmnElement="Flow_0nritne">
-        <di:waypoint x="670" y="570" />
-        <di:waypoint x="705" y="570" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0pawikq_di" bpmnElement="Flow_0pawikq">
-        <di:waypoint x="1645" y="570" />
-        <di:waypoint x="2302" y="570" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1hvxas2_di" bpmnElement="Flow_1hvxas2">
         <di:waypoint x="2000" y="390" />
         <di:waypoint x="2320" y="390" />
@@ -442,57 +415,23 @@
           <dc:Bounds x="1628" y="515" width="43" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1lgnaji_di" bpmnElement="Flow_1lgnaji">
-        <di:waypoint x="1830" y="365" />
-        <di:waypoint x="1830" y="320" />
-        <di:waypoint x="1620" y="320" />
-        <di:waypoint x="1620" y="350" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1jtzjzy_di" bpmnElement="Flow_1jtzjzy">
-        <di:waypoint x="1670" y="390" />
-        <di:waypoint x="1705" y="390" />
+      <bpmndi:BPMNEdge id="Flow_17hpetn_di" bpmnElement="Flow_17hpetn">
+        <di:waypoint x="1755" y="390" />
+        <di:waypoint x="1805" y="390" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_07vvmye_di" bpmnElement="Flow_07vvmye">
         <di:waypoint x="1855" y="390" />
         <di:waypoint x="1900" y="390" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17hpetn_di" bpmnElement="Flow_17hpetn">
-        <di:waypoint x="1755" y="390" />
-        <di:waypoint x="1805" y="390" />
+      <bpmndi:BPMNEdge id="Flow_1jtzjzy_di" bpmnElement="Flow_1jtzjzy">
+        <di:waypoint x="1670" y="390" />
+        <di:waypoint x="1705" y="390" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0kr6hjo_di" bpmnElement="Flow_0kr6hjo">
-        <di:waypoint x="1415" y="570" />
-        <di:waypoint x="1595" y="570" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1451" y="552" width="18" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0l246b7_di" bpmnElement="Flow_0l246b7">
-        <di:waypoint x="1402" y="583" />
-        <di:waypoint x="1520" y="710" />
-        <di:waypoint x="1570" y="710" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1422" y="623" width="15" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_01qhktf_di" bpmnElement="Flow_01qhktf">
-        <di:waypoint x="1620" y="670" />
-        <di:waypoint x="1620" y="595" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1ogj4fu_di" bpmnElement="Flow_1ogj4fu">
-        <di:waypoint x="2080" y="848" />
-        <di:waypoint x="2080" y="735" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19x2wtx_di" bpmnElement="Flow_19x2wtx">
-        <di:waypoint x="2055" y="710" />
-        <di:waypoint x="2000" y="710" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="989" y="311" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0qvdnyq_di" bpmnElement="Flow_0qvdnyq">
-        <di:waypoint x="2105" y="710" />
-        <di:waypoint x="2140" y="710" />
+      <bpmndi:BPMNEdge id="Flow_1lgnaji_di" bpmnElement="Flow_1lgnaji">
+        <di:waypoint x="1830" y="365" />
+        <di:waypoint x="1830" y="320" />
+        <di:waypoint x="1620" y="320" />
+        <di:waypoint x="1620" y="350" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1twhx74_di" bpmnElement="Flow_1twhx74">
         <di:waypoint x="2000" y="873" />
@@ -502,6 +441,64 @@
         <di:waypoint x="1950" y="750" />
         <di:waypoint x="1950" y="833" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nvtbw4_di" bpmnElement="Flow_0nvtbw4">
+        <di:waypoint x="2080" y="898" />
+        <di:waypoint x="2080" y="990" />
+        <di:waypoint x="620" y="990" />
+        <di:waypoint x="620" y="610" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1bnsbkw_di" bpmnElement="Flow_1bnsbkw">
+        <di:waypoint x="2240" y="710" />
+        <di:waypoint x="2320" y="710" />
+        <di:waypoint x="2320" y="588" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qvdnyq_di" bpmnElement="Flow_0qvdnyq">
+        <di:waypoint x="2105" y="710" />
+        <di:waypoint x="2140" y="710" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1k4hd8y_di" bpmnElement="Flow_1k4hd8y">
+        <di:waypoint x="1632" y="583" />
+        <di:waypoint x="1740" y="710" />
+        <di:waypoint x="1900" y="710" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1686" y="623" width="48" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19x2wtx_di" bpmnElement="Flow_19x2wtx">
+        <di:waypoint x="2055" y="710" />
+        <di:waypoint x="2000" y="710" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="989" y="311" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ogj4fu_di" bpmnElement="Flow_1ogj4fu">
+        <di:waypoint x="2080" y="848" />
+        <di:waypoint x="2080" y="735" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0yqamon_di" bpmnElement="Flow_0yqamon">
+        <di:waypoint x="1608" y="557" />
+        <di:waypoint x="1440" y="370" />
+        <di:waypoint x="620" y="370" />
+        <di:waypoint x="620" y="530" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1529" y="515" width="41" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0pawikq_di" bpmnElement="Flow_0pawikq">
+        <di:waypoint x="1645" y="570" />
+        <di:waypoint x="2302" y="570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0tijz6t_di" bpmnElement="Flow_0tijz6t">
+        <di:waypoint x="755" y="570" />
+        <di:waypoint x="935" y="570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nritne_di" bpmnElement="Flow_0nritne">
+        <di:waypoint x="670" y="570" />
+        <di:waypoint x="705" y="570" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0pmmumb_di" bpmnElement="EndEvent_BF2_TRIAGE">
+        <dc:Bounds x="2302" y="552" width="36" height="36" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_11s75w3_di" bpmnElement="Validate_Capture_Reason">
         <dc:Bounds x="570" y="530" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -510,6 +507,42 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="716" y="515" width="29" height="14" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0tf16js_di" bpmnElement="Gateway_0tf16js" isMarkerVisible="true">
+        <dc:Bounds x="1595" y="545" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1535" y="593" width="69" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0drd59m_di" bpmnElement="Gateway_0drd59m" isMarkerVisible="true">
+        <dc:Bounds x="2055" y="685" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1g7b2fa_di" bpmnElement="Gateway_1g7b2fa" isMarkerVisible="true">
+        <dc:Bounds x="2055" y="848" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1065" y="486" width="76" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ui0b1l_di" bpmnElement="Complete_Reason">
+        <dc:Bounds x="1900" y="670" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0yi6phj_di" bpmnElement="Validate_Complete_Reason">
+        <dc:Bounds x="1900" y="833" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_13taydb_di" bpmnElement="Activity_13taydb">
+        <dc:Bounds x="2140" y="670" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09xwkjb_di" bpmnElement="Validate_Escalate">
+        <dc:Bounds x="1570" y="350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hn5mnb_di" bpmnElement="Save_Note">
+        <dc:Bounds x="1900" y="350" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_01ihebc_di" bpmnElement="Gateway_01ihebc" isMarkerVisible="true">
+        <dc:Bounds x="1705" y="365" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_05ok60y_di" bpmnElement="Gateway_05ok60y" isMarkerVisible="true">
+        <dc:Bounds x="1805" y="365" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0jggixz_di" bpmnElement="Event_0jggixz">
         <dc:Bounds x="152" y="552" width="36" height="36" />
@@ -565,24 +598,6 @@
           <dc:Bounds x="846" y="756" width="87" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0tf16js_di" bpmnElement="Gateway_0tf16js" isMarkerVisible="true">
-        <dc:Bounds x="1595" y="545" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1535" y="593" width="69" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_09xwkjb_di" bpmnElement="Validate_Escalate">
-        <dc:Bounds x="1570" y="350" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0hn5mnb_di" bpmnElement="Save_Note">
-        <dc:Bounds x="1900" y="350" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_01ihebc_di" bpmnElement="Gateway_01ihebc" isMarkerVisible="true">
-        <dc:Bounds x="1705" y="365" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_05ok60y_di" bpmnElement="Gateway_05ok60y" isMarkerVisible="true">
-        <dc:Bounds x="1805" y="365" width="50" height="50" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1se1mck_di" bpmnElement="Gateway_1se1mck" isMarkerVisible="true">
         <dc:Bounds x="1365" y="545" width="50" height="50" />
         <bpmndi:BPMNLabel>
@@ -591,27 +606,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1fjpl5x_di" bpmnElement="CLEAR_REQUESTED_AMOUNT">
         <dc:Bounds x="1570" y="670" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="EndEvent_0pmmumb_di" bpmnElement="EndEvent_BF2_TRIAGE">
-        <dc:Bounds x="2302" y="552" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_13taydb_di" bpmnElement="Activity_13taydb">
-        <dc:Bounds x="2140" y="670" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0drd59m_di" bpmnElement="Gateway_0drd59m" isMarkerVisible="true">
-        <dc:Bounds x="2055" y="685" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1g7b2fa_di" bpmnElement="Gateway_1g7b2fa" isMarkerVisible="true">
-        <dc:Bounds x="2055" y="848" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1065" y="486" width="76" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0ui0b1l_di" bpmnElement="Complete_Reason">
-        <dc:Bounds x="1900" y="670" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0yi6phj_di" bpmnElement="Validate_Complete_Reason">
-        <dc:Bounds x="1900" y="833" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/bf/BF_TRIAGE.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/bf/BF_TRIAGE.java
@@ -238,7 +238,6 @@ public class BF_TRIAGE {
                         VALID, true,
                         "BFTriageResult", "Draft",
                         PAYMENT_TYPE_CONSOLATORY, YES,
-                        PAYMENT_TYPE_EXGRATIA, NO,
                         PAYMENT_REQUESTED, NO
                 )));
 
@@ -263,7 +262,6 @@ public class BF_TRIAGE {
                 .thenReturn(task -> task.complete(withVariables(
                         VALID, true,
                         "BFTriageResult", "Draft",
-                        PAYMENT_TYPE_CONSOLATORY, NO,
                         PAYMENT_TYPE_EXGRATIA, YES,
                         PAYMENT_REQUESTED, NO
                 )));

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/bf2/BF2_TRIAGE.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/bf2/BF2_TRIAGE.java
@@ -237,7 +237,6 @@ public class BF2_TRIAGE {
                         VALID, true,
                         "BFTriageResult", "Draft",
                         PAYMENT_TYPE_CONSOLATORY, YES,
-                        PAYMENT_TYPE_EXGRATIA, NO,
                         PAYMENT_REQUESTED, NO
                 )));
 
@@ -262,7 +261,6 @@ public class BF2_TRIAGE {
                 .thenReturn(task -> task.complete(withVariables(
                         VALID, true,
                         "BFTriageResult", "Draft",
-                        PAYMENT_TYPE_CONSOLATORY, NO,
                         PAYMENT_TYPE_EXGRATIA, YES,
                         PAYMENT_REQUESTED, NO
                 )));


### PR DESCRIPTION
If neither a 'Yes'/'No' value is passed to either the
`PaymentTypeConsolatory` or `PaymentTypeExGratia` at BF(2) Triage
but one is 'Yes' then a null exception is thrown by workflow. This
change reworks the expressions to have default flows to clear values and
also changes the 'Yes' expressions to be more readable.