### PR TITLE
HOCS-4768: add base POGR stage 2 flow 

### DIFF
--- a/src/main/resources/processes/POGR/POGR_GRO.bpmn
+++ b/src/main/resources/processes/POGR/POGR_GRO.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <bpmn:process id="POGR_GRO" isExecutable="true">
     <bpmn:startEvent id="StartEvent_Gro">
       <bpmn:outgoing>Flow_1twhwzx</bpmn:outgoing>
@@ -29,8 +29,8 @@
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1twhwzx</bpmn:incoming>
       <bpmn:incoming>Flow_1pe6gam</bpmn:incoming>
-      <bpmn:incoming>Flow_17wam1l</bpmn:incoming>
       <bpmn:incoming>Flow_0o3pbbn</bpmn:incoming>
+      <bpmn:incoming>Flow_17wam1l</bpmn:incoming>
       <bpmn:outgoing>Flow_0c34qe7</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="Flow_0c34qe7" sourceRef="CallActivity_PogrGroInvestigation" targetRef="Gateway_0tbhxzn" />
@@ -85,7 +85,7 @@
       <bpmn:outgoing>Flow_0vt2qm6</bpmn:outgoing>
       <bpmn:outgoing>Flow_17wam1l</bpmn:outgoing>
       <bpmn:outgoing>Flow_167shm2</bpmn:outgoing>
-      <bpmn:outgoing>Flow_0dgzshg</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0w1go6v</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_1wp5g18" name="Dispatch" sourceRef="Gateway_1kt8g50" targetRef="CallActivity_PogrGroDispatch">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DraftOutcome == "Dispatch" }</bpmn:conditionExpression>
@@ -125,21 +125,25 @@
         <camunda:in source="QAUserUUID" target="AllocatedUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_167shm2</bpmn:incoming>
+      <bpmn:incoming>Flow_0n6rl2w</bpmn:incoming>
       <bpmn:outgoing>Flow_09crvpm</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="Flow_167shm2" sourceRef="Gateway_1kt8g50" targetRef="CallActivity_PogrGroQa">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DraftOutcome == "QA" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="Gateway_1vzae9d" default="Flow_1g1jsaz">
+    <bpmn:exclusiveGateway id="Gateway_1vzae9d" default="Flow_0n6rl2w">
       <bpmn:incoming>Flow_09crvpm</bpmn:incoming>
       <bpmn:outgoing>Flow_0a3i2m9</bpmn:outgoing>
       <bpmn:outgoing>Flow_1g1jsaz</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0n6rl2w</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_09crvpm" sourceRef="CallActivity_PogrGroQa" targetRef="Gateway_1vzae9d" />
     <bpmn:sequenceFlow id="Flow_0a3i2m9" sourceRef="Gateway_1vzae9d" targetRef="CallActivity_PogrGroDispatch">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ QaOutcome == "Accept" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_1g1jsaz" sourceRef="Gateway_1vzae9d" targetRef="CallActivity_PogrGroDraft" />
+    <bpmn:sequenceFlow id="Flow_1g1jsaz" sourceRef="Gateway_1vzae9d" targetRef="CallActivity_PogrGroDraft">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ QaOutcome == "Reject" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
     <bpmn:callActivity id="CallActivity_PogrGroDispatch" name="Dispatch" calledElement="STAGE_WITH_USER">
       <bpmn:extensionElements>
         <camunda:in sourceExpression="POGR_GRO_DISPATCH" target="StageWorkFlow" />
@@ -176,57 +180,72 @@
         <camunda:out source="EscalationOutcome" target="EscalationOutcome" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1w9oeo1</bpmn:incoming>
-      <bpmn:incoming>Flow_0dgzshg</bpmn:incoming>
+      <bpmn:incoming>Flow_0pfihgc</bpmn:incoming>
+      <bpmn:incoming>Flow_0w1go6v</bpmn:incoming>
       <bpmn:outgoing>Flow_05k8rns</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:exclusiveGateway id="Gateway_1kd8gi5" default="Flow_0o3pbbn">
+    <bpmn:exclusiveGateway id="Gateway_1kd8gi5" default="Flow_0pfihgc">
       <bpmn:incoming>Flow_05k8rns</bpmn:incoming>
       <bpmn:outgoing>Flow_0o3pbbn</bpmn:outgoing>
       <bpmn:outgoing>Flow_141t6la</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0pfihgc</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_05k8rns" sourceRef="CallActivity_PogrGroEscalate" targetRef="Gateway_1kd8gi5" />
     <bpmn:sequenceFlow id="Flow_1w9oeo1" sourceRef="Gateway_0tbhxzn" targetRef="CallActivity_PogrGroEscalate">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ InvestigationOutcome == "Escalate" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0dgzshg" sourceRef="Gateway_1kt8g50" targetRef="CallActivity_PogrGroEscalate">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DraftOutcome == "Escalate" }</bpmn:conditionExpression>
+    <bpmn:sequenceFlow id="Flow_0o3pbbn" sourceRef="Gateway_1kd8gi5" targetRef="CallActivity_PogrGroInvestigation">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ EscalationOutcome == "Investigation" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0o3pbbn" sourceRef="Gateway_1kd8gi5" targetRef="CallActivity_PogrGroInvestigation" />
     <bpmn:sequenceFlow id="Flow_141t6la" sourceRef="Gateway_1kd8gi5" targetRef="CallActivity_PogrGroDraft">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ EscalationOutcome == "Draft" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0n6rl2w" sourceRef="Gateway_1vzae9d" targetRef="CallActivity_PogrGroQa" />
+    <bpmn:sequenceFlow id="Flow_0pfihgc" sourceRef="Gateway_1kd8gi5" targetRef="CallActivity_PogrGroEscalate" />
+    <bpmn:sequenceFlow id="Flow_0w1go6v" sourceRef="Gateway_1kt8g50" targetRef="CallActivity_PogrGroEscalate">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DraftOutcome == "Escalate" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR_GRO">
-      <bpmndi:BPMNEdge id="Flow_141t6la_di" bpmnElement="Flow_141t6la">
-        <di:waypoint x="585" y="550" />
-        <di:waypoint x="640" y="550" />
+      <bpmndi:BPMNEdge id="Flow_0pfihgc_di" bpmnElement="Flow_0pfihgc" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="910" y="505" />
+        <di:waypoint x="910" y="570" />
+        <di:waypoint x="780" y="570" />
+        <di:waypoint x="780" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0n6rl2w_di" bpmnElement="Flow_0n6rl2w" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="1100" y="234" />
+        <di:waypoint x="1100" y="150" />
+        <di:waypoint x="980" y="150" />
+        <di:waypoint x="980" y="219" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_141t6la_di" bpmnElement="Flow_141t6la" bioc:stroke="#fb8c00" color:border-color="#fb8c00">
+        <di:waypoint x="910" y="455" />
+        <di:waypoint x="910" y="390" />
+        <di:waypoint x="640" y="390" />
         <di:waypoint x="640" y="299" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0o3pbbn_di" bpmnElement="Flow_0o3pbbn">
-        <di:waypoint x="535" y="550" />
-        <di:waypoint x="330" y="550" />
+        <di:waypoint x="910" y="505" />
+        <di:waypoint x="910" y="610" />
+        <di:waypoint x="330" y="610" />
         <di:waypoint x="330" y="299" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0dgzshg_di" bpmnElement="Flow_0dgzshg">
-        <di:waypoint x="780" y="284" />
-        <di:waypoint x="780" y="440" />
-        <di:waypoint x="610" y="440" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1w9oeo1_di" bpmnElement="Flow_1w9oeo1">
         <di:waypoint x="460" y="284" />
-        <di:waypoint x="460" y="440" />
-        <di:waypoint x="510" y="440" />
+        <di:waypoint x="460" y="480" />
+        <di:waypoint x="730" y="480" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_05k8rns_di" bpmnElement="Flow_05k8rns">
-        <di:waypoint x="560" y="480" />
-        <di:waypoint x="560" y="525" />
+        <di:waypoint x="830" y="480" />
+        <di:waypoint x="885" y="480" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_19hatch_di" bpmnElement="Flow_19hatch">
         <di:waypoint x="1280" y="259" />
         <di:waypoint x="1332" y="259" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1g1jsaz_di" bpmnElement="Flow_1g1jsaz">
+      <bpmndi:BPMNEdge id="Flow_1g1jsaz_di" bpmnElement="Flow_1g1jsaz" bioc:stroke="#fb8c00" color:border-color="#fb8c00">
         <di:waypoint x="1100" y="284" />
         <di:waypoint x="1100" y="390" />
         <di:waypoint x="640" y="390" />
@@ -248,28 +267,28 @@
         <di:waypoint x="805" y="150" />
         <di:waypoint x="862" y="150" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_02httl1_di" bpmnElement="Flow_02httl1">
+      <bpmndi:BPMNEdge id="Flow_02httl1_di" bpmnElement="Flow_02httl1" bioc:stroke="#e53935" color:border-color="#e53935">
         <di:waypoint x="755" y="150" />
         <di:waypoint x="640" y="150" />
         <di:waypoint x="640" y="219" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17wam1l_di" bpmnElement="Flow_17wam1l">
+      <bpmndi:BPMNEdge id="Flow_17wam1l_di" bpmnElement="Flow_17wam1l" bioc:stroke="#43a047" color:border-color="#43a047">
         <di:waypoint x="780" y="284" />
-        <di:waypoint x="780" y="630" />
-        <di:waypoint x="330" y="630" />
+        <di:waypoint x="780" y="360" />
+        <di:waypoint x="330" y="360" />
         <di:waypoint x="330" y="299" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0vt2qm6_di" bpmnElement="Flow_0vt2qm6">
+      <bpmndi:BPMNEdge id="Flow_0vt2qm6_di" bpmnElement="Flow_0vt2qm6" bioc:stroke="#e53935" color:border-color="#e53935">
         <di:waypoint x="780" y="234" />
         <di:waypoint x="780" y="175" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1wp5g18_di" bpmnElement="Flow_1wp5g18">
-        <di:waypoint x="794" y="248" />
-        <di:waypoint x="860" y="190" />
-        <di:waypoint x="1230" y="190" />
-        <di:waypoint x="1230" y="219" />
+        <di:waypoint x="792" y="272" />
+        <di:waypoint x="860" y="340" />
+        <di:waypoint x="1230" y="340" />
+        <di:waypoint x="1230" y="299" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1024" y="172" width="43" height="14" />
+          <dc:Bounds x="1024" y="322" width="43" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_02fz0yv_di" bpmnElement="Flow_02fz0yv">
@@ -280,12 +299,12 @@
         <di:waypoint x="485" y="150" />
         <di:waypoint x="532" y="150" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1pe6gam_di" bpmnElement="Flow_1pe6gam">
+      <bpmndi:BPMNEdge id="Flow_1pe6gam_di" bpmnElement="Flow_1pe6gam" bioc:stroke="#e53935" color:border-color="#e53935">
         <di:waypoint x="435" y="150" />
         <di:waypoint x="330" y="150" />
         <di:waypoint x="330" y="219" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ac3n3p_di" bpmnElement="Flow_0ac3n3p">
+      <bpmndi:BPMNEdge id="Flow_0ac3n3p_di" bpmnElement="Flow_0ac3n3p" bioc:stroke="#e53935" color:border-color="#e53935">
         <di:waypoint x="460" y="234" />
         <di:waypoint x="460" y="175" />
       </bpmndi:BPMNEdge>
@@ -300,6 +319,10 @@
       <bpmndi:BPMNEdge id="Flow_1twhwzx_di" bpmnElement="Flow_1twhwzx">
         <di:waypoint x="215" y="259" />
         <di:waypoint x="280" y="259" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0w1go6v_di" bpmnElement="Flow_0w1go6v">
+        <di:waypoint x="780" y="284" />
+        <di:waypoint x="780" y="440" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_Gro">
         <dc:Bounds x="179" y="241" width="36" height="36" />
@@ -347,10 +370,10 @@
         <dc:Bounds x="1180" y="219" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_16iluj7_di" bpmnElement="CallActivity_PogrGroEscalate">
-        <dc:Bounds x="510" y="400" width="100" height="80" />
+        <dc:Bounds x="730" y="440" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1kd8gi5_di" bpmnElement="Gateway_1kd8gi5" isMarkerVisible="true">
-        <dc:Bounds x="535" y="525" width="50" height="50" />
+        <dc:Bounds x="885" y="455" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/POGR/POGR_HMPO.bpmn
+++ b/src/main/resources/processes/POGR/POGR_HMPO.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <bpmn:process id="POGR_HMPO" isExecutable="true">
     <bpmn:startEvent id="StartEvent_Hmpo">
       <bpmn:outgoing>Flow_1m1w4pf</bpmn:outgoing>
@@ -28,8 +28,8 @@
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1m1w4pf</bpmn:incoming>
       <bpmn:incoming>Flow_08g22s9</bpmn:incoming>
+      <bpmn:incoming>Flow_0ajdefo</bpmn:incoming>
       <bpmn:incoming>Flow_1wpf0yz</bpmn:incoming>
-      <bpmn:incoming>Flow_0b35gdf</bpmn:incoming>
       <bpmn:outgoing>Flow_0mp9wnv</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="Flow_0mp9wnv" sourceRef="CallActivity_PogrHmpoInvestigation" targetRef="Gateway_0ph73vq" />
@@ -72,8 +72,8 @@
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_080khuu</bpmn:incoming>
       <bpmn:incoming>Flow_1tfrnhg</bpmn:incoming>
-      <bpmn:incoming>Flow_0lq3kwv</bpmn:incoming>
       <bpmn:incoming>Flow_14sxnho</bpmn:incoming>
+      <bpmn:incoming>Flow_0aq2fgr</bpmn:incoming>
       <bpmn:outgoing>Flow_1oz5xon</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="Flow_1oz5xon" sourceRef="CallActivity_PogrHmpoDraft" targetRef="Gateway_08mh27j" />
@@ -86,7 +86,7 @@
       <bpmn:outgoing>Flow_1wpf0yz</bpmn:outgoing>
       <bpmn:outgoing>Flow_1rjw8ef</bpmn:outgoing>
       <bpmn:outgoing>Flow_1del5l1</bpmn:outgoing>
-      <bpmn:outgoing>Flow_00yq97a</bpmn:outgoing>
+      <bpmn:outgoing>Flow_05z8qi2</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_0obo8w9" sourceRef="Gateway_0fbkujt" targetRef="EndEvent_HmpoDraftEnd">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("CloseCase") == true }</bpmn:conditionExpression>
@@ -124,6 +124,7 @@
         <camunda:in source="QAUserUUID" target="AllocatedUserUUID" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1rjw8ef</bpmn:incoming>
+      <bpmn:incoming>Flow_0lq3kwv</bpmn:incoming>
       <bpmn:outgoing>Flow_11v7vw9</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="Flow_11v7vw9" sourceRef="CallActivity_PogrHmpoQa" targetRef="Gateway_1wmv5rn" />
@@ -134,11 +135,12 @@
       <bpmn:incoming>Flow_11v7vw9</bpmn:incoming>
       <bpmn:outgoing>Flow_1xvf5wx</bpmn:outgoing>
       <bpmn:outgoing>Flow_0lq3kwv</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0aq2fgr</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_1xvf5wx" sourceRef="Gateway_1wmv5rn" targetRef="CallActivity_PogrHmpoDispatch">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ QaOutcome == "Accept" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0lq3kwv" sourceRef="Gateway_1wmv5rn" targetRef="CallActivity_PogrHmpoDraft" />
+    <bpmn:sequenceFlow id="Flow_0lq3kwv" sourceRef="Gateway_1wmv5rn" targetRef="CallActivity_PogrHmpoQa" />
     <bpmn:callActivity id="CallActivity_PogrHmpoDispatch" name="Dispatch" calledElement="STAGE_WITH_USER">
       <bpmn:extensionElements>
         <camunda:in sourceExpression="POGR_HMPO_DISPATCH" target="StageWorkFlow" />
@@ -175,98 +177,115 @@
         <camunda:out source="EscalationOutcome" target="EscalationOutcome" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_05c2dd5</bpmn:incoming>
-      <bpmn:incoming>Flow_00yq97a</bpmn:incoming>
+      <bpmn:incoming>Flow_0b35gdf</bpmn:incoming>
+      <bpmn:incoming>Flow_05z8qi2</bpmn:incoming>
       <bpmn:outgoing>Flow_1vchjhj</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:exclusiveGateway id="Gateway_157w6qt" default="Flow_0b35gdf">
       <bpmn:incoming>Flow_1vchjhj</bpmn:incoming>
       <bpmn:outgoing>Flow_14sxnho</bpmn:outgoing>
       <bpmn:outgoing>Flow_0b35gdf</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ajdefo</bpmn:outgoing>
     </bpmn:exclusiveGateway>
     <bpmn:sequenceFlow id="Flow_1vchjhj" sourceRef="CallActivity_PogrHmpoEscalate" targetRef="Gateway_157w6qt" />
     <bpmn:sequenceFlow id="Flow_05c2dd5" sourceRef="Gateway_0ph73vq" targetRef="CallActivity_PogrHmpoEscalate">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ InvestigationOutcome == "Escalate" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_00yq97a" sourceRef="Gateway_08mh27j" targetRef="CallActivity_PogrHmpoEscalate">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DraftOutcome == "Escalate" }</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_14sxnho" sourceRef="Gateway_157w6qt" targetRef="CallActivity_PogrHmpoDraft">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ EscalationOutcome == "Draft" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0b35gdf" sourceRef="Gateway_157w6qt" targetRef="CallActivity_PogrHmpoInvestigation" />
+    <bpmn:sequenceFlow id="Flow_0b35gdf" sourceRef="Gateway_157w6qt" targetRef="CallActivity_PogrHmpoEscalate" />
+    <bpmn:sequenceFlow id="Flow_0ajdefo" sourceRef="Gateway_157w6qt" targetRef="CallActivity_PogrHmpoInvestigation">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ EscalationOutcome == "Investigation" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0aq2fgr" sourceRef="Gateway_1wmv5rn" targetRef="CallActivity_PogrHmpoDraft">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ QaOutcome == "Reject" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_05z8qi2" sourceRef="Gateway_08mh27j" targetRef="CallActivity_PogrHmpoEscalate">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DraftOutcome == "Escalate" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR_HMPO">
-      <bpmndi:BPMNEdge id="Flow_0b35gdf_di" bpmnElement="Flow_0b35gdf">
-        <di:waypoint x="525" y="470" />
-        <di:waypoint x="320" y="470" />
-        <di:waypoint x="320" y="229" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_14sxnho_di" bpmnElement="Flow_14sxnho">
-        <di:waypoint x="575" y="470" />
-        <di:waypoint x="640" y="470" />
-        <di:waypoint x="640" y="229" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_00yq97a_di" bpmnElement="Flow_00yq97a">
-        <di:waypoint x="760" y="214" />
-        <di:waypoint x="760" y="360" />
-        <di:waypoint x="600" y="360" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_05c2dd5_di" bpmnElement="Flow_05c2dd5">
-        <di:waypoint x="440" y="214" />
-        <di:waypoint x="440" y="360" />
-        <di:waypoint x="500" y="360" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1vchjhj_di" bpmnElement="Flow_1vchjhj">
-        <di:waypoint x="550" y="400" />
-        <di:waypoint x="550" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_09ux94z_di" bpmnElement="Flow_09ux94z">
-        <di:waypoint x="1270" y="189" />
-        <di:waypoint x="1332" y="189" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0lq3kwv_di" bpmnElement="Flow_0lq3kwv">
-        <di:waypoint x="1090" y="214" />
-        <di:waypoint x="1090" y="310" />
+      <bpmndi:BPMNEdge id="Flow_0aq2fgr_di" bpmnElement="Flow_0aq2fgr" bioc:stroke="#fb8c00" color:border-color="#fb8c00">
+        <di:waypoint x="1150" y="214" />
+        <di:waypoint x="1150" y="310" />
         <di:waypoint x="640" y="310" />
         <di:waypoint x="640" y="229" />
       </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ajdefo_di" bpmnElement="Flow_0ajdefo">
+        <di:waypoint x="920" y="425" />
+        <di:waypoint x="920" y="540" />
+        <di:waypoint x="320" y="540" />
+        <di:waypoint x="320" y="229" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b35gdf_di" bpmnElement="Flow_0b35gdf" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="920" y="425" />
+        <di:waypoint x="920" y="490" />
+        <di:waypoint x="760" y="490" />
+        <di:waypoint x="760" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14sxnho_di" bpmnElement="Flow_14sxnho" bioc:stroke="#fb8c00" color:border-color="#fb8c00">
+        <di:waypoint x="920" y="375" />
+        <di:waypoint x="920" y="310" />
+        <di:waypoint x="640" y="310" />
+        <di:waypoint x="640" y="229" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05c2dd5_di" bpmnElement="Flow_05c2dd5">
+        <di:waypoint x="440" y="214" />
+        <di:waypoint x="440" y="400" />
+        <di:waypoint x="710" y="400" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vchjhj_di" bpmnElement="Flow_1vchjhj">
+        <di:waypoint x="810" y="400" />
+        <di:waypoint x="895" y="400" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09ux94z_di" bpmnElement="Flow_09ux94z">
+        <di:waypoint x="1330" y="189" />
+        <di:waypoint x="1392" y="189" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lq3kwv_di" bpmnElement="Flow_0lq3kwv" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="1150" y="164" />
+        <di:waypoint x="1150" y="80" />
+        <di:waypoint x="1020" y="80" />
+        <di:waypoint x="1020" y="149" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1xvf5wx_di" bpmnElement="Flow_1xvf5wx">
-        <di:waypoint x="1115" y="189" />
-        <di:waypoint x="1170" y="189" />
+        <di:waypoint x="1175" y="189" />
+        <di:waypoint x="1230" y="189" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1del5l1_di" bpmnElement="Flow_1del5l1">
-        <di:waypoint x="775" y="179" />
-        <di:waypoint x="850" y="120" />
-        <di:waypoint x="1220" y="120" />
-        <di:waypoint x="1220" y="149" />
+        <di:waypoint x="772" y="202" />
+        <di:waypoint x="850" y="280" />
+        <di:waypoint x="1280" y="280" />
+        <di:waypoint x="1280" y="229" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1014" y="102" width="43" height="14" />
+          <dc:Bounds x="1044" y="262" width="43" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_11v7vw9_di" bpmnElement="Flow_11v7vw9">
-        <di:waypoint x="1010" y="189" />
-        <di:waypoint x="1065" y="189" />
+        <di:waypoint x="1070" y="189" />
+        <di:waypoint x="1125" y="189" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1rjw8ef_di" bpmnElement="Flow_1rjw8ef">
         <di:waypoint x="785" y="189" />
-        <di:waypoint x="910" y="189" />
+        <di:waypoint x="970" y="189" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1tfrnhg_di" bpmnElement="Flow_1tfrnhg">
+      <bpmndi:BPMNEdge id="Flow_1tfrnhg_di" bpmnElement="Flow_1tfrnhg" bioc:stroke="#e53935" color:border-color="#e53935">
         <di:waypoint x="735" y="80" />
         <di:waypoint x="640" y="80" />
         <di:waypoint x="640" y="149" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1wpf0yz_di" bpmnElement="Flow_1wpf0yz">
+      <bpmndi:BPMNEdge id="Flow_1wpf0yz_di" bpmnElement="Flow_1wpf0yz" bioc:stroke="#43a047" color:border-color="#43a047">
         <di:waypoint x="760" y="214" />
-        <di:waypoint x="760" y="550" />
-        <di:waypoint x="320" y="550" />
+        <di:waypoint x="760" y="270" />
+        <di:waypoint x="320" y="270" />
         <di:waypoint x="320" y="229" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="545" y="296" width="62" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1skjq0z_di" bpmnElement="Flow_1skjq0z">
+      <bpmndi:BPMNEdge id="Flow_1skjq0z_di" bpmnElement="Flow_1skjq0z" bioc:stroke="#e53935" color:border-color="#e53935">
         <di:waypoint x="760" y="164" />
         <di:waypoint x="760" y="105" />
       </bpmndi:BPMNEdge>
@@ -278,7 +297,7 @@
         <di:waypoint x="690" y="189" />
         <di:waypoint x="735" y="189" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_08g22s9_di" bpmnElement="Flow_08g22s9">
+      <bpmndi:BPMNEdge id="Flow_08g22s9_di" bpmnElement="Flow_08g22s9" bioc:stroke="#e53935" color:border-color="#e53935">
         <di:waypoint x="415" y="80" />
         <di:waypoint x="320" y="80" />
         <di:waypoint x="320" y="149" />
@@ -287,7 +306,7 @@
         <di:waypoint x="465" y="80" />
         <di:waypoint x="512" y="80" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1lew7z0_di" bpmnElement="Flow_1lew7z0">
+      <bpmndi:BPMNEdge id="Flow_1lew7z0_di" bpmnElement="Flow_1lew7z0" bioc:stroke="#e53935" color:border-color="#e53935">
         <di:waypoint x="440" y="164" />
         <di:waypoint x="440" y="105" />
       </bpmndi:BPMNEdge>
@@ -302,6 +321,10 @@
       <bpmndi:BPMNEdge id="Flow_1m1w4pf_di" bpmnElement="Flow_1m1w4pf">
         <di:waypoint x="215" y="189" />
         <di:waypoint x="270" y="189" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05z8qi2_di" bpmnElement="Flow_05z8qi2">
+        <di:waypoint x="760" y="214" />
+        <di:waypoint x="760" y="360" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_Hmpo">
         <dc:Bounds x="179" y="171" width="36" height="36" />
@@ -337,22 +360,22 @@
         <dc:Bounds x="735" y="55" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0wby6am_di" bpmnElement="EndEvent_Hmpo">
-        <dc:Bounds x="1332" y="171" width="36" height="36" />
+        <dc:Bounds x="1392" y="171" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_09g92t3_di" bpmnElement="CallActivity_PogrHmpoQa">
-        <dc:Bounds x="910" y="149" width="100" height="80" />
+        <dc:Bounds x="970" y="149" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1wmv5rn_di" bpmnElement="Gateway_1wmv5rn" isMarkerVisible="true">
-        <dc:Bounds x="1065" y="164" width="50" height="50" />
+        <dc:Bounds x="1125" y="164" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0ht2mbu_di" bpmnElement="CallActivity_PogrHmpoDispatch">
-        <dc:Bounds x="1170" y="149" width="100" height="80" />
+        <dc:Bounds x="1230" y="149" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0mndufl_di" bpmnElement="CallActivity_PogrHmpoEscalate">
-        <dc:Bounds x="500" y="320" width="100" height="80" />
+        <dc:Bounds x="710" y="360" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_157w6qt_di" bpmnElement="Gateway_157w6qt" isMarkerVisible="true">
-        <dc:Bounds x="525" y="445" width="50" height="50" />
+        <dc:Bounds x="895" y="375" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/POGR2/POGR2.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2.bpmn
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_13upkgq" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_13upkgq" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="POGR2" isExecutable="true">
     <bpmn:startEvent id="StartEvent_POGR2">
       <bpmn:outgoing>Flow_0c8wdx7</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:endEvent id="EndEvent_POGR2">
-      <bpmn:incoming>Flow_0vbkq83</bpmn:incoming>
-    </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_0c8wdx7" sourceRef="StartEvent_POGR2" targetRef="CallActivity_RegistrationStage" />
     <bpmn:callActivity id="CallActivity_RegistrationStage" name="Registration" calledElement="STAGE">
       <bpmn:extensionElements>
@@ -28,40 +25,107 @@
         <camunda:in source="BusinessArea" target="BusinessArea" />
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0c8wdx7</bpmn:incoming>
-      <bpmn:outgoing>Flow_0g71sdp</bpmn:outgoing>
+      <bpmn:outgoing>Flow_10bbmrb</bpmn:outgoing>
     </bpmn:callActivity>
-    <bpmn:sequenceFlow id="Flow_0g71sdp" sourceRef="CallActivity_RegistrationStage" targetRef="ServiceTask_CompleteCase" />
+    <bpmn:endEvent id="EndEvent_POGR2" name="End Case">
+      <bpmn:incoming>Flow_0v5rzlu</bpmn:incoming>
+    </bpmn:endEvent>
     <bpmn:serviceTask id="ServiceTask_CompleteCase" name="Complete Case" camunda:expression="${bpmnService.completeCase(execution.processBusinessKey)}">
-      <bpmn:incoming>Flow_0g71sdp</bpmn:incoming>
-      <bpmn:outgoing>Flow_0vbkq83</bpmn:outgoing>
+      <bpmn:incoming>Flow_0goula5</bpmn:incoming>
+      <bpmn:incoming>Flow_1jfz8tn</bpmn:incoming>
+      <bpmn:outgoing>Flow_0v5rzlu</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_0vbkq83" sourceRef="ServiceTask_CompleteCase" targetRef="EndEvent_POGR2" />
+    <bpmn:callActivity id="CallActivity_PogrHmpo" name="HMPO" calledElement="POGR2_HMPO">
+      <bpmn:extensionElements>
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0tbzsse</bpmn:incoming>
+      <bpmn:outgoing>Flow_0goula5</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_1eiolt1">
+      <bpmn:incoming>Flow_10bbmrb</bpmn:incoming>
+      <bpmn:outgoing>Flow_0tbzsse</bpmn:outgoing>
+      <bpmn:outgoing>Flow_05kcm78</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:callActivity id="CallActivity_PogrGro" name="GRO" calledElement="POGR2_GRO">
+      <bpmn:extensionElements>
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_05kcm78</bpmn:incoming>
+      <bpmn:outgoing>Flow_1jfz8tn</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0v5rzlu" sourceRef="ServiceTask_CompleteCase" targetRef="EndEvent_POGR2" />
+    <bpmn:sequenceFlow id="Flow_0goula5" sourceRef="CallActivity_PogrHmpo" targetRef="ServiceTask_CompleteCase" />
+    <bpmn:sequenceFlow id="Flow_1jfz8tn" sourceRef="CallActivity_PogrGro" targetRef="ServiceTask_CompleteCase" />
+    <bpmn:sequenceFlow id="Flow_0tbzsse" sourceRef="Gateway_1eiolt1" targetRef="CallActivity_PogrHmpo">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("BusinessArea") == "HMPO" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_05kcm78" sourceRef="Gateway_1eiolt1" targetRef="CallActivity_PogrGro">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("BusinessArea") == "GRO" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_10bbmrb" sourceRef="CallActivity_RegistrationStage" targetRef="Gateway_1eiolt1" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2">
-      <bpmndi:BPMNEdge id="Flow_0g71sdp_di" bpmnElement="Flow_0g71sdp">
-        <di:waypoint x="350" y="97" />
-        <di:waypoint x="390" y="97" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0c8wdx7_di" bpmnElement="Flow_0c8wdx7">
-        <di:waypoint x="188" y="97" />
-        <di:waypoint x="250" y="97" />
+        <di:waypoint x="188" y="197" />
+        <di:waypoint x="250" y="197" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0vbkq83_di" bpmnElement="Flow_0vbkq83">
-        <di:waypoint x="490" y="97" />
-        <di:waypoint x="532" y="97" />
+      <bpmndi:BPMNEdge id="Flow_10bbmrb_di" bpmnElement="Flow_10bbmrb">
+        <di:waypoint x="350" y="197" />
+        <di:waypoint x="405" y="197" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v5rzlu_di" bpmnElement="Flow_0v5rzlu">
+        <di:waypoint x="760" y="197" />
+        <di:waypoint x="802" y="197" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0goula5_di" bpmnElement="Flow_0goula5">
+        <di:waypoint x="570" y="118" />
+        <di:waypoint x="609" y="118" />
+        <di:waypoint x="609" y="197" />
+        <di:waypoint x="660" y="197" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1jfz8tn_di" bpmnElement="Flow_1jfz8tn">
+        <di:waypoint x="570" y="288" />
+        <di:waypoint x="609" y="288" />
+        <di:waypoint x="609" y="197" />
+        <di:waypoint x="660" y="197" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0tbzsse_di" bpmnElement="Flow_0tbzsse">
+        <di:waypoint x="430" y="172" />
+        <di:waypoint x="430" y="118" />
+        <di:waypoint x="470" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05kcm78_di" bpmnElement="Flow_05kcm78">
+        <di:waypoint x="430" y="222" />
+        <di:waypoint x="430" y="288" />
+        <di:waypoint x="470" y="288" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_POGR2">
-        <dc:Bounds x="152" y="79" width="36" height="36" />
+        <dc:Bounds x="152" y="179" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0inploq_di" bpmnElement="CallActivity_RegistrationStage">
-        <dc:Bounds x="250" y="57" width="100" height="80" />
+        <dc:Bounds x="250" y="157" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0cuim7o_di" bpmnElement="ServiceTask_CompleteCase">
-        <dc:Bounds x="390" y="57" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_1ne9y4u_di" bpmnElement="EndEvent_POGR2">
+        <dc:Bounds x="802" y="179" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="847" y="190" width="49" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_0gpzas7_di" bpmnElement="EndEvent_POGR2">
-        <dc:Bounds x="532" y="79" width="36" height="36" />
+      <bpmndi:BPMNShape id="Activity_1a1ch11_di" bpmnElement="ServiceTask_CompleteCase">
+        <dc:Bounds x="660" y="157" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1eiolt1_di" bpmnElement="Gateway_1eiolt1" isMarkerVisible="true">
+        <dc:Bounds x="405" y="172" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1bwtx8f_di" bpmnElement="CallActivity_PogrHmpo">
+        <dc:Bounds x="470" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_15wpte0_di" bpmnElement="CallActivity_PogrGro">
+        <dc:Bounds x="470" y="248" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/POGR2/POGR2_GRO.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2_GRO.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+  <bpmn:process id="POGR2_GRO" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Gro">
+      <bpmn:outgoing>Flow_0p6mzsj</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_Gro">
+      <bpmn:incoming>Flow_0p6mzsj</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0p6mzsj" sourceRef="StartEvent_Gro" targetRef="EndEvent_Gro" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2_GRO">
+      <bpmndi:BPMNEdge id="Flow_0p6mzsj_di" bpmnElement="Flow_0p6mzsj">
+        <di:waypoint x="215" y="99" />
+        <di:waypoint x="302" y="99" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_Gro">
+        <dc:Bounds x="179" y="81" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="172" y="254" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_Gro">
+        <dc:Bounds x="302" y="81" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="477" y="222" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR2/POGR2_GRO.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2_GRO.bpmn
@@ -1,31 +1,379 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <bpmn:process id="POGR2_GRO" isExecutable="true">
     <bpmn:startEvent id="StartEvent_Gro">
-      <bpmn:outgoing>Flow_0p6mzsj</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1twhwzx</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:endEvent id="EndEvent_Gro">
-      <bpmn:incoming>Flow_0p6mzsj</bpmn:incoming>
+      <bpmn:incoming>Flow_19hatch</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_0p6mzsj" sourceRef="StartEvent_Gro" targetRef="EndEvent_Gro" />
+    <bpmn:sequenceFlow id="Flow_1twhwzx" sourceRef="StartEvent_Gro" targetRef="CallActivity_PogrGroInvestigation" />
+    <bpmn:callActivity id="CallActivity_PogrGroInvestigation" name="Investigation" calledElement="STAGE_WITH_USER">
+      <bpmn:extensionElements>
+        <camunda:in source="InvestigationUUID" target="StageUUID" />
+        <camunda:in sourceExpression="POGR2_GRO_INVESTIGATION" target="StageWorkFlow" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+        <camunda:out source="StageUUID" target="InvestigationUUID" />
+        <camunda:in sourceExpression="POGR2_GRO_INVESTIGATION" target="StageType" />
+        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:out source="Stage" target="Stage" />
+        <camunda:in source="DraftTeamUUID" target="AllocationTeamUUID" />
+        <camunda:out source="CloseCase" target="CloseCase" />
+        <camunda:out source="InvestigationOutcome" target="InvestigationOutcome" />
+        <camunda:out source="LastUpdatedByUserUUID" target="DraftUserUUID" />
+        <camunda:in source="DraftUserUUID" target="AllocatedUserUUID" />
+        <camunda:out source="DraftTeamUUID" target="DraftTeamUUID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1twhwzx</bpmn:incoming>
+      <bpmn:incoming>Flow_1pe6gam</bpmn:incoming>
+      <bpmn:incoming>Flow_0o3pbbn</bpmn:incoming>
+      <bpmn:incoming>Flow_17wam1l</bpmn:incoming>
+      <bpmn:outgoing>Flow_0c34qe7</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0c34qe7" sourceRef="CallActivity_PogrGroInvestigation" targetRef="Gateway_0tbhxzn" />
+    <bpmn:exclusiveGateway id="Gateway_0tbhxzn" default="Flow_0ac3n3p">
+      <bpmn:incoming>Flow_0c34qe7</bpmn:incoming>
+      <bpmn:outgoing>Flow_1oaxdm7</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ac3n3p</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1w9oeo1</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1oaxdm7" sourceRef="Gateway_0tbhxzn" targetRef="CallActivity_PogrGroDraft">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ InvestigationOutcome == "Draft" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0ac3n3p" sourceRef="Gateway_0tbhxzn" targetRef="Gateway_09u60iz" />
+    <bpmn:exclusiveGateway id="Gateway_09u60iz" default="Flow_1pe6gam">
+      <bpmn:incoming>Flow_0ac3n3p</bpmn:incoming>
+      <bpmn:outgoing>Flow_1pe6gam</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1tlv10i</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1pe6gam" sourceRef="Gateway_09u60iz" targetRef="CallActivity_PogrGroInvestigation" />
+    <bpmn:sequenceFlow id="Flow_1tlv10i" sourceRef="Gateway_09u60iz" targetRef="EndEvent_GroInvestigationEnd">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("CloseCase") == true }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:callActivity id="CallActivity_PogrGroDraft" name="Draft" calledElement="STAGE_WITH_USER">
+      <bpmn:extensionElements>
+        <camunda:in source="DraftUUID" target="StageUUID" />
+        <camunda:in sourceExpression="POGR2_GRO_DRAFT" target="StageWorkFlow" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+        <camunda:out source="StageUUID" target="DraftUUID" />
+        <camunda:in sourceExpression="POGR2_GRO_DRAFT" target="StageType" />
+        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:out source="Stage" target="Stage" />
+        <camunda:in source="DraftTeamUUID" target="AllocationTeamUUID" />
+        <camunda:out source="DraftOutcome" target="DraftOutcome" />
+        <camunda:out source="CloseCase" target="CloseCase" />
+        <camunda:in source="DraftUserUUID" target="AllocatedUserUUID" />
+        <camunda:out source="LastUpdatedByUserUUID" target="DraftUserUUID" />
+        <camunda:out source="AllocationTeamUUID" target="DraftTeamUUID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1oaxdm7</bpmn:incoming>
+      <bpmn:incoming>Flow_02httl1</bpmn:incoming>
+      <bpmn:incoming>Flow_1g1jsaz</bpmn:incoming>
+      <bpmn:incoming>Flow_141t6la</bpmn:incoming>
+      <bpmn:outgoing>Flow_02fz0yv</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_02fz0yv" sourceRef="CallActivity_PogrGroDraft" targetRef="Gateway_1kt8g50" />
+    <bpmn:exclusiveGateway id="Gateway_1kt8g50" default="Flow_0vt2qm6">
+      <bpmn:incoming>Flow_02fz0yv</bpmn:incoming>
+      <bpmn:outgoing>Flow_1wp5g18</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0vt2qm6</bpmn:outgoing>
+      <bpmn:outgoing>Flow_17wam1l</bpmn:outgoing>
+      <bpmn:outgoing>Flow_167shm2</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0x2xtc3</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1wp5g18" name="Dispatch" sourceRef="Gateway_1kt8g50" targetRef="CallActivity_PogrGroDispatch">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DraftOutcome == "Dispatch" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="EndEvent_GroInvestigationEnd">
+      <bpmn:incoming>Flow_1tlv10i</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0vt2qm6" sourceRef="Gateway_1kt8g50" targetRef="Gateway_0m16v09" />
+    <bpmn:sequenceFlow id="Flow_17wam1l" sourceRef="Gateway_1kt8g50" targetRef="CallActivity_PogrGroInvestigation">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DraftOutcome == "ReturnInvestigation" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="EndEvent_GroDraftEnd">
+      <bpmn:incoming>Flow_1ixm0bm</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_0m16v09" default="Flow_02httl1">
+      <bpmn:incoming>Flow_0vt2qm6</bpmn:incoming>
+      <bpmn:outgoing>Flow_02httl1</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1ixm0bm</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_02httl1" sourceRef="Gateway_0m16v09" targetRef="CallActivity_PogrGroDraft" />
+    <bpmn:sequenceFlow id="Flow_1ixm0bm" sourceRef="Gateway_0m16v09" targetRef="EndEvent_GroDraftEnd">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("CloseCase") == true}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:callActivity id="CallActivity_PogrGroQa" name="QA" calledElement="STAGE_WITH_USER">
+      <bpmn:extensionElements>
+        <camunda:in sourceExpression="POGR2_GRO_QA" target="StageWorkFlow" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+        <camunda:in sourceExpression="POGR2_GRO_QA" target="StageType" />
+        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:out source="BusinessArea" target="BusinessArea" />
+        <camunda:out source="Stage" target="Stage" />
+        <camunda:out source="QaOutcome" target="QaOutcome" />
+        <camunda:out source="LastUpdatedByUserUUID" target="QAUserUUID" />
+        <camunda:in source="QAUserUUID" target="AllocatedUserUUID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_167shm2</bpmn:incoming>
+      <bpmn:incoming>Flow_0n6rl2w</bpmn:incoming>
+      <bpmn:outgoing>Flow_09crvpm</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_167shm2" sourceRef="Gateway_1kt8g50" targetRef="CallActivity_PogrGroQa">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DraftOutcome == "QA" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="Gateway_1vzae9d" default="Flow_0n6rl2w">
+      <bpmn:incoming>Flow_09crvpm</bpmn:incoming>
+      <bpmn:outgoing>Flow_0a3i2m9</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1g1jsaz</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0n6rl2w</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_09crvpm" sourceRef="CallActivity_PogrGroQa" targetRef="Gateway_1vzae9d" />
+    <bpmn:sequenceFlow id="Flow_0a3i2m9" sourceRef="Gateway_1vzae9d" targetRef="CallActivity_PogrGroDispatch">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ QaOutcome == "Accept" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1g1jsaz" sourceRef="Gateway_1vzae9d" targetRef="CallActivity_PogrGroDraft">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ QaOutcome == "Reject" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:callActivity id="CallActivity_PogrGroDispatch" name="Dispatch" calledElement="STAGE_WITH_USER">
+      <bpmn:extensionElements>
+        <camunda:in sourceExpression="POGR2_GRO_DISPATCH" target="StageWorkFlow" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+        <camunda:in sourceExpression="POGR2_GRO_DISPATCH" target="StageType" />
+        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:out source="BusinessArea" target="BusinessArea" />
+        <camunda:out source="Stage" target="Stage" />
+        <camunda:out source="DispatchOutcome" target="DispatchOutcome" />
+        <camunda:out source="LastUpdatedByUserUUID" target="DispatchUserUUID" />
+        <camunda:in source="DraftUserUUID" target="AllocatedUserUUID" />
+        <camunda:in source="DraftTeamUUID" target="AllocationTeamUUID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0a3i2m9</bpmn:incoming>
+      <bpmn:incoming>Flow_1wp5g18</bpmn:incoming>
+      <bpmn:outgoing>Flow_19hatch</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_19hatch" sourceRef="CallActivity_PogrGroDispatch" targetRef="EndEvent_Gro" />
+    <bpmn:callActivity id="CallActivity_PogrGroEscalate" name="Escalate" calledElement="STAGE">
+      <bpmn:extensionElements>
+        <camunda:in source="EscalationUUID" target="StageUUID" />
+        <camunda:in sourceExpression="POGR2_GRO_ESCALATE" target="StageWorkFlow" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+        <camunda:out source="StageUUID" target="EscalationUUID" />
+        <camunda:in sourceExpression="POGR2_GRO_ESCALATE" target="StageType" />
+        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:out source="Stage" target="Stage" />
+        <camunda:out source="EscalationOutcome" target="EscalationOutcome" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1w9oeo1</bpmn:incoming>
+      <bpmn:incoming>Flow_0pfihgc</bpmn:incoming>
+      <bpmn:incoming>Flow_0x2xtc3</bpmn:incoming>
+      <bpmn:outgoing>Flow_05k8rns</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_1kd8gi5" default="Flow_0pfihgc">
+      <bpmn:incoming>Flow_05k8rns</bpmn:incoming>
+      <bpmn:outgoing>Flow_0o3pbbn</bpmn:outgoing>
+      <bpmn:outgoing>Flow_141t6la</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0pfihgc</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_05k8rns" sourceRef="CallActivity_PogrGroEscalate" targetRef="Gateway_1kd8gi5" />
+    <bpmn:sequenceFlow id="Flow_1w9oeo1" sourceRef="Gateway_0tbhxzn" targetRef="CallActivity_PogrGroEscalate">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ InvestigationOutcome == "Escalate" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0o3pbbn" sourceRef="Gateway_1kd8gi5" targetRef="CallActivity_PogrGroInvestigation">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ EscalationOutcome == "Investigation" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_141t6la" sourceRef="Gateway_1kd8gi5" targetRef="CallActivity_PogrGroDraft">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ EscalationOutcome == "Draft" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0n6rl2w" sourceRef="Gateway_1vzae9d" targetRef="CallActivity_PogrGroQa" />
+    <bpmn:sequenceFlow id="Flow_0pfihgc" sourceRef="Gateway_1kd8gi5" targetRef="CallActivity_PogrGroEscalate" />
+    <bpmn:sequenceFlow id="Flow_0x2xtc3" sourceRef="Gateway_1kt8g50" targetRef="CallActivity_PogrGroEscalate">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DraftOutcome == "Escalate" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2_GRO">
-      <bpmndi:BPMNEdge id="Flow_0p6mzsj_di" bpmnElement="Flow_0p6mzsj">
-        <di:waypoint x="215" y="99" />
-        <di:waypoint x="302" y="99" />
+      <bpmndi:BPMNEdge id="Flow_0pfihgc_di" bpmnElement="Flow_0pfihgc" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="910" y="505" />
+        <di:waypoint x="910" y="570" />
+        <di:waypoint x="780" y="570" />
+        <di:waypoint x="780" y="520" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0n6rl2w_di" bpmnElement="Flow_0n6rl2w" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="1100" y="234" />
+        <di:waypoint x="1100" y="150" />
+        <di:waypoint x="980" y="150" />
+        <di:waypoint x="980" y="219" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_141t6la_di" bpmnElement="Flow_141t6la" bioc:stroke="#fb8c00" color:border-color="#fb8c00">
+        <di:waypoint x="910" y="455" />
+        <di:waypoint x="910" y="390" />
+        <di:waypoint x="640" y="390" />
+        <di:waypoint x="640" y="299" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0o3pbbn_di" bpmnElement="Flow_0o3pbbn">
+        <di:waypoint x="910" y="505" />
+        <di:waypoint x="910" y="610" />
+        <di:waypoint x="330" y="610" />
+        <di:waypoint x="330" y="299" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1w9oeo1_di" bpmnElement="Flow_1w9oeo1">
+        <di:waypoint x="460" y="284" />
+        <di:waypoint x="460" y="480" />
+        <di:waypoint x="730" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05k8rns_di" bpmnElement="Flow_05k8rns">
+        <di:waypoint x="830" y="480" />
+        <di:waypoint x="885" y="480" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19hatch_di" bpmnElement="Flow_19hatch">
+        <di:waypoint x="1280" y="259" />
+        <di:waypoint x="1332" y="259" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1g1jsaz_di" bpmnElement="Flow_1g1jsaz" bioc:stroke="#fb8c00" color:border-color="#fb8c00">
+        <di:waypoint x="1100" y="284" />
+        <di:waypoint x="1100" y="390" />
+        <di:waypoint x="640" y="390" />
+        <di:waypoint x="640" y="299" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0a3i2m9_di" bpmnElement="Flow_0a3i2m9">
+        <di:waypoint x="1125" y="259" />
+        <di:waypoint x="1180" y="259" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09crvpm_di" bpmnElement="Flow_09crvpm">
+        <di:waypoint x="1030" y="259" />
+        <di:waypoint x="1075" y="259" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_167shm2_di" bpmnElement="Flow_167shm2">
+        <di:waypoint x="805" y="259" />
+        <di:waypoint x="930" y="259" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1ixm0bm_di" bpmnElement="Flow_1ixm0bm">
+        <di:waypoint x="805" y="150" />
+        <di:waypoint x="862" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02httl1_di" bpmnElement="Flow_02httl1" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="755" y="150" />
+        <di:waypoint x="640" y="150" />
+        <di:waypoint x="640" y="219" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17wam1l_di" bpmnElement="Flow_17wam1l" bioc:stroke="#43a047" color:border-color="#43a047">
+        <di:waypoint x="780" y="284" />
+        <di:waypoint x="780" y="350" />
+        <di:waypoint x="330" y="350" />
+        <di:waypoint x="330" y="299" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vt2qm6_di" bpmnElement="Flow_0vt2qm6" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="780" y="234" />
+        <di:waypoint x="780" y="175" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wp5g18_di" bpmnElement="Flow_1wp5g18">
+        <di:waypoint x="792" y="272" />
+        <di:waypoint x="860" y="340" />
+        <di:waypoint x="1230" y="340" />
+        <di:waypoint x="1230" y="299" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1024" y="322" width="43" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02fz0yv_di" bpmnElement="Flow_02fz0yv">
+        <di:waypoint x="690" y="259" />
+        <di:waypoint x="755" y="259" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tlv10i_di" bpmnElement="Flow_1tlv10i">
+        <di:waypoint x="485" y="150" />
+        <di:waypoint x="532" y="150" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1pe6gam_di" bpmnElement="Flow_1pe6gam" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="435" y="150" />
+        <di:waypoint x="330" y="150" />
+        <di:waypoint x="330" y="219" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ac3n3p_di" bpmnElement="Flow_0ac3n3p" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="460" y="234" />
+        <di:waypoint x="460" y="175" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1oaxdm7_di" bpmnElement="Flow_1oaxdm7">
+        <di:waypoint x="485" y="259" />
+        <di:waypoint x="590" y="259" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0c34qe7_di" bpmnElement="Flow_0c34qe7">
+        <di:waypoint x="380" y="259" />
+        <di:waypoint x="435" y="259" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1twhwzx_di" bpmnElement="Flow_1twhwzx">
+        <di:waypoint x="215" y="259" />
+        <di:waypoint x="280" y="259" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0x2xtc3_di" bpmnElement="Flow_0x2xtc3">
+        <di:waypoint x="780" y="284" />
+        <di:waypoint x="780" y="440" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_Gro">
-        <dc:Bounds x="179" y="81" width="36" height="36" />
+        <dc:Bounds x="179" y="241" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="172" y="254" width="50" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_Gro">
-        <dc:Bounds x="302" y="81" width="36" height="36" />
+        <dc:Bounds x="1332" y="241" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="477" y="222" width="49" height="14" />
         </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0aric96_di" bpmnElement="CallActivity_PogrGroInvestigation">
+        <dc:Bounds x="280" y="219" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0tbhxzn_di" bpmnElement="Gateway_0tbhxzn" isMarkerVisible="true">
+        <dc:Bounds x="435" y="234" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_09u60iz_di" bpmnElement="Gateway_09u60iz" isMarkerVisible="true">
+        <dc:Bounds x="435" y="125" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1aqe90x_di" bpmnElement="CallActivity_PogrGroDraft">
+        <dc:Bounds x="590" y="219" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1kt8g50_di" bpmnElement="Gateway_1kt8g50" isMarkerVisible="true">
+        <dc:Bounds x="755" y="234" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0p8afpi_di" bpmnElement="EndEvent_GroInvestigationEnd">
+        <dc:Bounds x="532" y="132" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_05ni17l_di" bpmnElement="EndEvent_GroDraftEnd">
+        <dc:Bounds x="862" y="132" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0m16v09_di" bpmnElement="Gateway_0m16v09" isMarkerVisible="true">
+        <dc:Bounds x="755" y="125" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_04c1ldj_di" bpmnElement="CallActivity_PogrGroQa">
+        <dc:Bounds x="930" y="219" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1vzae9d_di" bpmnElement="Gateway_1vzae9d" isMarkerVisible="true">
+        <dc:Bounds x="1075" y="234" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1q6p9vf_di" bpmnElement="CallActivity_PogrGroDispatch">
+        <dc:Bounds x="1180" y="219" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_16iluj7_di" bpmnElement="CallActivity_PogrGroEscalate">
+        <dc:Bounds x="730" y="440" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1kd8gi5_di" bpmnElement="Gateway_1kd8gi5" isMarkerVisible="true">
+        <dc:Bounds x="885" y="455" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/POGR2/POGR2_GRO_DISPATCH.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2_GRO_DISPATCH.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0gw1f1j" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="POGR2_GRO_DISPATCH" isExecutable="true">
+    <bpmn:startEvent id="Event_0l25la0">
+      <bpmn:outgoing>Flow_1v358gf</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_GroQa">
+      <bpmn:incoming>Flow_1v358gf</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1v358gf" sourceRef="Event_0l25la0" targetRef="EndEvent_GroQa" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2_GRO_DISPATCH">
+      <bpmndi:BPMNEdge id="Flow_1v358gf_di" bpmnElement="Flow_1v358gf">
+        <di:waypoint x="215" y="120" />
+        <di:waypoint x="342" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0l25la0_di" bpmnElement="Event_0l25la0">
+        <dc:Bounds x="179" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1pgutvf_di" bpmnElement="EndEvent_GroQa">
+        <dc:Bounds x="342" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR2/POGR2_GRO_DRAFT.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2_GRO_DRAFT.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+  <bpmn:process id="POGR2_GRO_DRAFT" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_GroDraft">
+      <bpmn:outgoing>Flow_05p46q0</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_GroDraft">
+      <bpmn:incoming>Flow_05p46q0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_05p46q0" sourceRef="StartEvent_GroDraft" targetRef="EndEvent_GroDraft" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2_GRO_DRAFT">
+      <bpmndi:BPMNEdge id="Flow_05p46q0_di" bpmnElement="Flow_05p46q0">
+        <di:waypoint x="188" y="100" />
+        <di:waypoint x="322" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0pid86l_di" bpmnElement="StartEvent_GroDraft">
+        <dc:Bounds x="152" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04tmesu_di" bpmnElement="EndEvent_GroDraft">
+        <dc:Bounds x="322" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR2/POGR2_GRO_ESCALATE.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2_GRO_ESCALATE.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1wel7kv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="POGR2_GRO_ESCALATE" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1v8480u</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_GroEscalate">
+      <bpmn:incoming>Flow_1v8480u</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1v8480u" sourceRef="StartEvent_1" targetRef="EndEvent_GroEscalate" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2_GRO_ESCALATE">
+      <bpmndi:BPMNEdge id="Flow_1v8480u_di" bpmnElement="Flow_1v8480u">
+        <di:waypoint x="215" y="97" />
+        <di:waypoint x="322" y="97" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_06a7aaz_di" bpmnElement="EndEvent_GroEscalate">
+        <dc:Bounds x="322" y="79" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR2/POGR2_GRO_INVESTIGATION.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2_GRO_INVESTIGATION.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+  <bpmn:process id="POGR2_GRO_INVESTIGATION" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_POGR_GRO_INVESTIGATION">
+      <bpmn:outgoing>Flow_01d38lp</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_POGR_GRO_INVESTIGATION">
+      <bpmn:incoming>Flow_01d38lp</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_01d38lp" sourceRef="StartEvent_POGR_GRO_INVESTIGATION" targetRef="EndEvent_POGR_GRO_INVESTIGATION" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2_GRO_INVESTIGATION">
+      <bpmndi:BPMNEdge id="Flow_01d38lp_di" bpmnElement="Flow_01d38lp">
+        <di:waypoint x="148" y="100" />
+        <di:waypoint x="292" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0pid86l_di" bpmnElement="StartEvent_POGR_GRO_INVESTIGATION">
+        <dc:Bounds x="112" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04tmesu_di" bpmnElement="EndEvent_POGR_GRO_INVESTIGATION">
+        <dc:Bounds x="292" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR2/POGR2_GRO_QA.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2_GRO_QA.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_0gw1f1j" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="POGR2_GRO_QA" isExecutable="true">
+    <bpmn:startEvent id="Event_0l25la0">
+      <bpmn:outgoing>Flow_1pcvoik</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_GroQa">
+      <bpmn:incoming>Flow_1pcvoik</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1pcvoik" sourceRef="Event_0l25la0" targetRef="EndEvent_GroQa" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2_GRO_QA">
+      <bpmndi:BPMNEdge id="Flow_1pcvoik_di" bpmnElement="Flow_1pcvoik">
+        <di:waypoint x="215" y="120" />
+        <di:waypoint x="332" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0l25la0_di" bpmnElement="Event_0l25la0">
+        <dc:Bounds x="179" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1pgutvf_di" bpmnElement="EndEvent_GroQa">
+        <dc:Bounds x="332" y="102" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR2/POGR2_HMPO.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2_HMPO.bpmn
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+  <bpmn:process id="POGR2_HMPO" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_Hmpo">
+      <bpmn:outgoing>Flow_0c6noum</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_Hmpo">
+      <bpmn:incoming>Flow_0c6noum</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0c6noum" sourceRef="StartEvent_Hmpo" targetRef="EndEvent_Hmpo" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2_HMPO">
+      <bpmndi:BPMNEdge id="Flow_0c6noum_di" bpmnElement="Flow_0c6noum">
+        <di:waypoint x="215" y="99" />
+        <di:waypoint x="302" y="99" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_Hmpo">
+        <dc:Bounds x="179" y="81" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="172" y="144" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0wby6am_di" bpmnElement="EndEvent_Hmpo">
+        <dc:Bounds x="302" y="81" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR2/POGR2_HMPO.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2_HMPO.bpmn
@@ -1,28 +1,381 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <bpmn:process id="POGR2_HMPO" isExecutable="true">
     <bpmn:startEvent id="StartEvent_Hmpo">
-      <bpmn:outgoing>Flow_0c6noum</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1m1w4pf</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:endEvent id="EndEvent_Hmpo">
-      <bpmn:incoming>Flow_0c6noum</bpmn:incoming>
+    <bpmn:endEvent id="EndEvent_HmpoDraftEnd">
+      <bpmn:incoming>Flow_0obo8w9</bpmn:incoming>
     </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_0c6noum" sourceRef="StartEvent_Hmpo" targetRef="EndEvent_Hmpo" />
+    <bpmn:sequenceFlow id="Flow_1m1w4pf" sourceRef="StartEvent_Hmpo" targetRef="CallActivity_PogrHmpoInvestigation" />
+    <bpmn:callActivity id="CallActivity_PogrHmpoInvestigation" name="Investigation" calledElement="STAGE_WITH_USER">
+      <bpmn:extensionElements>
+        <camunda:in source="InvestigationUUID" target="StageUUID" />
+        <camunda:in sourceExpression="POGR2_HMPO_INVESTIGATION" target="StageWorkFlow" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+        <camunda:out source="StageUUID" target="InvestigationUUID" />
+        <camunda:in sourceExpression="POGR2_HMPO_INVESTIGATION" target="StageType" />
+        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:out source="BusinessArea" target="BusinessArea" />
+        <camunda:out source="Stage" target="Stage" />
+        <camunda:out source="InvestigationOutcome" target="InvestigationOutcome" />
+        <camunda:out source="CloseCase" target="CloseCase" />
+        <camunda:out source="LastUpdatedByUserUUID" target="DraftUserUUID" />
+        <camunda:in source="DraftUserUUID" target="AllocatedUserUUID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1m1w4pf</bpmn:incoming>
+      <bpmn:incoming>Flow_08g22s9</bpmn:incoming>
+      <bpmn:incoming>Flow_0ajdefo</bpmn:incoming>
+      <bpmn:incoming>Flow_1wpf0yz</bpmn:incoming>
+      <bpmn:outgoing>Flow_0mp9wnv</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_0mp9wnv" sourceRef="CallActivity_PogrHmpoInvestigation" targetRef="Gateway_0ph73vq" />
+    <bpmn:exclusiveGateway id="Gateway_0ph73vq" default="Flow_1lew7z0">
+      <bpmn:incoming>Flow_0mp9wnv</bpmn:incoming>
+      <bpmn:outgoing>Flow_080khuu</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1lew7z0</bpmn:outgoing>
+      <bpmn:outgoing>Flow_05c2dd5</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_080khuu" sourceRef="Gateway_0ph73vq" targetRef="CallActivity_PogrHmpoDraft">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ InvestigationOutcome == "Draft" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1lew7z0" sourceRef="Gateway_0ph73vq" targetRef="Gateway_0i7bw1a" />
+    <bpmn:exclusiveGateway id="Gateway_0i7bw1a" default="Flow_08g22s9">
+      <bpmn:incoming>Flow_1lew7z0</bpmn:incoming>
+      <bpmn:outgoing>Flow_10j7han</bpmn:outgoing>
+      <bpmn:outgoing>Flow_08g22s9</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_10j7han" sourceRef="Gateway_0i7bw1a" targetRef="EndEvent_HmpoInvestigationEnd">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("CloseCase") == true}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_08g22s9" sourceRef="Gateway_0i7bw1a" targetRef="CallActivity_PogrHmpoInvestigation" />
+    <bpmn:callActivity id="CallActivity_PogrHmpoDraft" name="Draft" calledElement="STAGE_WITH_USER">
+      <bpmn:extensionElements>
+        <camunda:in source="DraftUUID" target="StageUUID" />
+        <camunda:in sourceExpression="POGR2_HMPO_DRAFT" target="StageWorkFlow" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+        <camunda:out source="StageUUID" target="DraftUUID" />
+        <camunda:in sourceExpression="POGR2_HMPO_DRAFT" target="StageType" />
+        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:out source="BusinessArea" target="BusinessArea" />
+        <camunda:out source="Stage" target="Stage" />
+        <camunda:out source="DraftOutcome" target="DraftOutcome" />
+        <camunda:out source="CloseCase" target="CloseCase" />
+        <camunda:in source="DraftUserUUID" target="AllocatedUserUUID" />
+        <camunda:out source="LastUpdatedByUserUUID" target="DraftUserUUID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_080khuu</bpmn:incoming>
+      <bpmn:incoming>Flow_1tfrnhg</bpmn:incoming>
+      <bpmn:incoming>Flow_14sxnho</bpmn:incoming>
+      <bpmn:incoming>Flow_0aq2fgr</bpmn:incoming>
+      <bpmn:outgoing>Flow_1oz5xon</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_1oz5xon" sourceRef="CallActivity_PogrHmpoDraft" targetRef="Gateway_08mh27j" />
+    <bpmn:endEvent id="EndEvent_HmpoInvestigationEnd">
+      <bpmn:incoming>Flow_10j7han</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:exclusiveGateway id="Gateway_08mh27j" default="Flow_1skjq0z">
+      <bpmn:incoming>Flow_1oz5xon</bpmn:incoming>
+      <bpmn:outgoing>Flow_1skjq0z</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1wpf0yz</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1rjw8ef</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1del5l1</bpmn:outgoing>
+      <bpmn:outgoing>Flow_10qxg85</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0obo8w9" sourceRef="Gateway_0fbkujt" targetRef="EndEvent_HmpoDraftEnd">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("CloseCase") == true }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_1skjq0z" sourceRef="Gateway_08mh27j" targetRef="Gateway_0fbkujt" />
+    <bpmn:sequenceFlow id="Flow_1wpf0yz" sourceRef="Gateway_08mh27j" targetRef="CallActivity_PogrHmpoInvestigation">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DraftOutcome == "ReturnInvestigation" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="Gateway_0fbkujt" default="Flow_1tfrnhg">
+      <bpmn:incoming>Flow_1skjq0z</bpmn:incoming>
+      <bpmn:outgoing>Flow_1tfrnhg</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0obo8w9</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1tfrnhg" sourceRef="Gateway_0fbkujt" targetRef="CallActivity_PogrHmpoDraft" />
+    <bpmn:endEvent id="EndEvent_Hmpo">
+      <bpmn:incoming>Flow_09ux94z</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1rjw8ef" sourceRef="Gateway_08mh27j" targetRef="CallActivity_PogrHmpoQa">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DraftOutcome == "QA" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:callActivity id="CallActivity_PogrHmpoQa" name="QA" calledElement="STAGE_WITH_USER">
+      <bpmn:extensionElements>
+        <camunda:in sourceExpression="POGR2_HMPO_QA" target="StageWorkFlow" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+        <camunda:in sourceExpression="POGR2_HMPO_QA" target="StageType" />
+        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
+        <camunda:out source="BusinessArea" target="BusinessArea" />
+        <camunda:out source="Stage" target="Stage" />
+        <camunda:out source="QaOutcome" target="QaOutcome" />
+        <camunda:out source="LastUpdatedByUserUUID" target="QAUserUUID" />
+        <camunda:in source="QAUserUUID" target="AllocatedUserUUID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1rjw8ef</bpmn:incoming>
+      <bpmn:incoming>Flow_0lq3kwv</bpmn:incoming>
+      <bpmn:outgoing>Flow_11v7vw9</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_11v7vw9" sourceRef="CallActivity_PogrHmpoQa" targetRef="Gateway_1wmv5rn" />
+    <bpmn:sequenceFlow id="Flow_1del5l1" name="Dispatch" sourceRef="Gateway_08mh27j" targetRef="CallActivity_PogrHmpoDispatch">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DraftOutcome == "Dispatch" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:exclusiveGateway id="Gateway_1wmv5rn" default="Flow_0lq3kwv">
+      <bpmn:incoming>Flow_11v7vw9</bpmn:incoming>
+      <bpmn:outgoing>Flow_1xvf5wx</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0lq3kwv</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0aq2fgr</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1xvf5wx" sourceRef="Gateway_1wmv5rn" targetRef="CallActivity_PogrHmpoDispatch">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ QaOutcome == "Accept" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0lq3kwv" sourceRef="Gateway_1wmv5rn" targetRef="CallActivity_PogrHmpoQa" />
+    <bpmn:callActivity id="CallActivity_PogrHmpoDispatch" name="Dispatch" calledElement="STAGE_WITH_USER">
+      <bpmn:extensionElements>
+        <camunda:in sourceExpression="POGR2_HMPO_DISPATCH" target="StageWorkFlow" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+        <camunda:in sourceExpression="POGR2_HMPO_DISPATCH" target="StageType" />
+        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
+        <camunda:out source="BusinessArea" target="BusinessArea" />
+        <camunda:out source="Stage" target="Stage" />
+        <camunda:out source="DispatchOutcome" target="DispatchOutcome" />
+        <camunda:out source="LastUpdatedByUserUUID" target="DispatchUserUUID" />
+        <camunda:in source="DispatchUserUUID" target="AllocatedUserUUID" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1xvf5wx</bpmn:incoming>
+      <bpmn:incoming>Flow_1del5l1</bpmn:incoming>
+      <bpmn:outgoing>Flow_09ux94z</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:sequenceFlow id="Flow_09ux94z" sourceRef="CallActivity_PogrHmpoDispatch" targetRef="EndEvent_Hmpo" />
+    <bpmn:callActivity id="CallActivity_PogrHmpoEscalate" name="Escalate" calledElement="STAGE">
+      <bpmn:extensionElements>
+        <camunda:in source="EscalationUUID" target="StageUUID" />
+        <camunda:in sourceExpression="POGR2_HMPO_ESCALATE" target="StageWorkFlow" />
+        <camunda:in businessKey="#{execution.processBusinessKey}" />
+        <camunda:in variables="all" />
+        <camunda:out source="StageUUID" target="EscalationUUID" />
+        <camunda:in sourceExpression="POGR2_HMPO_ESCALATE" target="StageType" />
+        <camunda:in sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:in sourceExpression="${execution.processBusinessKey}" target="CaseUUID" />
+        <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
+        <camunda:out source="Stage" target="Stage" />
+        <camunda:out source="EscalationOutcome" target="EscalationOutcome" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_05c2dd5</bpmn:incoming>
+      <bpmn:incoming>Flow_0b35gdf</bpmn:incoming>
+      <bpmn:incoming>Flow_10qxg85</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vchjhj</bpmn:outgoing>
+    </bpmn:callActivity>
+    <bpmn:exclusiveGateway id="Gateway_157w6qt" default="Flow_0b35gdf">
+      <bpmn:incoming>Flow_1vchjhj</bpmn:incoming>
+      <bpmn:outgoing>Flow_14sxnho</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0b35gdf</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0ajdefo</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1vchjhj" sourceRef="CallActivity_PogrHmpoEscalate" targetRef="Gateway_157w6qt" />
+    <bpmn:sequenceFlow id="Flow_05c2dd5" sourceRef="Gateway_0ph73vq" targetRef="CallActivity_PogrHmpoEscalate">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ InvestigationOutcome == "Escalate" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_14sxnho" sourceRef="Gateway_157w6qt" targetRef="CallActivity_PogrHmpoDraft">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ EscalationOutcome == "Draft" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0b35gdf" sourceRef="Gateway_157w6qt" targetRef="CallActivity_PogrHmpoEscalate" />
+    <bpmn:sequenceFlow id="Flow_0ajdefo" sourceRef="Gateway_157w6qt" targetRef="CallActivity_PogrHmpoInvestigation">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ EscalationOutcome == "Investigation" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_0aq2fgr" sourceRef="Gateway_1wmv5rn" targetRef="CallActivity_PogrHmpoDraft">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ QaOutcome == "Reject" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_10qxg85" sourceRef="Gateway_08mh27j" targetRef="CallActivity_PogrHmpoEscalate">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DraftOutcome == "Escalate" }</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2_HMPO">
-      <bpmndi:BPMNEdge id="Flow_0c6noum_di" bpmnElement="Flow_0c6noum">
-        <di:waypoint x="215" y="99" />
-        <di:waypoint x="302" y="99" />
+      <bpmndi:BPMNEdge id="Flow_0aq2fgr_di" bpmnElement="Flow_0aq2fgr" bioc:stroke="#fb8c00" color:border-color="#fb8c00">
+        <di:waypoint x="1150" y="214" />
+        <di:waypoint x="1150" y="310" />
+        <di:waypoint x="640" y="310" />
+        <di:waypoint x="640" y="229" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ajdefo_di" bpmnElement="Flow_0ajdefo">
+        <di:waypoint x="920" y="425" />
+        <di:waypoint x="920" y="540" />
+        <di:waypoint x="320" y="540" />
+        <di:waypoint x="320" y="229" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0b35gdf_di" bpmnElement="Flow_0b35gdf" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="920" y="425" />
+        <di:waypoint x="920" y="490" />
+        <di:waypoint x="760" y="490" />
+        <di:waypoint x="760" y="440" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14sxnho_di" bpmnElement="Flow_14sxnho" bioc:stroke="#fb8c00" color:border-color="#fb8c00">
+        <di:waypoint x="920" y="375" />
+        <di:waypoint x="920" y="310" />
+        <di:waypoint x="640" y="310" />
+        <di:waypoint x="640" y="229" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05c2dd5_di" bpmnElement="Flow_05c2dd5">
+        <di:waypoint x="440" y="214" />
+        <di:waypoint x="440" y="400" />
+        <di:waypoint x="710" y="400" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vchjhj_di" bpmnElement="Flow_1vchjhj">
+        <di:waypoint x="810" y="400" />
+        <di:waypoint x="895" y="400" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_09ux94z_di" bpmnElement="Flow_09ux94z">
+        <di:waypoint x="1330" y="189" />
+        <di:waypoint x="1392" y="189" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0lq3kwv_di" bpmnElement="Flow_0lq3kwv" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="1150" y="164" />
+        <di:waypoint x="1150" y="80" />
+        <di:waypoint x="1020" y="80" />
+        <di:waypoint x="1020" y="149" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xvf5wx_di" bpmnElement="Flow_1xvf5wx">
+        <di:waypoint x="1175" y="189" />
+        <di:waypoint x="1230" y="189" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1del5l1_di" bpmnElement="Flow_1del5l1">
+        <di:waypoint x="772" y="202" />
+        <di:waypoint x="850" y="280" />
+        <di:waypoint x="1280" y="280" />
+        <di:waypoint x="1280" y="229" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1044" y="262" width="43" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_11v7vw9_di" bpmnElement="Flow_11v7vw9">
+        <di:waypoint x="1070" y="189" />
+        <di:waypoint x="1125" y="189" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rjw8ef_di" bpmnElement="Flow_1rjw8ef">
+        <di:waypoint x="785" y="189" />
+        <di:waypoint x="970" y="189" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1tfrnhg_di" bpmnElement="Flow_1tfrnhg" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="735" y="80" />
+        <di:waypoint x="640" y="80" />
+        <di:waypoint x="640" y="149" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1wpf0yz_di" bpmnElement="Flow_1wpf0yz" bioc:stroke="#43a047" color:border-color="#43a047">
+        <di:waypoint x="760" y="214" />
+        <di:waypoint x="760" y="280" />
+        <di:waypoint x="320" y="280" />
+        <di:waypoint x="320" y="230" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="545" y="296" width="62" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1skjq0z_di" bpmnElement="Flow_1skjq0z" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="760" y="164" />
+        <di:waypoint x="760" y="105" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0obo8w9_di" bpmnElement="Flow_0obo8w9">
+        <di:waypoint x="785" y="80" />
+        <di:waypoint x="842" y="80" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1oz5xon_di" bpmnElement="Flow_1oz5xon">
+        <di:waypoint x="690" y="189" />
+        <di:waypoint x="735" y="189" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08g22s9_di" bpmnElement="Flow_08g22s9" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="415" y="80" />
+        <di:waypoint x="320" y="80" />
+        <di:waypoint x="320" y="149" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10j7han_di" bpmnElement="Flow_10j7han">
+        <di:waypoint x="465" y="80" />
+        <di:waypoint x="512" y="80" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1lew7z0_di" bpmnElement="Flow_1lew7z0" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="440" y="164" />
+        <di:waypoint x="440" y="105" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_080khuu_di" bpmnElement="Flow_080khuu">
+        <di:waypoint x="465" y="189" />
+        <di:waypoint x="590" y="189" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mp9wnv_di" bpmnElement="Flow_0mp9wnv">
+        <di:waypoint x="370" y="189" />
+        <di:waypoint x="415" y="189" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1m1w4pf_di" bpmnElement="Flow_1m1w4pf">
+        <di:waypoint x="215" y="189" />
+        <di:waypoint x="270" y="189" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10qxg85_di" bpmnElement="Flow_10qxg85">
+        <di:waypoint x="760" y="214" />
+        <di:waypoint x="760" y="360" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_Hmpo">
-        <dc:Bounds x="179" y="81" width="36" height="36" />
+        <dc:Bounds x="179" y="171" width="36" height="36" />
         <bpmndi:BPMNLabel>
           <dc:Bounds x="172" y="144" width="50" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_HmpoDraftEnd">
+        <dc:Bounds x="842" y="62" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="467" y="112" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kj7g9i_di" bpmnElement="CallActivity_PogrHmpoInvestigation">
+        <dc:Bounds x="270" y="149" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ph73vq_di" bpmnElement="Gateway_0ph73vq" isMarkerVisible="true">
+        <dc:Bounds x="415" y="164" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0i7bw1a_di" bpmnElement="Gateway_0i7bw1a" isMarkerVisible="true">
+        <dc:Bounds x="415" y="55" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_150iolg_di" bpmnElement="CallActivity_PogrHmpoDraft">
+        <dc:Bounds x="590" y="149" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0y5jpxb_di" bpmnElement="EndEvent_HmpoInvestigationEnd">
+        <dc:Bounds x="512" y="62" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_08mh27j_di" bpmnElement="Gateway_08mh27j" isMarkerVisible="true">
+        <dc:Bounds x="735" y="164" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0fbkujt_di" bpmnElement="Gateway_0fbkujt" isMarkerVisible="true">
+        <dc:Bounds x="735" y="55" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0wby6am_di" bpmnElement="EndEvent_Hmpo">
-        <dc:Bounds x="302" y="81" width="36" height="36" />
+        <dc:Bounds x="1392" y="171" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_09g92t3_di" bpmnElement="CallActivity_PogrHmpoQa">
+        <dc:Bounds x="970" y="149" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1wmv5rn_di" bpmnElement="Gateway_1wmv5rn" isMarkerVisible="true">
+        <dc:Bounds x="1125" y="164" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0ht2mbu_di" bpmnElement="CallActivity_PogrHmpoDispatch">
+        <dc:Bounds x="1230" y="149" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0mndufl_di" bpmnElement="CallActivity_PogrHmpoEscalate">
+        <dc:Bounds x="710" y="360" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_157w6qt_di" bpmnElement="Gateway_157w6qt" isMarkerVisible="true">
+        <dc:Bounds x="895" y="375" width="50" height="50" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/POGR2/POGR2_HMPO_DISPATCH.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2_HMPO_DISPATCH.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1bmu0jv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="POGR2_HMPO_DISPATCH" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0hx9kki</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_HmpoQa">
+      <bpmn:incoming>Flow_0hx9kki</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0hx9kki" sourceRef="StartEvent_1" targetRef="EndEvent_HmpoQa" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2_HMPO_DISPATCH">
+      <bpmndi:BPMNEdge id="Flow_0hx9kki_di" bpmnElement="Flow_0hx9kki">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="342" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10rc1v1_di" bpmnElement="EndEvent_HmpoQa">
+        <dc:Bounds x="342" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR2/POGR2_HMPO_DRAFT.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2_HMPO_DRAFT.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+  <bpmn:process id="POGR2_HMPO_DRAFT" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_HmpoDraft">
+      <bpmn:outgoing>Flow_0wep40c</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_HmpoDraft">
+      <bpmn:incoming>Flow_0wep40c</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0wep40c" sourceRef="StartEvent_HmpoDraft" targetRef="EndEvent_HmpoDraft" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2_HMPO_DRAFT">
+      <bpmndi:BPMNEdge id="Flow_0wep40c_di" bpmnElement="Flow_0wep40c">
+        <di:waypoint x="208" y="100" />
+        <di:waypoint x="292" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_0pid86l_di" bpmnElement="StartEvent_HmpoDraft">
+        <dc:Bounds x="172" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_04tmesu_di" bpmnElement="EndEvent_HmpoDraft">
+        <dc:Bounds x="292" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR2/POGR2_HMPO_ESCALATE.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2_HMPO_ESCALATE.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1wel7kv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="POGR2_HMPO_ESCALATE" isExecutable="true">
+    <bpmn:startEvent id="Event_1y0ldhw">
+      <bpmn:outgoing>Flow_0tf5ph0</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_HmpoEscalate">
+      <bpmn:incoming>Flow_0tf5ph0</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0tf5ph0" sourceRef="Event_1y0ldhw" targetRef="EndEvent_HmpoEscalate" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2_HMPO_ESCALATE">
+      <bpmndi:BPMNEdge id="Flow_0tf5ph0_di" bpmnElement="Flow_0tf5ph0">
+        <di:waypoint x="215" y="100" />
+        <di:waypoint x="342" y="100" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1y0ldhw_di" bpmnElement="Event_1y0ldhw">
+        <dc:Bounds x="179" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0vefo00_di" bpmnElement="EndEvent_HmpoEscalate">
+        <dc:Bounds x="342" y="82" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR2/POGR2_HMPO_INVESTIGATION.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2_HMPO_INVESTIGATION.bpmn
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0pru6n5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
+  <bpmn:process id="POGR2_HMPO_INVESTIGATION" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_POGR_HMPO_INVESTIGATION">
+      <bpmn:outgoing>Flow_1vdpytq</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_POGR_HMPO_INVESTIGATION">
+      <bpmn:incoming>Flow_1vdpytq</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1vdpytq" sourceRef="StartEvent_POGR_HMPO_INVESTIGATION" targetRef="EndEvent_POGR_HMPO_INVESTIGATION" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2_HMPO_INVESTIGATION">
+      <bpmndi:BPMNEdge id="Flow_1vdpytq_di" bpmnElement="Flow_1vdpytq">
+        <di:waypoint x="188" y="99" />
+        <di:waypoint x="302" y="99" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_POGR_HMPO_INVESTIGATION">
+        <dc:Bounds x="152" y="81" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="172" y="144" width="50" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0h34pj4_di" bpmnElement="EndEvent_POGR_HMPO_INVESTIGATION">
+        <dc:Bounds x="302" y="81" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="467" y="112" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/main/resources/processes/POGR2/POGR2_HMPO_QA.bpmn
+++ b/src/main/resources/processes/POGR2/POGR2_HMPO_QA.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1bmu0jv" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+  <bpmn:process id="POGR2_HMPO_QA" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0hx9kki</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_HmpoQa">
+      <bpmn:incoming>Flow_0hx9kki</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0hx9kki" sourceRef="StartEvent_1" targetRef="EndEvent_HmpoQa" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="POGR2_HMPO_QA">
+      <bpmndi:BPMNEdge id="Flow_0hx9kki_di" bpmnElement="Flow_0hx9kki">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="302" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10rc1v1_di" bpmnElement="EndEvent_HmpoQa">
+        <dc:Bounds x="302" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_GRO.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_GRO.java
@@ -148,7 +148,8 @@ public class POGR_GRO {
                 .deploy(rule);
 
         whenAtCallActivity("POGR_GRO_QA")
-                .thenReturn("QaOutcome", "Reject", "reallocate", "true")
+                .thenReturn("QaOutcome", "")
+                .thenReturn("QaOutcome", "Reject")
                 .deploy(rule);
 
         whenAtCallActivity("POGR_GRO_DISPATCH")
@@ -160,7 +161,7 @@ public class POGR_GRO {
 
         verify(processScenario).hasCompleted("StartEvent_Gro");
         verify(processScenario).hasCompleted("CallActivity_PogrGroInvestigation");
-        verify(processScenario).hasCompleted("CallActivity_PogrGroQa");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrGroQa");
         verify(processScenario, times(2)).hasCompleted("CallActivity_PogrGroDraft");
     }
 
@@ -200,6 +201,7 @@ public class POGR_GRO {
                 .deploy(rule);
 
         whenAtCallActivity("POGR_GRO_ESCALATE")
+                .thenReturn("EscalationOutcome", "")
                 .thenReturn("EscalationOutcome", "Investigation")
                 .deploy(rule);
 
@@ -220,8 +222,8 @@ public class POGR_GRO {
 
         verify(processScenario).hasCompleted("StartEvent_Gro");
         verify(processScenario, times(2)).hasCompleted("CallActivity_PogrGroInvestigation");
-        verify(processScenario, times(1)).hasCompleted("CallActivity_PogrGroEscalate");
-        verify(processScenario, times(1)).hasCompleted("CallActivity_PogrGroDraft");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrGroEscalate");
+        verify(processScenario).hasCompleted("CallActivity_PogrGroDraft");
         verify(processScenario).hasCompleted("EndEvent_Gro");
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_HMPO.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr/POGR_HMPO.java
@@ -151,7 +151,8 @@ public class POGR_HMPO {
                 .deploy(rule);
 
         whenAtCallActivity("POGR_HMPO_QA")
-                .thenReturn("QaOutcome", "Reject", "reallocate", "true")
+                .thenReturn("QaOutcome", "")
+                .thenReturn("QaOutcome", "Reject")
                 .deploy(rule);
 
         whenAtCallActivity("POGR_HMPO_DISPATCH")
@@ -163,7 +164,7 @@ public class POGR_HMPO {
 
         verify(processScenario).hasCompleted("StartEvent_Hmpo");
         verify(processScenario).hasCompleted("CallActivity_PogrHmpoInvestigation");
-        verify(processScenario).hasCompleted("CallActivity_PogrHmpoQa");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrHmpoQa");
         verify(processScenario, times(2)).hasCompleted("CallActivity_PogrHmpoDraft");
     }
 
@@ -204,6 +205,7 @@ public class POGR_HMPO {
                 .deploy(rule);
 
         whenAtCallActivity("POGR_HMPO_ESCALATE")
+                .thenReturn("EscalationOutcome", "")
                 .thenReturn("EscalationOutcome", "Investigation")
                 .deploy(rule);
 
@@ -224,8 +226,8 @@ public class POGR_HMPO {
 
         verify(processScenario).hasCompleted("StartEvent_Hmpo");
         verify(processScenario, times(2)).hasCompleted("CallActivity_PogrHmpoInvestigation");
-        verify(processScenario, times(1)).hasCompleted("CallActivity_PogrHmpoEscalate");
-        verify(processScenario, times(1)).hasCompleted("CallActivity_PogrHmpoDraft");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrHmpoEscalate");
+        verify(processScenario).hasCompleted("CallActivity_PogrHmpoDraft");
         verify(processScenario).hasCompleted("EndEvent_Hmpo");
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr2/POGR2.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr2/POGR2.java
@@ -27,7 +27,7 @@ public class POGR2 {
 
     @Rule
     @ClassRule
-    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create().assertClassCoverageAtLeast(0.1).build();
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create().assertClassCoverageAtLeast(1).build();
 
     @Rule
     public ProcessEngineRule processEngineRule = new ProcessEngineRule();
@@ -46,7 +46,10 @@ public class POGR2 {
     @Test
     public void testHappyHmpoPath() {
         whenAtCallActivity("POGR2_REGISTRATION")
-                .thenReturn("", "")
+                .thenReturn("BusinessArea", "HMPO")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO")
                 .deploy(rule);
 
         Scenario.run(processScenario)
@@ -55,6 +58,7 @@ public class POGR2 {
 
         verify(processScenario).hasCompleted("StartEvent_POGR2");
         verify(processScenario).hasCompleted("CallActivity_RegistrationStage");
+        verify(processScenario).hasCompleted("CallActivity_PogrHmpo");
         verify(processScenario).hasCompleted("ServiceTask_CompleteCase");
         verify(processScenario).hasCompleted("EndEvent_POGR2");
     }
@@ -62,7 +66,10 @@ public class POGR2 {
     @Test
     public void testHappyGroPath() {
         whenAtCallActivity("POGR2_REGISTRATION")
-                .thenReturn("", "")
+                .thenReturn("BusinessArea", "GRO")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO")
                 .deploy(rule);
 
         Scenario.run(processScenario)
@@ -71,6 +78,7 @@ public class POGR2 {
 
         verify(processScenario).hasCompleted("StartEvent_POGR2");
         verify(processScenario).hasCompleted("CallActivity_RegistrationStage");
+        verify(processScenario).hasCompleted("CallActivity_PogrGro");
         verify(processScenario).hasCompleted("ServiceTask_CompleteCase");
         verify(processScenario).hasCompleted("EndEvent_POGR2");
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr2/POGR2_GRO.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr2/POGR2_GRO.java
@@ -1,0 +1,263 @@
+package uk.gov.digital.ho.hocs.workflow.processes.pogr2;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.scenario.ProcessScenario;
+import org.camunda.bpm.scenario.Scenario;
+import org.camunda.community.process_test_coverage.junit4.platform7.rules.TestCoverageProcessEngineRule;
+import org.camunda.community.process_test_coverage.junit4.platform7.rules.TestCoverageProcessEngineRuleBuilder;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.withVariables;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static uk.gov.digital.ho.hocs.workflow.util.CallActivityMockWrapper.whenAtCallActivity;
+
+@RunWith(MockitoJUnitRunner.class)
+@Deployment(resources = {
+        "processes/POGR2/POGR2_GRO.bpmn",
+        "processes/STAGE_WITH_USER.bpmn",
+        "processes/STAGE.bpmn" })
+public class POGR2_GRO {
+
+    @Rule
+    @ClassRule
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create().assertClassCoverageAtLeast(1).build();
+
+    @Rule
+    public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+
+    @Mock
+    BpmnService bpmnService;
+
+    @Mock
+    private ProcessScenario processScenario;
+
+    @Before
+    public void setup() {
+        Mocks.register("bpmnService", bpmnService);
+    }
+
+    @Test
+    public void testHappyPath() {
+        whenAtCallActivity("POGR2_GRO_INVESTIGATION")
+                .thenReturn("InvestigationOutcome", "", "CloseCaseInvestigation", "false")
+                .thenReturn("InvestigationOutcome", "Draft", "CloseCaseInvestigation", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_DRAFT")
+                .thenReturn("DraftOutcome", "", "CloseCaseDraft", "false")
+                .thenReturn("DraftOutcome", "QA", "CloseCaseDraft", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_QA")
+                .thenReturn("QaOutcome", "Accept")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_DISPATCH")
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_GRO", withVariables("LastUpdatedByUserUUID", "userUUID"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Gro");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrGroInvestigation");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrGroDraft");
+        verify(processScenario).hasCompleted("EndEvent_Gro");
+    }
+
+    @Test
+    public void testInvestigationCloseCase() {
+        whenAtCallActivity("POGR2_GRO_INVESTIGATION")
+                .thenReturn("CloseCase", Boolean.toString(true))
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_GRO")
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Gro");
+        verify(processScenario).hasCompleted("CallActivity_PogrGroInvestigation");
+        verify(processScenario).hasCompleted("EndEvent_GroInvestigationEnd");
+    }
+
+    @Test
+    public void testDraftReturnInvestigation() {
+        whenAtCallActivity("POGR2_GRO_INVESTIGATION")
+                .thenReturn("InvestigationOutcome", "Draft", "CloseCaseInvestigation", "false")
+                .thenReturn("InvestigationOutcome", "Draft", "CloseCaseInvestigation", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_DRAFT")
+                .thenReturn("DraftOutcome", "ReturnInvestigation", "CloseCaseDraft", "false")
+                .thenReturn("DraftOutcome", "QA")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_QA")
+                .thenReturn("QaOutcome", "Accept")
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_GRO", withVariables("LastUpdatedByUserUUID", "userUUID"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Gro");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrGroInvestigation");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrGroDraft");
+        verify(processScenario).hasCompleted("EndEvent_Gro");
+    }
+
+    @Test
+    public void testDraftCloseCase() {
+        whenAtCallActivity("POGR2_GRO_INVESTIGATION")
+                .thenReturn("InvestigationOutcome", "Draft")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_DRAFT")
+                .thenReturn("CloseCase", Boolean.toString(true))
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_GRO", withVariables("LastUpdatedByUserUUID", "userUUID"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Gro");
+        verify(processScenario).hasCompleted("CallActivity_PogrGroInvestigation");
+        verify(processScenario).hasCompleted("CallActivity_PogrGroDraft");
+        verify(processScenario).hasCompleted("EndEvent_GroDraftEnd");
+    }
+
+    @Test
+    public void testQaReject() {
+        whenAtCallActivity("POGR2_GRO_INVESTIGATION")
+                .thenReturn("InvestigationOutcome", "Draft", "CloseCaseInvestigation", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_DRAFT")
+                .thenReturn("DraftOutcome", "QA")
+                .thenReturn("DraftOutcome", "Dispatch")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_QA")
+                .thenReturn("QaOutcome", "")
+                .thenReturn("QaOutcome", "Reject")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_DISPATCH")
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_GRO", withVariables("LastUpdatedByUserUUID", "userUUID"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Gro");
+        verify(processScenario).hasCompleted("CallActivity_PogrGroInvestigation");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrGroQa");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrGroDraft");
+    }
+
+    @Test
+    public void testQaBypassStraightToDispatch() {
+        whenAtCallActivity("POGR2_GRO_INVESTIGATION")
+                .thenReturn("InvestigationOutcome", "Draft", "CloseCaseInvestigation", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_DRAFT")
+                .thenReturn("DraftOutcome", "Dispatch")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_QA")
+                .thenReturn("QaOutcome", "Accept")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_DISPATCH")
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_GRO", withVariables("LastUpdatedByUserUUID", "userUUID"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Gro");
+        verify(processScenario, times(1)).hasCompleted("CallActivity_PogrGroInvestigation");
+        verify(processScenario, times(1)).hasCompleted("CallActivity_PogrGroDraft");
+        verify(processScenario, times(1)).hasCompleted("CallActivity_PogrGroDispatch");
+        verify(processScenario).hasCompleted("EndEvent_Gro");
+    }
+
+    @Test
+    public void testInvestigationEscalate() {
+        whenAtCallActivity("POGR2_GRO_INVESTIGATION")
+                .thenReturn("InvestigationOutcome", "Escalate")
+                .thenReturn("InvestigationOutcome", "Draft", "CloseCaseInvestigation", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_ESCALATE")
+                .thenReturn("EscalationOutcome", "")
+                .thenReturn("EscalationOutcome", "Investigation")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_DRAFT")
+                .thenReturn("DraftOutcome", "QA", "CloseCaseDraft", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_QA")
+                .thenReturn("QaOutcome", "Accept")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_DISPATCH")
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_GRO", withVariables("LastUpdatedByUserUUID", "userUUID"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Gro");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrGroInvestigation");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrGroEscalate");
+        verify(processScenario).hasCompleted("CallActivity_PogrGroDraft");
+        verify(processScenario).hasCompleted("EndEvent_Gro");
+    }
+
+    @Test
+    public void testDraftEscalate() {
+        whenAtCallActivity("POGR2_GRO_INVESTIGATION")
+                .thenReturn("InvestigationOutcome", "Draft", "CloseCaseInvestigation", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_ESCALATE")
+                .thenReturn("EscalationOutcome", "Draft")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_DRAFT")
+                .thenReturn("DraftOutcome", "Escalate")
+                .thenReturn("DraftOutcome", "QA", "CloseCaseDraft", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_QA")
+                .thenReturn("QaOutcome", "Accept")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_GRO_DISPATCH")
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_GRO", withVariables("LastUpdatedByUserUUID", "userUUID"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Gro");
+        verify(processScenario, times(1)).hasCompleted("CallActivity_PogrGroInvestigation");
+        verify(processScenario, times(1)).hasCompleted("CallActivity_PogrGroEscalate");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrGroDraft");
+        verify(processScenario).hasCompleted("EndEvent_Gro");
+    }
+
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr2/POGR2_HMPO.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/pogr2/POGR2_HMPO.java
@@ -1,0 +1,264 @@
+package uk.gov.digital.ho.hocs.workflow.processes.pogr2;
+
+import org.camunda.bpm.engine.test.Deployment;
+import org.camunda.bpm.engine.test.ProcessEngineRule;
+import org.camunda.bpm.engine.test.mock.Mocks;
+import org.camunda.bpm.scenario.ProcessScenario;
+import org.camunda.bpm.scenario.Scenario;
+import org.camunda.community.process_test_coverage.junit4.platform7.rules.TestCoverageProcessEngineRule;
+import org.camunda.community.process_test_coverage.junit4.platform7.rules.TestCoverageProcessEngineRuleBuilder;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+
+import static org.camunda.bpm.engine.test.assertions.ProcessEngineTests.withVariables;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static uk.gov.digital.ho.hocs.workflow.util.CallActivityMockWrapper.whenAtCallActivity;
+
+@RunWith(MockitoJUnitRunner.class)
+@Deployment(resources = {
+        "processes/POGR2/POGR2_HMPO.bpmn",
+        "processes/STAGE_WITH_USER.bpmn",
+        "processes/STAGE.bpmn" })
+public class POGR2_HMPO {
+
+    @Rule
+    @ClassRule
+    public static TestCoverageProcessEngineRule rule = TestCoverageProcessEngineRuleBuilder.create().assertClassCoverageAtLeast(1).build();
+
+    @Rule
+    public ProcessEngineRule processEngineRule = new ProcessEngineRule();
+
+    @Mock
+    BpmnService bpmnService;
+
+    @Mock
+    private ProcessScenario processScenario;
+
+    @Before
+    public void setup() {
+        Mocks.register("bpmnService", bpmnService);
+    }
+
+    @Test
+    public void testHappyPath() {
+        whenAtCallActivity("POGR2_HMPO_INVESTIGATION")
+                .thenReturn("InvestigationOutcome", "", "CloseCaseInvestigation", "false")
+                .thenReturn("InvestigationOutcome", "Draft", "CloseCaseInvestigation", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_DRAFT")
+                .thenReturn("DraftOutcome", "", "CloseCaseDraft", "false")
+                .thenReturn("DraftOutcome", "QA", "CloseCaseDraft", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_QA")
+                .thenReturn("QaOutcome", "Accept")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_DISPATCH")
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_HMPO", withVariables("LastUpdatedByUserUUID", "userUUID"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Hmpo");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrHmpoInvestigation");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrHmpoDraft");
+        verify(processScenario).hasCompleted("EndEvent_Hmpo");
+    }
+
+    @Test
+    public void testInvestigationCloseCase() {
+        whenAtCallActivity("POGR2_HMPO_INVESTIGATION")
+                .thenReturn("CloseCase", Boolean.toString(true))
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_HMPO")
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Hmpo");
+        verify(processScenario).hasCompleted("CallActivity_PogrHmpoInvestigation");
+        verify(processScenario).hasCompleted("EndEvent_HmpoInvestigationEnd");
+    }
+
+    @Test
+    public void testDraftReturnInvestigation() {
+        whenAtCallActivity("POGR2_HMPO_INVESTIGATION")
+                .thenReturn("InvestigationOutcome", "Draft", "CloseCaseInvestigation", "false")
+                .thenReturn("InvestigationOutcome", "Draft", "CloseCaseInvestigation", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_DRAFT")
+                .thenReturn("DraftOutcome", "ReturnInvestigation", "CloseCaseDraft", "false")
+                .thenReturn("DraftOutcome", "QA", "CloseCaseDraft", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_QA")
+                .thenReturn("QaOutcome", "Accept")
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_HMPO", withVariables("LastUpdatedByUserUUID", "userUUID"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Hmpo");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrHmpoInvestigation");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrHmpoDraft");
+        verify(processScenario).hasCompleted("EndEvent_Hmpo");
+    }
+
+    @Test
+    public void testDraftCloseCase() {
+        whenAtCallActivity("POGR2_HMPO_INVESTIGATION")
+                .thenReturn("InvestigationOutcome", "Draft")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_DRAFT")
+                .thenReturn("CloseCase", Boolean.toString(true))
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_HMPO", withVariables("LastUpdatedByUserUUID", "userUUID"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Hmpo");
+        verify(processScenario).hasCompleted("CallActivity_PogrHmpoInvestigation");
+        verify(processScenario).hasCompleted("CallActivity_PogrHmpoDraft");
+        verify(processScenario).hasCompleted("EndEvent_HmpoDraftEnd");
+    }
+
+    @Test
+    public void testQaReject() {
+        whenAtCallActivity("POGR2_HMPO_INVESTIGATION")
+                .thenReturn("InvestigationOutcome", "Draft", "CloseCaseInvestigation", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_DRAFT")
+                .thenReturn("DraftOutcome", "QA")
+                .thenReturn("DraftOutcome", "Dispatch")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_QA")
+                .thenReturn("QaOutcome", "")
+                .thenReturn("QaOutcome", "Reject")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_DISPATCH")
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_HMPO", withVariables("LastUpdatedByUserUUID", "userUUID"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Hmpo");
+        verify(processScenario).hasCompleted("CallActivity_PogrHmpoInvestigation");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrHmpoQa");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrHmpoDraft");
+    }
+
+    @Test
+    public void testQaBypassStraightToDispatch() {
+        whenAtCallActivity("POGR2_HMPO_INVESTIGATION")
+                .thenReturn("InvestigationOutcome", "Draft", "CloseCaseInvestigation", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_DRAFT")
+                .thenReturn("DraftOutcome", "QA")
+                .thenReturn("DraftOutcome", "Dispatch")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_QA")
+                .thenReturn("QaOutcome", "Accept")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_DISPATCH")
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_HMPO", withVariables("LastUpdatedByUserUUID", "userUUID"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Hmpo");
+        verify(processScenario, times(1)).hasCompleted("CallActivity_PogrHmpoInvestigation");
+        verify(processScenario, times(1)).hasCompleted("CallActivity_PogrHmpoQa");
+        verify(processScenario).hasCompleted("CallActivity_PogrHmpoDraft");
+        verify(processScenario).hasCompleted("CallActivity_PogrHmpoDispatch");
+    }
+
+    @Test
+    public void testInvestigationEscalate() {
+        whenAtCallActivity("POGR2_HMPO_INVESTIGATION")
+                .thenReturn("InvestigationOutcome", "Escalate")
+                .thenReturn("InvestigationOutcome", "Draft", "CloseCaseInvestigation", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_ESCALATE")
+                .thenReturn("EscalationOutcome", "")
+                .thenReturn("EscalationOutcome", "Investigation")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_DRAFT")
+                .thenReturn("DraftOutcome", "QA", "CloseCaseDraft", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_QA")
+                .thenReturn("QaOutcome", "Accept")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_DISPATCH")
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_HMPO", withVariables("LastUpdatedByUserUUID", "userUUID"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Hmpo");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrHmpoInvestigation");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrHmpoEscalate");
+        verify(processScenario).hasCompleted("CallActivity_PogrHmpoDraft");
+        verify(processScenario).hasCompleted("EndEvent_Hmpo");
+    }
+
+    @Test
+    public void testDraftEscalate() {
+        whenAtCallActivity("POGR2_HMPO_INVESTIGATION")
+                .thenReturn("InvestigationOutcome", "Draft", "CloseCaseInvestigation", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_ESCALATE")
+                .thenReturn("EscalationOutcome", "Draft")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_DRAFT")
+                .thenReturn("DraftOutcome", "Escalate")
+                .thenReturn("DraftOutcome", "QA", "CloseCaseDraft", "false")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_QA")
+                .thenReturn("QaOutcome", "Accept")
+                .deploy(rule);
+
+        whenAtCallActivity("POGR2_HMPO_DISPATCH")
+                .deploy(rule);
+
+        Scenario.run(processScenario)
+                .startByKey("POGR2_HMPO", withVariables("LastUpdatedByUserUUID", "userUUID"))
+                .execute();
+
+        verify(processScenario).hasCompleted("StartEvent_Hmpo");
+        verify(processScenario, times(1)).hasCompleted("CallActivity_PogrHmpoInvestigation");
+        verify(processScenario, times(1)).hasCompleted("CallActivity_PogrHmpoEscalate");
+        verify(processScenario, times(2)).hasCompleted("CallActivity_PogrHmpoDraft");
+        verify(processScenario).hasCompleted("EndEvent_Hmpo");
+    }
+
+}


### PR DESCRIPTION
Add the base HMPO and GRO stage 2 flows to support ongoing development. This allows for multiple developers to work on individual stages while also ensuring that the team assignation is the same as Stage.

Blank Investigation, Draft, Escalation, QA and Dispatch stages have been added that should be updated as necessary. 

This also includes a minor cleanup of the HMPO and GRO Stage 1 flow to ensure default flows exist where necessary.