### PR TITLE
Hocs 5617 confirm complaint reason

### DIFF
--- a/src/main/resources/screens/POGR2_GRO_DISPATCH_INPUT.json
+++ b/src/main/resources/screens/POGR2_GRO_DISPATCH_INPUT.json
@@ -65,6 +65,134 @@
       "validation": [
         "required"
       ],
+      "props": {
+        "choices": "GRO_COMPLAINT_CATEGORIES"
+      },
+      "component": "dropdown",
+      "name": "ComplainantCategory",
+      "label": "Complaint Category"
+    },
+    {
+      "validation": [
+        "required"
+      ],
+      "props": {
+        "conditionChoices": [
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_CSMT",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "CSMT - Customer Service"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_STANDARD",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - Standard"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_PRIORITIES",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - Priorities"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_EXCEPTIONS",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - Exceptions"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_PDF",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - PDF"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_EMAIL_TEAM",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - Email Team"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_CCU_POST_TEAM",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - CCU Post team"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_KIT",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - KIT"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_INDEXING",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - Indexing"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_SD_FDU",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "S&D - FDU"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_SD_ENGAGEMENT",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "S&D - Engagement"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_SYSTEMS",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Systems - ROLO"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_ARC_ADOPTIONS",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "ARC - Adoptions"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_ARC_CASEWORK",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "ARC - Casework"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_POLICY",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Policy"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_POLICY_BUSINESS",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Policy - Business Procedures"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_THIRD_PARTY_DHL",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Third Party - DHL"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_THIRD_PARTY_ROYAL_MAIL",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Third Party - Royal Mail"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_THIRD_PARTY_MAIL",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Third Party - International / UK Mail"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_THIRD_PARTY_WORLD_PAY",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Third Party - World Pay"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_OTHER",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Other"
+          }
+        ]
+      },
+      "component": "dropdown",
+      "name": "ComplaintReason",
+      "label": "Complaint Reason"
+    },
+    {
+      "validation": [
+        "required"
+      ],
       "props": {},
       "component": "date",
       "name": "DispatchDate",

--- a/src/main/resources/screens/POGR2_HMPO_DISPATCH_INPUT.json
+++ b/src/main/resources/screens/POGR2_HMPO_DISPATCH_INPUT.json
@@ -65,6 +65,134 @@
       "validation": [
         "required"
       ],
+      "props": {
+        "choices": "HMPO_COMPLAINT_CATEGORIES"
+      },
+      "component": "dropdown",
+      "name": "ComplainantCategory",
+      "label": "Complaint Category"
+    },
+    {
+      "validation": [
+        "required"
+      ],
+      "props": {
+        "conditionChoices": [
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_ABI",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Authentication By Interview (ABI)"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_CUSTOMER_COMMUNICATIONS",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Customer Communications"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_DHL",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "DHL"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_DISCRIMINATORY",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Discriminatory"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_FEDEX",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Fedex"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_EXAMINATION",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Examination"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_CSMT",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "CSMT"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_COUNTER_SERVICES",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "HMPO Counter Services"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_POLICY",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "HMPO Policy and Procedures"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_ID_CHECKS",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "ID Checks & Counter Fraud"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_NATIONALITY",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Nationality"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_DIGITAL",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Digital Application Channels"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_PAPER",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Paper Application Form"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_PARTNERS_OTHER",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Partners - Other"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_POL",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "POL - Check & Send"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_QUALITY",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Product Quality & Design"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_ROYAL_MAIL",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Royal Mail"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_TP_ADVICELINE",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "TP - Passport Adviceline"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_OAB",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "OAB"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_SOPRA_STERIA",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Sopra Steria"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_SVS",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "SVS"
+          }
+        ]
+      },
+      "component": "dropdown",
+      "name": "ComplaintReason",
+      "label": "Complaint Reason"
+    },
+    {
+      "validation": [
+        "required"
+      ],
       "props": {},
       "component": "date",
       "name": "DispatchDate",

--- a/src/main/resources/screens/POGR_GRO_DISPATCH_INPUT.json
+++ b/src/main/resources/screens/POGR_GRO_DISPATCH_INPUT.json
@@ -65,6 +65,134 @@
       "validation": [
         "required"
       ],
+      "props": {
+        "choices": "GRO_COMPLAINT_CATEGORIES"
+      },
+      "component": "dropdown",
+      "name": "ComplainantCategory",
+      "label": "Complaint Category"
+    },
+    {
+      "validation": [
+        "required"
+      ],
+      "props": {
+        "conditionChoices": [
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_CSMT",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "CSMT - Customer Service"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_STANDARD",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - Standard"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_PRIORITIES",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - Priorities"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_EXCEPTIONS",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - Exceptions"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_PDF",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - PDF"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_EMAIL_TEAM",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - Email Team"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_CCU_POST_TEAM",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - CCU Post team"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_KIT",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - KIT"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_PRODUCTION_INDEXING",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Production - Indexing"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_SD_FDU",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "S&D - FDU"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_SD_ENGAGEMENT",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "S&D - Engagement"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_SYSTEMS",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Systems - ROLO"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_ARC_ADOPTIONS",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "ARC - Adoptions"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_ARC_CASEWORK",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "ARC - Casework"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_POLICY",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Policy"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_POLICY_BUSINESS",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Policy - Business Procedures"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_THIRD_PARTY_DHL",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Third Party - DHL"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_THIRD_PARTY_ROYAL_MAIL",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Third Party - Royal Mail"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_THIRD_PARTY_MAIL",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Third Party - International / UK Mail"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_THIRD_PARTY_WORLD_PAY",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Third Party - World Pay"
+          },
+          {
+            "choices": "GRO_COMPLAINT_CATEGORIES_OTHER",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Other"
+          }
+        ]
+      },
+      "component": "dropdown",
+      "name": "ComplaintReason",
+      "label": "Complaint Reason"
+    },
+    {
+      "validation": [
+        "required"
+      ],
       "props": {},
       "component": "date",
       "name": "DispatchDate",

--- a/src/main/resources/screens/POGR_HMPO_DISPATCH_INPUT.json
+++ b/src/main/resources/screens/POGR_HMPO_DISPATCH_INPUT.json
@@ -65,6 +65,134 @@
       "validation": [
         "required"
       ],
+      "props": {
+        "choices": "HMPO_COMPLAINT_CATEGORIES"
+      },
+      "component": "dropdown",
+      "name": "ComplainantCategory",
+      "label": "Complaint Category"
+    },
+    {
+      "validation": [
+        "required"
+      ],
+      "props": {
+        "conditionChoices": [
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_ABI",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Authentication By Interview (ABI)"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_CUSTOMER_COMMUNICATIONS",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Customer Communications"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_DHL",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "DHL"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_DISCRIMINATORY",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Discriminatory"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_FEDEX",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Fedex"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_EXAMINATION",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Examination"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_CSMT",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "CSMT"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_COUNTER_SERVICES",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "HMPO Counter Services"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_POLICY",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "HMPO Policy and Procedures"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_ID_CHECKS",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "ID Checks & Counter Fraud"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_NATIONALITY",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Nationality"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_DIGITAL",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Digital Application Channels"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_PAPER",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Paper Application Form"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_PARTNERS_OTHER",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Partners - Other"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_POL",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "POL - Check & Send"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_QUALITY",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Product Quality & Design"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_ROYAL_MAIL",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Royal Mail"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_TP_ADVICELINE",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "TP - Passport Adviceline"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_OAB",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "OAB"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_SOPRA_STERIA",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "Sopra Steria"
+          },
+          {
+            "choices": "HMPO_COMPLAINT_CATEGORIES_SVS",
+            "conditionPropertyName": "ComplainantCategory",
+            "conditionPropertyValue": "SVS"
+          }
+        ]
+      },
+      "component": "dropdown",
+      "name": "ComplaintReason",
+      "label": "Complaint Reason"
+    },
+    {
+      "validation": [
+        "required"
+      ],
       "props": {},
       "component": "date",
       "name": "DispatchDate",


### PR DESCRIPTION
1. Currently POGR & POGR2 case type support complaint category and reason(s) as part of data input screen. On some occasions the complaint reason maybe incorrect after being investigated. 
2. In these circumstances the complaint reason must be updatable in the dispatch stage. 
3. This PR changes would help user to recorrect the complaint category and complaint reasons during dispatch stage. This will affect POGR HMPO, POGR GRO, POGR2 HMPO and POGR2 GRO case types. 

