### PR TITLE
HOCS-5691: change draft document field

### DIFF
--- a/src/main/resources/screens/IEDET_DRAFT_INPUT.json
+++ b/src/main/resources/screens/IEDET_DRAFT_INPUT.json
@@ -9,12 +9,12 @@
       ],
       "props": {
         "entity": "document",
-        "choices": "CASE_DOCUMENT_LIST_ALL",
+        "choices": "CASE_DOCUMENT_LIST_DRAFT",
         "hasAddLink": true,
         "hasRemoveLink": true
       },
       "component": "entity-list",
-      "name": "ResponseDocuments",
+      "name": "DraftDocuments",
       "label": "Response document"
     },
     {


### PR DESCRIPTION
Change the document selection entity-list at IEDET Draft to only select draft documents. To allow for the `PRIMARY DRAFT` tag this change also changes the name to DraftDocuments for enrichment.