### PR TITLE
Rollback Camunda 7.18.0 update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ repositories {
 
 dependencyManagement {
     imports {
-        mavenBom 'org.camunda.bpm:camunda-bom:7.18.0'
+        mavenBom 'org.camunda.bpm:camunda-bom:7.17.0'
     }
 }
 
@@ -34,7 +34,7 @@ dependencies {
 
     implementation('net.logstash.logback:logstash-logback-encoder:7.2')
 
-    implementation('org.camunda.bpm:camunda-engine-spring:7.18.0')
+    implementation('org.camunda.bpm:camunda-engine-spring:7.17.0')
     implementation('com.fasterxml.uuid:java-uuid-generator:4.0.1')
     implementation('commons-codec:commons-codec:1.15')
     implementation('org.apache.httpcomponents:httpclient:4.5.13')


### PR DESCRIPTION
Rolls back Camunda 7.18.0 back to 7.17.0 due to identified breaking change

(cherry picked from commit 399739e2b5f2e9963a8369f1eed540d530b644f1)