### PR TITLE
HOCS-5696: remove unallocate call

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/BpmnService.java
@@ -1,11 +1,7 @@
 package uk.gov.digital.ho.hocs.workflow;
 
-import java.text.SimpleDateFormat;
-import java.time.Clock;
-
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -15,23 +11,34 @@ import uk.gov.digital.ho.hocs.workflow.api.WorkflowService;
 import uk.gov.digital.ho.hocs.workflow.api.dto.CreateCaseResponse;
 import uk.gov.digital.ho.hocs.workflow.client.camundaclient.CamundaClient;
 import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.CaseworkClient;
-import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.dto.*;
+import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.dto.CreateCaseworkStageRequest;
+import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.dto.GetCaseworkCaseDataResponse;
+import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.dto.GetCorrespondentResponse;
+import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.dto.GetCorrespondentsResponse;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.InfoClient;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.StageTypeDto;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.TeamDto;
 import uk.gov.digital.ho.hocs.workflow.client.infoclient.dto.UnitDto;
-
 import uk.gov.digital.ho.hocs.workflow.domain.exception.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.workflow.util.NoteType;
 import uk.gov.digital.ho.hocs.workflow.util.NumberUtils;
 
 import javax.validation.constraints.NotNull;
+import java.text.SimpleDateFormat;
+import java.time.Clock;
 import java.time.LocalDate;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import static net.logstash.logback.argument.StructuredArguments.value;
-import static uk.gov.digital.ho.hocs.workflow.application.LogEvent.*;
+import static uk.gov.digital.ho.hocs.workflow.application.LogEvent.EVENT;
+import static uk.gov.digital.ho.hocs.workflow.application.LogEvent.STAGE_CREATION_STARTED;
+import static uk.gov.digital.ho.hocs.workflow.application.LogEvent.STAGE_CREATION_SUCCESS;
 
 @Service
 @Slf4j
@@ -599,6 +606,7 @@ public class BpmnService {
 
     }
 
+    @Deprecated(forRemoval = true)
     public void unallocateUserFromStage(String caseUUIDString, String stageUUIDString) {
         UUID caseUUID = UUID.fromString(caseUUIDString);
         UUID stageUUID = UUID.fromString(stageUUIDString);

--- a/src/main/resources/processes/MPAM/MPAM.bpmn
+++ b/src/main/resources/processes/MPAM/MPAM.bpmn
@@ -544,7 +544,7 @@
       <bpmn:outgoing>SequenceFlow_06j8j3d</bpmn:outgoing>
     </bpmn:callActivity>
     <bpmn:sequenceFlow id="SequenceFlow_06j8j3d" sourceRef="CallActivity_1068j5g" targetRef="ExclusiveGateway_1hlhu8m" />
-    <bpmn:callActivity id="CallActivity_Triage_Requested_Contribution" name="Triage Requested Contribution" calledElement="STAGE_WITH_USER">
+    <bpmn:callActivity id="CallActivity_Triage_Requested_Contribution" name="Triage Requested Contribution" calledElement="STAGE">
       <bpmn:extensionElements>
         <camunda:in source="TriageRequestedContributionUUID" target="StageUUID" />
         <camunda:in sourceExpression="MPAM_TRIAGE_REQUESTED_CONTRIBUTION" target="StageWorkFlow" />
@@ -1248,6 +1248,20 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM">
+      <bpmndi:BPMNEdge id="SequenceFlow_04743df_di" bpmnElement="SequenceFlow_04743df">
+        <di:waypoint x="4561" y="353" />
+        <di:waypoint x="4610" y="280" />
+        <di:waypoint x="5090" y="280" />
+        <di:waypoint x="5090" y="457" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="4650" y="261" width="22" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0v6xqqj_di" bpmnElement="Flow_0v6xqqj">
+        <di:waypoint x="4557" y="399" />
+        <di:waypoint x="4557" y="586" />
+        <di:waypoint x="4935" y="586" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_18u47e2_di" bpmnElement="Flow_18u47e2">
         <di:waypoint x="3500" y="860" />
         <di:waypoint x="3500" y="915" />
@@ -1936,15 +1950,6 @@
         <di:waypoint x="4430" y="374" />
         <di:waypoint x="4532" y="374" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_04743df_di" bpmnElement="SequenceFlow_04743df">
-        <di:waypoint x="4561" y="353" />
-        <di:waypoint x="4610" y="280" />
-        <di:waypoint x="5090" y="280" />
-        <di:waypoint x="5090" y="457" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="4650" y="261" width="22" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1vol2gw_di" bpmnElement="SequenceFlow_1vol2gw">
         <di:waypoint x="4557" y="349" />
         <di:waypoint x="4557" y="305" />
@@ -2114,11 +2119,6 @@
       <bpmndi:BPMNEdge id="SequenceFlow_14toxc6_di" bpmnElement="SequenceFlow_14toxc6">
         <di:waypoint x="238" y="502" />
         <di:waypoint x="280" y="502" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0v6xqqj_di" bpmnElement="Flow_0v6xqqj">
-        <di:waypoint x="4557" y="399" />
-        <di:waypoint x="4557" y="586" />
-        <di:waypoint x="4935" y="586" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="202" y="484" width="36" height="36" />
@@ -2423,6 +2423,12 @@
       <bpmndi:BPMNShape id="Gateway_1orri9h_di" bpmnElement="Gateway_1orri9h" isMarkerVisible="true">
         <dc:Bounds x="3024" y="665" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1bfr09l_di" bpmnElement="Gateway_1bfr09l" isMarkerVisible="true">
+        <dc:Bounds x="4532" y="255" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="4488" y="250" width="51" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0g8kpaf_di" bpmnElement="CallActivity_0g8kpaf">
         <dc:Bounds x="4730" y="334" width="100" height="80" />
       </bpmndi:BPMNShape>
@@ -2440,12 +2446,6 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Gateway_1iqhsrd_di" bpmnElement="Gateway_1iqhsrd" isMarkerVisible="true">
         <dc:Bounds x="3475" y="915" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1bfr09l_di" bpmnElement="Gateway_1bfr09l" isMarkerVisible="true">
-        <dc:Bounds x="4532" y="255" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="4488" y="250" width="51" height="14" />
-        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/MPAM/MPAM_TRIAGE_ESCALATED_REQUESTED_CONTRIBUTION.bpmn
+++ b/src/main/resources/processes/MPAM/MPAM_TRIAGE_ESCALATED_REQUESTED_CONTRIBUTION.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ixf2kb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ixf2kb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <bpmn:process id="MPAM_TRIAGE_ESCALATED_REQUESTED_CONTRIBUTION" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_0x8dpmn</bpmn:outgoing>
@@ -8,7 +8,7 @@
       <bpmn:incoming>SequenceFlow_06v8hsn</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1m917qi</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_17wwsjo</bpmn:incoming>
-      <bpmn:incoming>Flow_19ef0w2</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_0x8dpmn</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_16wwh9z</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:userTask id="UserTask_0jxw8et" name="Validate User Input">
@@ -28,7 +28,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_1co3k2r" sourceRef="ExclusiveGateway_13qjvzx" targetRef="ExclusiveGateway_0p3mwpr">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0x8dpmn" sourceRef="StartEvent_1" targetRef="Activity_18ccgnf" />
+    <bpmn:sequenceFlow id="SequenceFlow_0x8dpmn" sourceRef="StartEvent_1" targetRef="ServiceTask_05nlmnl" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_0p3mwpr" name="TriageRequestedContributionOutcome?">
       <bpmn:incoming>SequenceFlow_1co3k2r</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_10l93df</bpmn:outgoing>
@@ -98,161 +98,149 @@
     <bpmn:sequenceFlow id="SequenceFlow_17wwsjo" sourceRef="ExclusiveGateway_0dlbolw" targetRef="ServiceTask_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="Activity_18ccgnf" name="Unallocate Stage From User" camunda:expression="${bpmnService.unallocateUserFromStage(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey)}">
-      <bpmn:incoming>SequenceFlow_0x8dpmn</bpmn:incoming>
-      <bpmn:outgoing>Flow_19ef0w2</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_19ef0w2" sourceRef="Activity_18ccgnf" targetRef="ServiceTask_05nlmnl" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_TRIAGE_ESCALATED_REQUESTED_CONTRIBUTION">
-      <bpmndi:BPMNEdge id="Flow_19ef0w2_di" bpmnElement="Flow_19ef0w2">
-        <di:waypoint x="390" y="532" />
-        <di:waypoint x="485" y="532" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_17wwsjo_di" bpmnElement="SequenceFlow_17wwsjo">
-        <di:waypoint x="1378" y="198" />
-        <di:waypoint x="1378" y="81" />
-        <di:waypoint x="535" y="81" />
-        <di:waypoint x="535" y="492" />
+        <di:waypoint x="1208" y="198" />
+        <di:waypoint x="1208" y="81" />
+        <di:waypoint x="365" y="81" />
+        <di:waypoint x="365" y="492" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0t1dhfb_di" bpmnElement="SequenceFlow_0t1dhfb">
-        <di:waypoint x="1493" y="223" />
-        <di:waypoint x="1616" y="223" />
+        <di:waypoint x="1323" y="223" />
+        <di:waypoint x="1446" y="223" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0jj0974_di" bpmnElement="SequenceFlow_0jj0974">
-        <di:waypoint x="1403" y="223" />
-        <di:waypoint x="1443" y="223" />
+        <di:waypoint x="1233" y="223" />
+        <di:waypoint x="1273" y="223" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1pscwkf_di" bpmnElement="SequenceFlow_1pscwkf">
-        <di:waypoint x="1315" y="223" />
-        <di:waypoint x="1353" y="223" />
+        <di:waypoint x="1145" y="223" />
+        <di:waypoint x="1183" y="223" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1a5ltb2_di" bpmnElement="SequenceFlow_1a5ltb2">
-        <di:waypoint x="1265" y="590" />
-        <di:waypoint x="1265" y="538" />
+        <di:waypoint x="1095" y="590" />
+        <di:waypoint x="1095" y="538" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1272" y="566" width="82" height="14" />
+          <dc:Bounds x="1102" y="566" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1dmmweu_di" bpmnElement="SequenceFlow_1dmmweu">
-        <di:waypoint x="1265" y="347" />
-        <di:waypoint x="1265" y="263" />
+        <di:waypoint x="1095" y="347" />
+        <di:waypoint x="1095" y="263" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1jj24t0_di" bpmnElement="SequenceFlow_1jj24t0">
-        <di:waypoint x="1265" y="458" />
-        <di:waypoint x="1265" y="427" />
+        <di:waypoint x="1095" y="458" />
+        <di:waypoint x="1095" y="427" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1n6ai9h_di" bpmnElement="SequenceFlow_1n6ai9h">
-        <di:waypoint x="1468" y="248" />
-        <di:waypoint x="1468" y="387" />
-        <di:waypoint x="1315" y="387" />
+        <di:waypoint x="1298" y="248" />
+        <di:waypoint x="1298" y="387" />
+        <di:waypoint x="1145" y="387" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0ssgyv1_di" bpmnElement="SequenceFlow_0ssgyv1">
-        <di:waypoint x="1666" y="263" />
-        <di:waypoint x="1666" y="597" />
+        <di:waypoint x="1496" y="263" />
+        <di:waypoint x="1496" y="597" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1eba3c1_di" bpmnElement="SequenceFlow_1eba3c1">
-        <di:waypoint x="1290" y="615" />
-        <di:waypoint x="1648" y="615" />
+        <di:waypoint x="1120" y="615" />
+        <di:waypoint x="1478" y="615" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1301" y="596" width="21" height="14" />
+          <dc:Bounds x="1131" y="596" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1m917qi_di" bpmnElement="SequenceFlow_1m917qi">
-        <di:waypoint x="867" y="590" />
-        <di:waypoint x="867" y="423" />
-        <di:waypoint x="535" y="423" />
-        <di:waypoint x="535" y="492" />
+        <di:waypoint x="697" y="590" />
+        <di:waypoint x="697" y="423" />
+        <di:waypoint x="365" y="423" />
+        <di:waypoint x="365" y="492" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="816" y="550" width="40" height="14" />
+          <dc:Bounds x="646" y="550" width="40" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_10l93df_di" bpmnElement="SequenceFlow_10l93df">
-        <di:waypoint x="892" y="615" />
-        <di:waypoint x="1240" y="615" />
+        <di:waypoint x="722" y="615" />
+        <di:waypoint x="1070" y="615" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="933" y="597" width="21" height="14" />
+          <dc:Bounds x="763" y="597" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0x8dpmn_di" bpmnElement="SequenceFlow_0x8dpmn">
         <di:waypoint x="188" y="532" />
-        <di:waypoint x="290" y="532" />
+        <di:waypoint x="315" y="532" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1co3k2r_di" bpmnElement="SequenceFlow_1co3k2r">
-        <di:waypoint x="740" y="615" />
-        <di:waypoint x="842" y="615" />
+        <di:waypoint x="570" y="615" />
+        <di:waypoint x="672" y="615" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1da9mhc_di" bpmnElement="SequenceFlow_1da9mhc">
-        <di:waypoint x="585" y="695" />
-        <di:waypoint x="715" y="695" />
-        <di:waypoint x="715" y="640" />
+        <di:waypoint x="415" y="695" />
+        <di:waypoint x="545" y="695" />
+        <di:waypoint x="545" y="640" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_16wwh9z_di" bpmnElement="SequenceFlow_16wwh9z">
-        <di:waypoint x="535" y="572" />
-        <di:waypoint x="535" y="655" />
+        <di:waypoint x="365" y="572" />
+        <di:waypoint x="365" y="655" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_06v8hsn_di" bpmnElement="SequenceFlow_06v8hsn">
-        <di:waypoint x="715" y="590" />
-        <di:waypoint x="715" y="532" />
-        <di:waypoint x="585" y="532" />
+        <di:waypoint x="545" y="590" />
+        <di:waypoint x="545" y="532" />
+        <di:waypoint x="415" y="532" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="703" y="511" width="24" height="14" />
+          <dc:Bounds x="533" y="511" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="152" y="514" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_05nlmnl_di" bpmnElement="ServiceTask_05nlmnl">
-        <dc:Bounds x="485" y="492" width="100" height="80" />
+        <dc:Bounds x="315" y="492" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0jxw8et_di" bpmnElement="UserTask_0jxw8et">
-        <dc:Bounds x="485" y="655" width="100" height="80" />
+        <dc:Bounds x="315" y="655" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_13qjvzx_di" bpmnElement="ExclusiveGateway_13qjvzx" isMarkerVisible="true">
-        <dc:Bounds x="690" y="590" width="50" height="50" />
+        <dc:Bounds x="520" y="590" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0p3mwpr_di" bpmnElement="ExclusiveGateway_0p3mwpr" isMarkerVisible="true">
-        <dc:Bounds x="842" y="590" width="50" height="50" />
+        <dc:Bounds x="672" y="590" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="777" y="634" width="84" height="40" />
+          <dc:Bounds x="607" y="634" width="84" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_155qjcq_di" bpmnElement="EndEvent_155qjcq">
-        <dc:Bounds x="1648" y="597" width="36" height="36" />
+        <dc:Bounds x="1478" y="597" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1640" y="643" width="52" height="14" />
+          <dc:Bounds x="1470" y="643" width="52" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0n42bj5_di" bpmnElement="ServiceTask_0n42bj5">
-        <dc:Bounds x="1215" y="347" width="100" height="80" />
+        <dc:Bounds x="1045" y="347" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1aiye3g_di" bpmnElement="ExclusiveGateway_1aiye3g" isMarkerVisible="true">
-        <dc:Bounds x="1240" y="590" width="50" height="50" />
+        <dc:Bounds x="1070" y="590" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1224" y="642" width="84" height="40" />
+          <dc:Bounds x="1054" y="642" width="84" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0wfgq51_di" bpmnElement="UserTask_0wfgq51">
-        <dc:Bounds x="1215" y="183" width="100" height="80" />
+        <dc:Bounds x="1045" y="183" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0dlbolw_di" bpmnElement="ExclusiveGateway_0dlbolw" isMarkerVisible="true">
-        <dc:Bounds x="1353" y="198" width="50" height="50" />
+        <dc:Bounds x="1183" y="198" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1339" y="258" width="78" height="14" />
+          <dc:Bounds x="1169" y="258" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1vuskiu_di" bpmnElement="ExclusiveGateway_1vuskiu" isMarkerVisible="true">
-        <dc:Bounds x="1443" y="198" width="50" height="50" />
+        <dc:Bounds x="1273" y="198" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0d0na5b_di" bpmnElement="ServiceTask_0d0na5b">
-        <dc:Bounds x="1616" y="183" width="100" height="80" />
+        <dc:Bounds x="1446" y="183" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0e3golq_di" bpmnElement="ServiceTask_0e3golq">
-        <dc:Bounds x="1215" y="458" width="100" height="80" />
+        <dc:Bounds x="1045" y="458" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_18ccgnf_di" bpmnElement="Activity_18ccgnf">
-        <dc:Bounds x="290" y="492" width="100" height="80" />
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="514" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/MPAM/MPAM_TRIAGE_REQUESTED_CONTRIBUTION.bpmn
+++ b/src/main/resources/processes/MPAM/MPAM_TRIAGE_REQUESTED_CONTRIBUTION.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ixf2kb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ixf2kb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <bpmn:process id="MPAM_TRIAGE_REQUESTED_CONTRIBUTION" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_0x8dpmn</bpmn:outgoing>
@@ -8,7 +8,7 @@
       <bpmn:incoming>SequenceFlow_06v8hsn</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1m917qi</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_17wwsjo</bpmn:incoming>
-      <bpmn:incoming>Flow_19ef0w2</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_0x8dpmn</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_16wwh9z</bpmn:outgoing>
     </bpmn:serviceTask>
     <bpmn:userTask id="UserTask_0jxw8et" name="Validate User Input">
@@ -28,7 +28,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_1co3k2r" sourceRef="ExclusiveGateway_13qjvzx" targetRef="ExclusiveGateway_0p3mwpr">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0x8dpmn" sourceRef="StartEvent_1" targetRef="Activity_18ccgnf" />
+    <bpmn:sequenceFlow id="SequenceFlow_0x8dpmn" sourceRef="StartEvent_1" targetRef="ServiceTask_05nlmnl" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_0p3mwpr" name="TriageRequestedContributionOutcome?">
       <bpmn:incoming>SequenceFlow_1co3k2r</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_10l93df</bpmn:outgoing>
@@ -98,161 +98,149 @@
     <bpmn:sequenceFlow id="SequenceFlow_17wwsjo" sourceRef="ExclusiveGateway_0dlbolw" targetRef="ServiceTask_05nlmnl">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "BACKWARD"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:serviceTask id="Activity_18ccgnf" name="Unallocate Stage From User" camunda:expression="${bpmnService.unallocateUserFromStage(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey)}">
-      <bpmn:incoming>SequenceFlow_0x8dpmn</bpmn:incoming>
-      <bpmn:outgoing>Flow_19ef0w2</bpmn:outgoing>
-    </bpmn:serviceTask>
-    <bpmn:sequenceFlow id="Flow_19ef0w2" sourceRef="Activity_18ccgnf" targetRef="ServiceTask_05nlmnl" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_TRIAGE_REQUESTED_CONTRIBUTION">
-      <bpmndi:BPMNEdge id="Flow_19ef0w2_di" bpmnElement="Flow_19ef0w2">
-        <di:waypoint x="390" y="532" />
-        <di:waypoint x="485" y="532" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_17wwsjo_di" bpmnElement="SequenceFlow_17wwsjo">
-        <di:waypoint x="1378" y="198" />
-        <di:waypoint x="1378" y="81" />
-        <di:waypoint x="535" y="81" />
-        <di:waypoint x="535" y="492" />
+        <di:waypoint x="1188" y="198" />
+        <di:waypoint x="1188" y="81" />
+        <di:waypoint x="345" y="81" />
+        <di:waypoint x="345" y="492" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0t1dhfb_di" bpmnElement="SequenceFlow_0t1dhfb">
-        <di:waypoint x="1493" y="223" />
-        <di:waypoint x="1616" y="223" />
+        <di:waypoint x="1303" y="223" />
+        <di:waypoint x="1426" y="223" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0jj0974_di" bpmnElement="SequenceFlow_0jj0974">
-        <di:waypoint x="1403" y="223" />
-        <di:waypoint x="1443" y="223" />
+        <di:waypoint x="1213" y="223" />
+        <di:waypoint x="1253" y="223" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1pscwkf_di" bpmnElement="SequenceFlow_1pscwkf">
-        <di:waypoint x="1315" y="223" />
-        <di:waypoint x="1353" y="223" />
+        <di:waypoint x="1125" y="223" />
+        <di:waypoint x="1163" y="223" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1a5ltb2_di" bpmnElement="SequenceFlow_1a5ltb2">
-        <di:waypoint x="1265" y="590" />
-        <di:waypoint x="1265" y="538" />
+        <di:waypoint x="1075" y="590" />
+        <di:waypoint x="1075" y="538" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1272" y="566" width="82" height="14" />
+          <dc:Bounds x="1082" y="566" width="82" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1dmmweu_di" bpmnElement="SequenceFlow_1dmmweu">
-        <di:waypoint x="1265" y="347" />
-        <di:waypoint x="1265" y="263" />
+        <di:waypoint x="1075" y="347" />
+        <di:waypoint x="1075" y="263" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1jj24t0_di" bpmnElement="SequenceFlow_1jj24t0">
-        <di:waypoint x="1265" y="458" />
-        <di:waypoint x="1265" y="427" />
+        <di:waypoint x="1075" y="458" />
+        <di:waypoint x="1075" y="427" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1n6ai9h_di" bpmnElement="SequenceFlow_1n6ai9h">
-        <di:waypoint x="1468" y="248" />
-        <di:waypoint x="1468" y="387" />
-        <di:waypoint x="1315" y="387" />
+        <di:waypoint x="1278" y="248" />
+        <di:waypoint x="1278" y="387" />
+        <di:waypoint x="1125" y="387" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0ssgyv1_di" bpmnElement="SequenceFlow_0ssgyv1">
-        <di:waypoint x="1666" y="263" />
-        <di:waypoint x="1666" y="597" />
+        <di:waypoint x="1476" y="263" />
+        <di:waypoint x="1476" y="597" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1eba3c1_di" bpmnElement="SequenceFlow_1eba3c1">
-        <di:waypoint x="1290" y="615" />
-        <di:waypoint x="1648" y="615" />
+        <di:waypoint x="1100" y="615" />
+        <di:waypoint x="1458" y="615" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1301" y="596" width="21" height="14" />
+          <dc:Bounds x="1111" y="596" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1m917qi_di" bpmnElement="SequenceFlow_1m917qi">
-        <di:waypoint x="867" y="590" />
-        <di:waypoint x="867" y="423" />
-        <di:waypoint x="535" y="423" />
-        <di:waypoint x="535" y="492" />
+        <di:waypoint x="677" y="590" />
+        <di:waypoint x="677" y="423" />
+        <di:waypoint x="345" y="423" />
+        <di:waypoint x="345" y="492" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="816" y="550" width="40" height="14" />
+          <dc:Bounds x="626" y="550" width="40" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_10l93df_di" bpmnElement="SequenceFlow_10l93df">
-        <di:waypoint x="892" y="615" />
-        <di:waypoint x="1240" y="615" />
+        <di:waypoint x="702" y="615" />
+        <di:waypoint x="1050" y="615" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="933" y="597" width="21" height="14" />
+          <dc:Bounds x="743" y="597" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_0x8dpmn_di" bpmnElement="SequenceFlow_0x8dpmn">
         <di:waypoint x="188" y="532" />
-        <di:waypoint x="290" y="532" />
+        <di:waypoint x="295" y="532" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1co3k2r_di" bpmnElement="SequenceFlow_1co3k2r">
-        <di:waypoint x="740" y="615" />
-        <di:waypoint x="842" y="615" />
+        <di:waypoint x="550" y="615" />
+        <di:waypoint x="652" y="615" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1da9mhc_di" bpmnElement="SequenceFlow_1da9mhc">
-        <di:waypoint x="585" y="695" />
-        <di:waypoint x="715" y="695" />
-        <di:waypoint x="715" y="640" />
+        <di:waypoint x="395" y="695" />
+        <di:waypoint x="525" y="695" />
+        <di:waypoint x="525" y="640" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_16wwh9z_di" bpmnElement="SequenceFlow_16wwh9z">
-        <di:waypoint x="535" y="572" />
-        <di:waypoint x="535" y="655" />
+        <di:waypoint x="345" y="572" />
+        <di:waypoint x="345" y="655" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_06v8hsn_di" bpmnElement="SequenceFlow_06v8hsn">
-        <di:waypoint x="715" y="590" />
-        <di:waypoint x="715" y="532" />
-        <di:waypoint x="585" y="532" />
+        <di:waypoint x="525" y="590" />
+        <di:waypoint x="525" y="532" />
+        <di:waypoint x="395" y="532" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="703" y="511" width="24" height="14" />
+          <dc:Bounds x="513" y="511" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="152" y="514" width="36" height="36" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_05nlmnl_di" bpmnElement="ServiceTask_05nlmnl">
-        <dc:Bounds x="485" y="492" width="100" height="80" />
+        <dc:Bounds x="295" y="492" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0jxw8et_di" bpmnElement="UserTask_0jxw8et">
-        <dc:Bounds x="485" y="655" width="100" height="80" />
+        <dc:Bounds x="295" y="655" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_13qjvzx_di" bpmnElement="ExclusiveGateway_13qjvzx" isMarkerVisible="true">
-        <dc:Bounds x="690" y="590" width="50" height="50" />
+        <dc:Bounds x="500" y="590" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0p3mwpr_di" bpmnElement="ExclusiveGateway_0p3mwpr" isMarkerVisible="true">
-        <dc:Bounds x="842" y="590" width="50" height="50" />
+        <dc:Bounds x="652" y="590" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="777" y="634" width="84" height="40" />
+          <dc:Bounds x="587" y="634" width="84" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="EndEvent_155qjcq_di" bpmnElement="EndEvent_155qjcq">
-        <dc:Bounds x="1648" y="597" width="36" height="36" />
+        <dc:Bounds x="1458" y="597" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1640" y="643" width="52" height="14" />
+          <dc:Bounds x="1450" y="643" width="52" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0n42bj5_di" bpmnElement="ServiceTask_0n42bj5">
-        <dc:Bounds x="1215" y="347" width="100" height="80" />
+        <dc:Bounds x="1025" y="347" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1aiye3g_di" bpmnElement="ExclusiveGateway_1aiye3g" isMarkerVisible="true">
-        <dc:Bounds x="1240" y="590" width="50" height="50" />
+        <dc:Bounds x="1050" y="590" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1224" y="642" width="84" height="40" />
+          <dc:Bounds x="1034" y="642" width="84" height="40" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="UserTask_0wfgq51_di" bpmnElement="UserTask_0wfgq51">
-        <dc:Bounds x="1215" y="183" width="100" height="80" />
+        <dc:Bounds x="1025" y="183" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_0dlbolw_di" bpmnElement="ExclusiveGateway_0dlbolw" isMarkerVisible="true">
-        <dc:Bounds x="1353" y="198" width="50" height="50" />
+        <dc:Bounds x="1163" y="198" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="1339" y="258" width="78" height="14" />
+          <dc:Bounds x="1149" y="258" width="78" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ExclusiveGateway_1vuskiu_di" bpmnElement="ExclusiveGateway_1vuskiu" isMarkerVisible="true">
-        <dc:Bounds x="1443" y="198" width="50" height="50" />
+        <dc:Bounds x="1253" y="198" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0d0na5b_di" bpmnElement="ServiceTask_0d0na5b">
-        <dc:Bounds x="1616" y="183" width="100" height="80" />
+        <dc:Bounds x="1426" y="183" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_0e3golq_di" bpmnElement="ServiceTask_0e3golq">
-        <dc:Bounds x="1215" y="458" width="100" height="80" />
+        <dc:Bounds x="1025" y="458" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_18ccgnf_di" bpmnElement="Activity_18ccgnf">
-        <dc:Bounds x="290" y="492" width="100" height="80" />
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="514" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
Removal of the unallocate user call from MPAM Triage Requested Contribution diagrams as unnecessary. This was from incorrect implementation initially and not required as the same user can be allocated to these cases.