### PR TITLE
HOCS-3628: change choice visibility

### DIFF
--- a/src/main/resources/screens/MPAM_QA_CLEARANCE_INPUT.json
+++ b/src/main/resources/screens/MPAM_QA_CLEARANCE_INPUT.json
@@ -258,8 +258,7 @@
           },
           {
             "label": "Request Secretariat Clearance",
-            "value": "RequestSecretariatClearance",
-            "visible": false
+            "value": "RequestSecretariatClearance"
           },
           {
             "label": "Rejected, move back to triage",


### PR DESCRIPTION
Remove the visible false flag from the `RequestSecretariatClearance` option in MPAM QA Clearance.