### PR TITLE
Add missing default flow to MPAM_TRIAGE

### DIFF
--- a/src/main/resources/processes/MPAM/MPAM_TRIAGE.bpmn
+++ b/src/main/resources/processes/MPAM/MPAM_TRIAGE.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ixf2kb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0ixf2kb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <bpmn:process id="MPAM_TRIAGE" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_0x8dpmn</bpmn:outgoing>
@@ -74,16 +74,14 @@
     <bpmn:sequenceFlow id="SequenceFlow_1vaolyx" name="else" sourceRef="ExclusiveGateway_1ivf0n0" targetRef="EndEvent_MpamTriage">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${TriageOutcome != "SendToDraft"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="ExclusiveGateway_08l5d8b" name="Direction Check">
+    <bpmn:exclusiveGateway id="ExclusiveGateway_08l5d8b" name="Direction Check" default="SequenceFlow_080dqh7">
       <bpmn:incoming>SequenceFlow_1da9mhc</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_080dqh7</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1stb0k6</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_1mlhuzu</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0nrrrl7</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:sequenceFlow id="SequenceFlow_080dqh7" name="FORWARD" sourceRef="ExclusiveGateway_08l5d8b" targetRef="ExclusiveGateway_13qjvzx">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "FORWARD"}</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_080dqh7" name="FORWARD" sourceRef="ExclusiveGateway_08l5d8b" targetRef="ExclusiveGateway_13qjvzx" />
     <bpmn:sequenceFlow id="SequenceFlow_1stb0k6" name="UpdateEnquirySubject" sourceRef="ExclusiveGateway_08l5d8b" targetRef="UpdateEnquiryReason_Activity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DIRECTION == "UpdateEnquirySubject"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
@@ -578,6 +576,97 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MPAM_TRIAGE">
+      <bpmndi:BPMNEdge id="SequenceFlow_068rpjw_di" bpmnElement="SequenceFlow_068rpjw">
+        <di:waypoint x="813" y="1935" />
+        <di:waypoint x="813" y="1999" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ijxxtj_di" bpmnElement="SequenceFlow_1ijxxtj">
+        <di:waypoint x="838" y="2138" />
+        <di:waypoint x="967" y="2138" />
+        <di:waypoint x="967" y="1823" />
+        <di:waypoint x="610" y="1823" />
+        <di:waypoint x="610" y="1895" />
+        <di:waypoint x="763" y="1895" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="890" y="2120" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_11990z3_di" bpmnElement="SequenceFlow_11990z3">
+        <di:waypoint x="813" y="2049" />
+        <di:waypoint x="813" y="2113" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="745" y="2064" width="57" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0enh4xh_di" bpmnElement="SequenceFlow_0enh4xh">
+        <di:waypoint x="788" y="2024" />
+        <di:waypoint x="480" y="2024" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="732" y="2003" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0wvio0a_di" bpmnElement="SequenceFlow_0wvio0a">
+        <di:waypoint x="813" y="2163" />
+        <di:waypoint x="813" y="2249" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1101m5b_di" bpmnElement="SequenceFlow_1101m5b">
+        <di:waypoint x="380" y="2024" />
+        <di:waypoint x="318" y="2024" />
+        <di:waypoint x="318" y="556" />
+        <di:waypoint x="380" y="556" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0a2kz4o_di" bpmnElement="SequenceFlow_0a2kz4o">
+        <di:waypoint x="863" y="2289" />
+        <di:waypoint x="966" y="2289" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_00xav5j_di" bpmnElement="SequenceFlow_00xav5j">
+        <di:waypoint x="1016" y="2329" />
+        <di:waypoint x="1016" y="2393" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0z80bhn_di" bpmnElement="SequenceFlow_0z80bhn">
+        <di:waypoint x="1041" y="2532" />
+        <di:waypoint x="1155" y="2532" />
+        <di:waypoint x="1155" y="2217" />
+        <di:waypoint x="813" y="2217" />
+        <di:waypoint x="813" y="2249" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1086" y="2515" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_08xepts_di" bpmnElement="SequenceFlow_08xepts">
+        <di:waypoint x="1016" y="2443" />
+        <di:waypoint x="1016" y="2507" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="948" y="2458" width="57" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1enm75p_di" bpmnElement="SequenceFlow_1enm75p">
+        <di:waypoint x="991" y="2418" />
+        <di:waypoint x="480" y="2418" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="925" y="2401" width="64" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_11zk0mc_di" bpmnElement="SequenceFlow_11zk0mc">
+        <di:waypoint x="991" y="2532" />
+        <di:waypoint x="480" y="2532" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sq5itz_di" bpmnElement="SequenceFlow_1sq5itz">
+        <di:waypoint x="380" y="2418" />
+        <di:waypoint x="318" y="2418" />
+        <di:waypoint x="318" y="556" />
+        <di:waypoint x="380" y="556" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0jpt0ej_di" bpmnElement="SequenceFlow_0jpt0ej">
+        <di:waypoint x="430" y="2492" />
+        <di:waypoint x="430" y="2458" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_183ayoj_di" bpmnElement="Flow_183ayoj">
+        <di:waypoint x="560" y="1590" />
+        <di:waypoint x="320" y="1590" />
+        <di:waypoint x="320" y="580" />
+        <di:waypoint x="380" y="580" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_10f25gy_di" bpmnElement="SequenceFlow_10f25gy">
         <di:waypoint x="1400" y="873" />
         <di:waypoint x="1445" y="873" />
@@ -961,91 +1050,6 @@
           <dc:Bounds x="986" y="621" width="21" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0enh4xh_di" bpmnElement="SequenceFlow_0enh4xh">
-        <di:waypoint x="788" y="2024" />
-        <di:waypoint x="480" y="2024" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="732" y="2003" width="64" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1enm75p_di" bpmnElement="SequenceFlow_1enm75p">
-        <di:waypoint x="991" y="2418" />
-        <di:waypoint x="480" y="2418" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="925" y="2401" width="64" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1101m5b_di" bpmnElement="SequenceFlow_1101m5b">
-        <di:waypoint x="380" y="2024" />
-        <di:waypoint x="318" y="2024" />
-        <di:waypoint x="318" y="556" />
-        <di:waypoint x="380" y="556" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1sq5itz_di" bpmnElement="SequenceFlow_1sq5itz">
-        <di:waypoint x="380" y="2418" />
-        <di:waypoint x="318" y="2418" />
-        <di:waypoint x="318" y="556" />
-        <di:waypoint x="380" y="556" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0jpt0ej_di" bpmnElement="SequenceFlow_0jpt0ej">
-        <di:waypoint x="430" y="2492" />
-        <di:waypoint x="430" y="2458" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_11zk0mc_di" bpmnElement="SequenceFlow_11zk0mc">
-        <di:waypoint x="991" y="2532" />
-        <di:waypoint x="480" y="2532" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_08xepts_di" bpmnElement="SequenceFlow_08xepts">
-        <di:waypoint x="1016" y="2443" />
-        <di:waypoint x="1016" y="2507" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="948" y="2458" width="57" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_00xav5j_di" bpmnElement="SequenceFlow_00xav5j">
-        <di:waypoint x="1016" y="2329" />
-        <di:waypoint x="1016" y="2393" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0a2kz4o_di" bpmnElement="SequenceFlow_0a2kz4o">
-        <di:waypoint x="863" y="2289" />
-        <di:waypoint x="966" y="2289" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0z80bhn_di" bpmnElement="SequenceFlow_0z80bhn">
-        <di:waypoint x="1041" y="2532" />
-        <di:waypoint x="1155" y="2532" />
-        <di:waypoint x="1155" y="2217" />
-        <di:waypoint x="813" y="2217" />
-        <di:waypoint x="813" y="2249" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1086" y="2515" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_11990z3_di" bpmnElement="SequenceFlow_11990z3">
-        <di:waypoint x="813" y="2049" />
-        <di:waypoint x="813" y="2113" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="745" y="2064" width="57" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0wvio0a_di" bpmnElement="SequenceFlow_0wvio0a">
-        <di:waypoint x="813" y="2163" />
-        <di:waypoint x="813" y="2249" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1ijxxtj_di" bpmnElement="SequenceFlow_1ijxxtj">
-        <di:waypoint x="838" y="2138" />
-        <di:waypoint x="967" y="2138" />
-        <di:waypoint x="967" y="1823" />
-        <di:waypoint x="610" y="1823" />
-        <di:waypoint x="610" y="1895" />
-        <di:waypoint x="763" y="1895" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="890" y="2120" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_068rpjw_di" bpmnElement="SequenceFlow_068rpjw">
-        <di:waypoint x="813" y="1935" />
-        <di:waypoint x="813" y="1999" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1stb0k6_di" bpmnElement="SequenceFlow_1stb0k6">
         <di:waypoint x="610" y="823" />
         <di:waypoint x="610" y="1550" />
@@ -1118,12 +1122,6 @@
           <dc:Bounds x="598" y="535" width="24" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_183ayoj_di" bpmnElement="Flow_183ayoj">
-        <di:waypoint x="560" y="1590" />
-        <di:waypoint x="320" y="1590" />
-        <di:waypoint x="320" y="580" />
-        <di:waypoint x="380" y="580" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="156" y="538" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -1162,42 +1160,6 @@
         <bpmndi:BPMNLabel>
           <dc:Bounds x="517" y="769" width="78" height="14" />
         </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_1r69osa_di" bpmnElement="UserTask_1r69osa">
-        <dc:Bounds x="763" y="1855" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_00ge51l_di" bpmnElement="ExclusiveGateway_00ge51l" isMarkerVisible="true">
-        <dc:Bounds x="788" y="2113" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_049krff_di" bpmnElement="ExclusiveGateway_049krff" isMarkerVisible="true">
-        <dc:Bounds x="788" y="1999" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="848" y="2017" width="78" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_1wl4mgd_di" bpmnElement="ServiceTask_1wl4mgd">
-        <dc:Bounds x="763" y="2249" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="UserTask_0kelzuk_di" bpmnElement="UserTask_0kelzuk">
-        <dc:Bounds x="966" y="2249" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_17q8hsm_di" bpmnElement="ExclusiveGateway_17q8hsm" isMarkerVisible="true">
-        <dc:Bounds x="991" y="2507" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ExclusiveGateway_1iftjr8_di" bpmnElement="ExclusiveGateway_1iftjr8" isMarkerVisible="true">
-        <dc:Bounds x="991" y="2393" width="50" height="50" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1051" y="2411" width="78" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_12eh3q4_di" bpmnElement="ServiceTask_12eh3q4">
-        <dc:Bounds x="380" y="2492" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_060ccpx_di" bpmnElement="ServiceTask_060ccpx">
-        <dc:Bounds x="380" y="2378" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="ServiceTask_0hpe5ym_di" bpmnElement="ServiceTask_0hpe5ym">
-        <dc:Bounds x="380" y="1984" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="ServiceTask_1w1h0tl_di" bpmnElement="ServiceTask_1w1h0tl">
         <dc:Bounds x="895" y="303" width="100" height="80" />
@@ -1378,6 +1340,42 @@
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_00opwf9_di" bpmnElement="UpdateEnquiryReason_Activity">
         <dc:Bounds x="560" y="1550" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_12eh3q4_di" bpmnElement="ServiceTask_12eh3q4">
+        <dc:Bounds x="380" y="2492" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_060ccpx_di" bpmnElement="ServiceTask_060ccpx">
+        <dc:Bounds x="380" y="2378" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_17q8hsm_di" bpmnElement="ExclusiveGateway_17q8hsm" isMarkerVisible="true">
+        <dc:Bounds x="991" y="2507" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_1iftjr8_di" bpmnElement="ExclusiveGateway_1iftjr8" isMarkerVisible="true">
+        <dc:Bounds x="991" y="2393" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1051" y="2411" width="78" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_0kelzuk_di" bpmnElement="UserTask_0kelzuk">
+        <dc:Bounds x="966" y="2249" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1wl4mgd_di" bpmnElement="ServiceTask_1wl4mgd">
+        <dc:Bounds x="763" y="2249" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0hpe5ym_di" bpmnElement="ServiceTask_0hpe5ym">
+        <dc:Bounds x="380" y="1984" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_00ge51l_di" bpmnElement="ExclusiveGateway_00ge51l" isMarkerVisible="true">
+        <dc:Bounds x="788" y="2113" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ExclusiveGateway_049krff_di" bpmnElement="ExclusiveGateway_049krff" isMarkerVisible="true">
+        <dc:Bounds x="788" y="1999" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="848" y="2017" width="78" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="UserTask_1r69osa_di" bpmnElement="UserTask_1r69osa">
+        <dc:Bounds x="763" y="1855" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>


### PR DESCRIPTION
After passing the initial user input screen in the MPAM_TRIAGE process there are 3 direction moves: `FORWARD`, `UpdateEnquirySubject`, and `UpdateRefType`. We currently don't handle a default flow out of this screen. This change makes the `FORWARD` route the default while we design best practice across processes.