### PR TITLE
[HOCS-5883] Correct typo in PSU triage stage CloseCase option

### DIFF
--- a/src/main/resources/screens/PSU_TRAIGE_COMPLAINT.json
+++ b/src/main/resources/screens/PSU_TRAIGE_COMPLAINT.json
@@ -18,7 +18,7 @@
             "value": "ReturnCase"
           },
           {
-            "label": "No - send to team not to DECS",
+            "label": "No - send to team not on DECS",
             "value": "CloseCase"
           }
         ],


### PR DESCRIPTION
In the IEDET PSU Triage stage, the option 'No - send to team not on DECS' is instead showing as 'No - send to team not to DECS'