### PR TITLE
HOCS-5859 - Update correct label name for Provision for Minors checkbox

### DIFF
--- a/src/main/resources/screens/IEDET_TRIAGE_CATEGORY.json
+++ b/src/main/resources/screens/IEDET_TRIAGE_CATEGORY.json
@@ -317,5 +317,5 @@
       "label": "Back"
     }
   ],
-  "validation": "{\"linkTo\": \"ServiceAccordion\", \"message\": \"Select at least one complaint category option\", \"options\": [\"CatAdminErr\", \"CatAvail\", \"CatDelay\", \"CatPhysEnv\", \"CatPoorComm\", \"CatLost\", \"CatStolen\", \"CatWithheld\", \"CatCCProvMinor\", \"CatWrongInfo\", \"CatHandle\", \"CatRude\", \"CatUnfair\", \"CatOtherUnprof\", \"CatDetOnDet\", \"CatTheft\", \"CatAssault\", \"CatSexAssault\", \"CatFraud\", \"CatRacism\"], \"validator\": \"oneOf\"}"
+  "validation": "{\"linkTo\": \"ServiceAccordion\", \"message\": \"Select at least one complaint category option\", \"options\": [\"CatAdminErr\", \"CatAvail\", \"CatDelay\", \"CatPhysEnv\", \"CatPoorComm\", \"CatLost\", \"CatStolen\", \"CatWithheld\", \"CatProvMinor\", \"CatWrongInfo\", \"CatHandle\", \"CatRude\", \"CatUnfair\", \"CatOtherUnprof\", \"CatDetOnDet\", \"CatTheft\", \"CatAssault\", \"CatSexAssault\", \"CatFraud\", \"CatRacism\"], \"validator\": \"oneOf\"}"
 }


### PR DESCRIPTION
HOCS-5859 - This PR would help to fix the bug when 
user selects Provision for minors check box and 
click on submit button where user would be navigated 
complaint details screen. 
Currently if the user selects this option and clicks on 
submit button then an error is propagated which is an 
incorrect behaviour.