### PR TITLE
HOCS-3567 - Update enums to make the translation looks better in DECS

### DIFF
--- a/src/main/resources/screens/COMP_OTHER_INPUT.json
+++ b/src/main/resources/screens/COMP_OTHER_INPUT.json
@@ -476,7 +476,7 @@
             "value": "EXISTING"
           },
           {
-            "label": "Document delays",
+            "label": "Decision or document delays",
             "value": "DOCUMENT_DELAYS"
           },
           {
@@ -492,11 +492,11 @@
             "value": "REFUND"
           },
           {
-            "label": "Poor staff behaviour",
+            "label": "Staff behaviour",
             "value": "POOR_STAFF_BEHAVIOUR"
           },
           {
-            "label": "Poor information",
+            "label": "Staff behaviour",
             "value": "POOR_INFORMATION"
           },
           {


### PR DESCRIPTION
HOCS-3567 : This PR would help to update the enum 
values so that user will have better complaint 
reason displayed in DECS. Currently DOCUMENT_DELAYS
mapped to Document Delays whereas POOR_STAFF_BEHAVIOUR
mapped to Poor staff behaviour and POOR_INFORMATION 
mapped to Poor Information.