### PR TITLE
HOCS-5931: rename process name

### DIFF
--- a/src/main/resources/processes/IEDET/IEDET.bpmn
+++ b/src/main/resources/processes/IEDET/IEDET.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1chg3vp" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1chg3vp" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0">
   <bpmn:process id="IEDET" isExecutable="true">
     <bpmn:startEvent id="StartEvent_IEDET">
       <bpmn:outgoing>SequenceFlow_1jkxh22</bpmn:outgoing>
@@ -116,7 +116,7 @@
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CompType == "SeriousMisconduct"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1r9dyvr" sourceRef="CallActivity_PSU_COMPLAINT" targetRef="Gateway_1qaiobu" />
-    <bpmn:callActivity id="CallActivity_PSU_COMPLAINT" name="PSU Complaint" calledElement="PSU_COMPLAINT">
+    <bpmn:callActivity id="CallActivity_PSU_COMPLAINT" name="PSU Complaint" calledElement="PSU_IEDET_COMPLAINT">
       <bpmn:extensionElements>
         <camunda:in businessKey="#{execution.processBusinessKey}" />
         <camunda:in variables="all" />

--- a/src/main/resources/processes/PSU/PSU_IEDET_COMPLAINT.bpmn
+++ b/src/main/resources/processes/PSU/PSU_IEDET_COMPLAINT.bpmn
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_00l63uj" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
-  <bpmn:process id="PSU_COMPLAINT" isExecutable="true">
+  <bpmn:process id="PSU_IEDET_COMPLAINT" isExecutable="true">
     <bpmn:startEvent id="StartEvent_Complaint">
       <bpmn:outgoing>Flow_0lb4jdo</bpmn:outgoing>
     </bpmn:startEvent>
@@ -23,7 +23,7 @@
     </bpmn:callActivity>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="PSU_COMPLAINT">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="PSU_IEDET_COMPLAINT">
       <bpmndi:BPMNEdge id="Flow_1wxyqkf_di" bpmnElement="Flow_1wxyqkf">
         <di:waypoint x="330" y="117" />
         <di:waypoint x="372" y="117" />

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/iedet/IEDET.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/iedet/IEDET.java
@@ -104,7 +104,7 @@ public class IEDET {
                 .thenReturn("CompType", "SeriousMisconduct")
                 .deploy(rule);
 
-        whenAtCallActivity("PSU_COMPLAINT")
+        whenAtCallActivity("PSU_IEDET_COMPLAINT")
             .alwaysReturn("ReturnCase", "ReturnCase-false")
             .deploy(rule);
 
@@ -128,7 +128,7 @@ public class IEDET {
             .thenReturn("CompType", "SeriousMisconduct")
             .deploy(rule);
 
-        whenAtCallActivity("PSU_COMPLAINT")
+        whenAtCallActivity("PSU_IEDET_COMPLAINT")
             .alwaysReturn("ReturnCase", "ReturnCase-true")
             .deploy(rule);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/psu/PSU_IEDET_COMPLAINT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/psu/PSU_IEDET_COMPLAINT.java
@@ -22,9 +22,8 @@ import static org.mockito.Mockito.verify;
 import static uk.gov.digital.ho.hocs.workflow.util.CallActivityMockWrapper.whenAtCallActivity;
 
 @RunWith(MockitoJUnitRunner.class)
-@Deployment(resources = {
-        "processes/PSU/PSU_COMPLAINT.bpmn"})
-public class PSU_COMPLAINT {
+@Deployment(resources = { "processes/PSU/PSU_IEDET_COMPLAINT.bpmn" })
+public class PSU_IEDET_COMPLAINT {
 
     @Rule
     @ClassRule
@@ -51,7 +50,7 @@ public class PSU_COMPLAINT {
                 .deploy(rule);
 
         Scenario.run(processScenario)
-                .startByKey("PSU_COMPLAINT", Map.of(
+                .startByKey("PSU_IEDET_COMPLAINT", Map.of(
                         "STAGE_REGISTRATION", "PSU_REGISTRATION",
                         "STAGE_TRIAGE", "PSU_TRIAGE",
                         "STAGE_OUTCOME", "PSU_OUTCOME"


### PR DESCRIPTION
Rename the `PSU_COMPLIANT` to `PSU_IEDET_COMPLAINT`. This makes it more clear what diagram is being called when we have multiple PSU integrations.