### PR TITLE
HOCS-5732 - Amend SLA for UKVI-PSU & vice-versa

### DIFF
--- a/src/main/resources/processes/COMP/COMP_PSU_OUTCOME.bpmn
+++ b/src/main/resources/processes/COMP/COMP_PSU_OUTCOME.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1qm3qgr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1qm3qgr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="COMP_PSU_OUTCOME" isExecutable="true">
     <bpmn:startEvent id="StartEvent_Outcome">
       <bpmn:outgoing>Flow_0cfsh6n</bpmn:outgoing>
@@ -15,8 +15,8 @@
           <camunda:outputParameter name="ReturnCase">${PsuComplaintOutcome == "ReturnCase" ? true : false}</camunda:outputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0cfsh6n</bpmn:incoming>
       <bpmn:incoming>Flow_05ykewo</bpmn:incoming>
+      <bpmn:incoming>Flow_080pfe1</bpmn:incoming>
       <bpmn:outgoing>Flow_1y61xv4</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:exclusiveGateway id="Gateway_1pmdn5d" default="Flow_0m5i91k">
@@ -37,7 +37,7 @@
     <bpmn:sequenceFlow id="Flow_1bcra1y" sourceRef="Gateway_1pmdn5d" targetRef="Activity_SaveWithdrawnNote">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ PsuComplaintOutcome == "Withdrawn" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0cfsh6n" sourceRef="StartEvent_Outcome" targetRef="Screen_ComplaintOutcome" />
+    <bpmn:sequenceFlow id="Flow_0cfsh6n" sourceRef="StartEvent_Outcome" targetRef="Service_UpdatePsuDeadline" />
     <bpmn:sequenceFlow id="Flow_0m5i91k" sourceRef="Gateway_1pmdn5d" targetRef="Screen_FinalResponse" />
     <bpmn:userTask id="Screen_FinalResponse" name="Final Response" camunda:formKey="COMP_PSU_OUTCOME_FINAL_RESPONSE">
       <bpmn:incoming>Flow_0m5i91k</bpmn:incoming>
@@ -58,77 +58,89 @@
     <bpmn:sequenceFlow id="Flow_05ykewo" sourceRef="Gateway_03el8xp" targetRef="Screen_ComplaintOutcome">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DIRECTION == "BACKWARD" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="Service_UpdatePsuDeadline" name="Update Case Deadline" camunda:expression="${bpmnService.updateDeadlineDays(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, 60)}">
+      <bpmn:incoming>Flow_0cfsh6n</bpmn:incoming>
+      <bpmn:outgoing>Flow_080pfe1</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_080pfe1" sourceRef="Service_UpdatePsuDeadline" targetRef="Screen_ComplaintOutcome" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMP_PSU_OUTCOME">
+      <bpmndi:BPMNEdge id="Flow_05ykewo_di" bpmnElement="Flow_05ykewo" bioc:stroke="#43a047" color:border-color="#43a047">
+        <di:waypoint x="760" y="295" />
+        <di:waypoint x="760" y="400" />
+        <di:waypoint x="420" y="400" />
+        <di:waypoint x="420" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0c2x7lv_di" bpmnElement="Flow_0c2x7lv" bioc:stroke="#e53935" color:border-color="#e53935">
+        <di:waypoint x="760" y="295" />
+        <di:waypoint x="760" y="350" />
+        <di:waypoint x="640" y="350" />
+        <di:waypoint x="640" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0wuzszh_di" bpmnElement="Flow_0wuzszh">
+        <di:waypoint x="785" y="270" />
+        <di:waypoint x="842" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_17s45h0_di" bpmnElement="Flow_17s45h0">
+        <di:waypoint x="690" y="270" />
+        <di:waypoint x="735" y="270" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0m5i91k_di" bpmnElement="Flow_0m5i91k">
-        <di:waypoint x="425" y="270" />
-        <di:waypoint x="460" y="270" />
+        <di:waypoint x="555" y="270" />
+        <di:waypoint x="590" y="270" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0cfsh6n_di" bpmnElement="Flow_0cfsh6n">
         <di:waypoint x="188" y="270" />
-        <di:waypoint x="240" y="270" />
+        <di:waypoint x="239" y="270" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1bcra1y_di" bpmnElement="Flow_1bcra1y">
-        <di:waypoint x="400" y="245" />
-        <di:waypoint x="400" y="163" />
-        <di:waypoint x="460" y="163" />
+        <di:waypoint x="530" y="245" />
+        <di:waypoint x="530" y="163" />
+        <di:waypoint x="590" y="163" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1y61xv4_di" bpmnElement="Flow_1y61xv4">
-        <di:waypoint x="340" y="270" />
-        <di:waypoint x="375" y="270" />
+        <di:waypoint x="470" y="270" />
+        <di:waypoint x="505" y="270" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_04brqap_di" bpmnElement="Flow_04brqap">
-        <di:waypoint x="560" y="163" />
-        <di:waypoint x="730" y="163" />
-        <di:waypoint x="730" y="252" />
+        <di:waypoint x="690" y="163" />
+        <di:waypoint x="860" y="163" />
+        <di:waypoint x="860" y="252" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1l3jiab_di" bpmnElement="Flow_1l3jiab">
-        <di:waypoint x="400" y="245" />
-        <di:waypoint x="400" y="83" />
-        <di:waypoint x="730" y="83" />
-        <di:waypoint x="730" y="252" />
+        <di:waypoint x="530" y="245" />
+        <di:waypoint x="530" y="83" />
+        <di:waypoint x="860" y="83" />
+        <di:waypoint x="860" y="252" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_17s45h0_di" bpmnElement="Flow_17s45h0">
-        <di:waypoint x="560" y="270" />
-        <di:waypoint x="605" y="270" />
+      <bpmndi:BPMNEdge id="Flow_080pfe1_di" bpmnElement="Flow_080pfe1">
+        <di:waypoint x="339" y="270" />
+        <di:waypoint x="370" y="270" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0wuzszh_di" bpmnElement="Flow_0wuzszh">
-        <di:waypoint x="655" y="270" />
-        <di:waypoint x="712" y="270" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0c2x7lv_di" bpmnElement="Flow_0c2x7lv" bioc:stroke="#e53935" color:border-color="#e53935">
-        <di:waypoint x="630" y="295" />
-        <di:waypoint x="630" y="350" />
-        <di:waypoint x="510" y="350" />
-        <di:waypoint x="510" y="310" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_05ykewo_di" bpmnElement="Flow_05ykewo" bioc:stroke="#43a047" color:border-color="#43a047">
-        <di:waypoint x="630" y="295" />
-        <di:waypoint x="630" y="400" />
-        <di:waypoint x="290" y="400" />
-        <di:waypoint x="290" y="310" />
-      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1npus9e_di" bpmnElement="EndEvent_Outcome">
+        <dc:Bounds x="842" y="252" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1m05qls_di" bpmnElement="Screen_ComplaintOutcome">
+        <dc:Bounds x="370" y="230" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1pmdn5d_di" bpmnElement="Gateway_1pmdn5d" isMarkerVisible="true">
+        <dc:Bounds x="505" y="245" width="50" height="50" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0d0cwma_di" bpmnElement="Activity_SaveWithdrawnNote">
+        <dc:Bounds x="590" y="123" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1yw4a93_di" bpmnElement="Screen_FinalResponse">
+        <dc:Bounds x="590" y="230" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_03el8xp_di" bpmnElement="Gateway_03el8xp" isMarkerVisible="true">
+        <dc:Bounds x="735" y="245" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_Outcome">
         <dc:Bounds x="152" y="252" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1m05qls_di" bpmnElement="Screen_ComplaintOutcome">
-        <dc:Bounds x="240" y="230" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1pmdn5d_di" bpmnElement="Gateway_1pmdn5d" isMarkerVisible="true">
-        <dc:Bounds x="375" y="245" width="50" height="50" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0d0cwma_di" bpmnElement="Activity_SaveWithdrawnNote">
-        <dc:Bounds x="460" y="123" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1yw4a93_di" bpmnElement="Screen_FinalResponse">
-        <dc:Bounds x="460" y="230" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1npus9e_di" bpmnElement="EndEvent_Outcome">
-        <dc:Bounds x="712" y="252" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_03el8xp_di" bpmnElement="Gateway_03el8xp" isMarkerVisible="true">
-        <dc:Bounds x="605" y="245" width="50" height="50" />
+      <bpmndi:BPMNShape id="Activity_07ke8wv_di" bpmnElement="Service_UpdatePsuDeadline">
+        <dc:Bounds x="239" y="230" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/COMP2/COMP2_PSU_OUTCOME.bpmn
+++ b/src/main/resources/processes/COMP2/COMP2_PSU_OUTCOME.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1qm3qgr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bioc="http://bpmn.io/schema/bpmn/biocolor/1.0" xmlns:color="http://www.omg.org/spec/BPMN/non-normative/color/1.0" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1qm3qgr" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="COMP2_PSU_OUTCOME" isExecutable="true">
     <bpmn:exclusiveGateway id="Gateway_1sifx7x" default="Flow_1f7jgm4">
       <bpmn:incoming>Flow_19n8e9j</bpmn:incoming>
@@ -13,8 +13,8 @@
           <camunda:outputParameter name="ReturnCase">${PsuComplaintOutcome == "ReturnCase" ? true : false}</camunda:outputParameter>
         </camunda:inputOutput>
       </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0r3xhq3</bpmn:incoming>
       <bpmn:incoming>Flow_0qti2to</bpmn:incoming>
+      <bpmn:incoming>Flow_1m1cv6u</bpmn:incoming>
       <bpmn:outgoing>Flow_19n8e9j</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:startEvent id="StartEvent_Outcome">
@@ -38,7 +38,7 @@
     </bpmn:sequenceFlow>
     <bpmn:sequenceFlow id="Flow_1f7jgm4" sourceRef="Gateway_1sifx7x" targetRef="Screen_FinalResponse" />
     <bpmn:sequenceFlow id="Flow_03d8yx1" sourceRef="Activity_SaveWithdrawnNote" targetRef="EndEvent_Outcome" />
-    <bpmn:sequenceFlow id="Flow_0r3xhq3" sourceRef="StartEvent_Outcome" targetRef="Screen_ComplaintOutcome" />
+    <bpmn:sequenceFlow id="Flow_0r3xhq3" sourceRef="StartEvent_Outcome" targetRef="Service_UpdatePsuDeadline" />
     <bpmn:userTask id="Screen_FinalResponse" name="Final Response" camunda:formKey="COMP_PSU_OUTCOME_FINAL_RESPONSE">
       <bpmn:incoming>Flow_1f7jgm4</bpmn:incoming>
       <bpmn:incoming>Flow_04kaoq1</bpmn:incoming>
@@ -58,77 +58,89 @@
     <bpmn:sequenceFlow id="Flow_0qti2to" sourceRef="Gateway_1cqxba3" targetRef="Screen_ComplaintOutcome">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ DIRECTION == "BACKWARD" }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="Service_UpdatePsuDeadline" name="Update Case Deadline" camunda:expression="${bpmnService.updateDeadlineDays(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, 60)}">
+      <bpmn:incoming>Flow_0r3xhq3</bpmn:incoming>
+      <bpmn:outgoing>Flow_1m1cv6u</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1m1cv6u" sourceRef="Service_UpdatePsuDeadline" targetRef="Screen_ComplaintOutcome" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMP2_PSU_OUTCOME">
-      <bpmndi:BPMNEdge id="Flow_0r3xhq3_di" bpmnElement="Flow_0r3xhq3">
-        <di:waypoint x="188" y="310" />
-        <di:waypoint x="240" y="310" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_03d8yx1_di" bpmnElement="Flow_03d8yx1">
-        <di:waypoint x="560" y="203" />
-        <di:waypoint x="750" y="203" />
-        <di:waypoint x="750" y="292" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1f7jgm4_di" bpmnElement="Flow_1f7jgm4">
-        <di:waypoint x="425" y="310" />
-        <di:waypoint x="460" y="310" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_14dp2lr_di" bpmnElement="Flow_14dp2lr">
-        <di:waypoint x="400" y="285" />
-        <di:waypoint x="400" y="203" />
-        <di:waypoint x="460" y="203" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_14rll2q_di" bpmnElement="Flow_14rll2q">
-        <di:waypoint x="400" y="285" />
-        <di:waypoint x="400" y="123" />
-        <di:waypoint x="750" y="123" />
-        <di:waypoint x="750" y="292" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19n8e9j_di" bpmnElement="Flow_19n8e9j">
-        <di:waypoint x="340" y="310" />
-        <di:waypoint x="375" y="310" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_01q7eyi_di" bpmnElement="Flow_01q7eyi">
-        <di:waypoint x="560" y="310" />
-        <di:waypoint x="615" y="310" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0s2203c_di" bpmnElement="Flow_0s2203c">
-        <di:waypoint x="665" y="310" />
-        <di:waypoint x="732" y="310" />
+      <bpmndi:BPMNEdge id="Flow_0qti2to_di" bpmnElement="Flow_0qti2to" bioc:stroke="#43a047" color:border-color="#43a047">
+        <di:waypoint x="740" y="335" />
+        <di:waypoint x="740" y="450" />
+        <di:waypoint x="390" y="450" />
+        <di:waypoint x="390" y="350" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_04kaoq1_di" bpmnElement="Flow_04kaoq1" bioc:stroke="#e53935" color:border-color="#e53935">
-        <di:waypoint x="640" y="335" />
-        <di:waypoint x="640" y="400" />
-        <di:waypoint x="500" y="400" />
-        <di:waypoint x="500" y="350" />
+        <di:waypoint x="740" y="335" />
+        <di:waypoint x="740" y="400" />
+        <di:waypoint x="600" y="400" />
+        <di:waypoint x="600" y="350" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0qti2to_di" bpmnElement="Flow_0qti2to" bioc:stroke="#43a047" color:border-color="#43a047">
-        <di:waypoint x="640" y="335" />
-        <di:waypoint x="640" y="450" />
-        <di:waypoint x="290" y="450" />
-        <di:waypoint x="290" y="350" />
+      <bpmndi:BPMNEdge id="Flow_0s2203c_di" bpmnElement="Flow_0s2203c">
+        <di:waypoint x="765" y="310" />
+        <di:waypoint x="832" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_01q7eyi_di" bpmnElement="Flow_01q7eyi">
+        <di:waypoint x="660" y="310" />
+        <di:waypoint x="715" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0r3xhq3_di" bpmnElement="Flow_0r3xhq3">
+        <di:waypoint x="188" y="310" />
+        <di:waypoint x="210" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03d8yx1_di" bpmnElement="Flow_03d8yx1">
+        <di:waypoint x="660" y="203" />
+        <di:waypoint x="850" y="203" />
+        <di:waypoint x="850" y="292" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1f7jgm4_di" bpmnElement="Flow_1f7jgm4">
+        <di:waypoint x="525" y="310" />
+        <di:waypoint x="560" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14dp2lr_di" bpmnElement="Flow_14dp2lr">
+        <di:waypoint x="500" y="285" />
+        <di:waypoint x="500" y="203" />
+        <di:waypoint x="560" y="203" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14rll2q_di" bpmnElement="Flow_14rll2q">
+        <di:waypoint x="500" y="285" />
+        <di:waypoint x="500" y="123" />
+        <di:waypoint x="850" y="123" />
+        <di:waypoint x="850" y="292" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19n8e9j_di" bpmnElement="Flow_19n8e9j">
+        <di:waypoint x="440" y="310" />
+        <di:waypoint x="475" y="310" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1m1cv6u_di" bpmnElement="Flow_1m1cv6u">
+        <di:waypoint x="310" y="310" />
+        <di:waypoint x="340" y="310" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Gateway_1sifx7x_di" bpmnElement="Gateway_1sifx7x" isMarkerVisible="true">
-        <dc:Bounds x="375" y="285" width="50" height="50" />
+        <dc:Bounds x="475" y="285" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_03wkq8r_di" bpmnElement="Screen_ComplaintOutcome">
-        <dc:Bounds x="240" y="270" width="100" height="80" />
+        <dc:Bounds x="340" y="270" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1l7tcyy_di" bpmnElement="EndEvent_Outcome">
+        <dc:Bounds x="832" y="292" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0xu03w4_di" bpmnElement="Activity_SaveWithdrawnNote">
+        <dc:Bounds x="560" y="163" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_02f5vgs_di" bpmnElement="Screen_FinalResponse">
+        <dc:Bounds x="560" y="270" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1cqxba3_di" bpmnElement="Gateway_1cqxba3" isMarkerVisible="true">
+        <dc:Bounds x="715" y="285" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_03bhqhx_di" bpmnElement="StartEvent_Outcome">
         <dc:Bounds x="152" y="292" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0xu03w4_di" bpmnElement="Activity_SaveWithdrawnNote">
-        <dc:Bounds x="460" y="163" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1l7tcyy_di" bpmnElement="EndEvent_Outcome">
-        <dc:Bounds x="732" y="292" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_02f5vgs_di" bpmnElement="Screen_FinalResponse">
-        <dc:Bounds x="460" y="270" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_1cqxba3_di" bpmnElement="Gateway_1cqxba3" isMarkerVisible="true">
-        <dc:Bounds x="615" y="285" width="50" height="50" />
+      <bpmndi:BPMNShape id="Activity_17elj49_di" bpmnElement="Service_UpdatePsuDeadline">
+        <dc:Bounds x="210" y="270" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/PSU/PSU_COMP2_COMPLAINT.bpmn
+++ b/src/main/resources/processes/PSU/PSU_COMP2_COMPLAINT.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1pddvvc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1pddvvc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="PSU_COMP2_COMPLAINT" isExecutable="true">
     <bpmn:startEvent id="StartEvent_Complaint">
       <bpmn:outgoing>Flow_1e3nxl3</bpmn:outgoing>
@@ -7,7 +7,7 @@
     <bpmn:sequenceFlow id="Flow_1e3nxl3" sourceRef="StartEvent_Complaint" targetRef="CallActivity_PSU" />
     <bpmn:endEvent id="EndEvent_Complaint">
       <bpmn:incoming>Flow_18qlayy</bpmn:incoming>
-      <bpmn:incoming>Flow_092o43w</bpmn:incoming>
+      <bpmn:incoming>Flow_0h52t86</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:callActivity id="CallActivity_PSU" name="PSU" calledElement="PSU">
       <bpmn:extensionElements>
@@ -35,10 +35,28 @@
     <bpmn:sequenceFlow id="Flow_0qulnc0" sourceRef="Gateway_1t829lo" targetRef="Service_ResetComplaintCategories">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("ReturnCase") == true }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_092o43w" sourceRef="Service_ResetComplaintCategories" targetRef="EndEvent_Complaint" />
+    <bpmn:sequenceFlow id="Flow_092o43w" sourceRef="Service_ResetComplaintCategories" targetRef="Service_UpdateUKVIDeadline" />
+    <bpmn:serviceTask id="Service_UpdateUKVIDeadline" name="Update Case Deadline" camunda:expression="${bpmnService.updateDeadlineDays(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, 20)}">
+      <bpmn:incoming>Flow_092o43w</bpmn:incoming>
+      <bpmn:outgoing>Flow_0h52t86</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0h52t86" sourceRef="Service_UpdateUKVIDeadline" targetRef="EndEvent_Complaint" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="PSU_COMP2_COMPLAINT">
+      <bpmndi:BPMNEdge id="Flow_092o43w_di" bpmnElement="Flow_092o43w">
+        <di:waypoint x="550" y="120" />
+        <di:waypoint x="590" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qulnc0_di" bpmnElement="Flow_0qulnc0">
+        <di:waypoint x="420" y="212" />
+        <di:waypoint x="420" y="120" />
+        <di:waypoint x="450" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18qlayy_di" bpmnElement="Flow_18qlayy">
+        <di:waypoint x="445" y="237" />
+        <di:waypoint x="702" y="237" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0c2lit7_di" bpmnElement="Flow_0c2lit7">
         <di:waypoint x="370" y="237" />
         <di:waypoint x="395" y="237" />
@@ -47,19 +65,10 @@
         <di:waypoint x="215" y="237" />
         <di:waypoint x="270" y="237" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_18qlayy_di" bpmnElement="Flow_18qlayy">
-        <di:waypoint x="445" y="237" />
-        <di:waypoint x="562" y="237" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0qulnc0_di" bpmnElement="Flow_0qulnc0">
-        <di:waypoint x="420" y="212" />
-        <di:waypoint x="420" y="120" />
-        <di:waypoint x="450" y="120" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_092o43w_di" bpmnElement="Flow_092o43w">
-        <di:waypoint x="550" y="120" />
-        <di:waypoint x="580" y="120" />
-        <di:waypoint x="580" y="219" />
+      <bpmndi:BPMNEdge id="Flow_0h52t86_di" bpmnElement="Flow_0h52t86">
+        <di:waypoint x="690" y="120" />
+        <di:waypoint x="720" y="120" />
+        <di:waypoint x="720" y="219" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_Complaint">
         <dc:Bounds x="179" y="219" width="36" height="36" />
@@ -74,7 +83,10 @@
         <dc:Bounds x="395" y="212" width="50" height="50" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_11ig7v2_di" bpmnElement="EndEvent_Complaint">
-        <dc:Bounds x="562" y="219" width="36" height="36" />
+        <dc:Bounds x="702" y="219" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1rzaykk_di" bpmnElement="Service_UpdateUKVIDeadline">
+        <dc:Bounds x="590" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/main/resources/processes/PSU/PSU_COMP_COMPLAINT.bpmn
+++ b/src/main/resources/processes/PSU/PSU_COMP_COMPLAINT.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1pddvvc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.11.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:modeler="http://camunda.org/schema/modeler/1.0" id="Definitions_1pddvvc" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.9.0" modeler:executionPlatform="Camunda Platform" modeler:executionPlatformVersion="7.15.0">
   <bpmn:process id="PSU_COMP_COMPLAINT" isExecutable="true">
     <bpmn:startEvent id="StartEvent_Complaint">
       <bpmn:outgoing>Flow_1e3nxl3</bpmn:outgoing>
@@ -7,7 +7,7 @@
     <bpmn:sequenceFlow id="Flow_1e3nxl3" sourceRef="StartEvent_Complaint" targetRef="CallActivity_PSU" />
     <bpmn:endEvent id="EndEvent_Complaint">
       <bpmn:incoming>Flow_0k1wt1l</bpmn:incoming>
-      <bpmn:incoming>Flow_0upf8ex</bpmn:incoming>
+      <bpmn:incoming>Flow_1txctbm</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:callActivity id="CallActivity_PSU" name="PSU" calledElement="PSU">
       <bpmn:extensionElements>
@@ -35,10 +35,28 @@
     <bpmn:sequenceFlow id="Flow_0w722h4" sourceRef="Gateway_0ri1zjl" targetRef="Service_ResetComplaintCategories">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${ execution.getVariable("ReturnCase") == true }</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="Flow_0upf8ex" sourceRef="Service_ResetComplaintCategories" targetRef="EndEvent_Complaint" />
+    <bpmn:sequenceFlow id="Flow_0upf8ex" sourceRef="Service_ResetComplaintCategories" targetRef="Service_UpdateUKVIDeadline" />
+    <bpmn:serviceTask id="Service_UpdateUKVIDeadline" name="Update Case Deadline" camunda:expression="${bpmnService.updateDeadlineDays(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, 20)}">
+      <bpmn:incoming>Flow_0upf8ex</bpmn:incoming>
+      <bpmn:outgoing>Flow_1txctbm</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_1txctbm" sourceRef="Service_UpdateUKVIDeadline" targetRef="EndEvent_Complaint" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="PSU_COMP_COMPLAINT">
+      <bpmndi:BPMNEdge id="Flow_0upf8ex_di" bpmnElement="Flow_0upf8ex">
+        <di:waypoint x="570" y="120" />
+        <di:waypoint x="620" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0w722h4_di" bpmnElement="Flow_0w722h4">
+        <di:waypoint x="430" y="212" />
+        <di:waypoint x="430" y="120" />
+        <di:waypoint x="470" y="120" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0k1wt1l_di" bpmnElement="Flow_0k1wt1l">
+        <di:waypoint x="455" y="237" />
+        <di:waypoint x="772" y="237" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_0c2lit7_di" bpmnElement="Flow_0c2lit7">
         <di:waypoint x="370" y="237" />
         <di:waypoint x="405" y="237" />
@@ -47,19 +65,10 @@
         <di:waypoint x="215" y="237" />
         <di:waypoint x="270" y="237" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0k1wt1l_di" bpmnElement="Flow_0k1wt1l">
-        <di:waypoint x="455" y="237" />
-        <di:waypoint x="592" y="237" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0w722h4_di" bpmnElement="Flow_0w722h4">
-        <di:waypoint x="430" y="212" />
-        <di:waypoint x="430" y="120" />
-        <di:waypoint x="470" y="120" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0upf8ex_di" bpmnElement="Flow_0upf8ex">
-        <di:waypoint x="570" y="120" />
-        <di:waypoint x="610" y="120" />
-        <di:waypoint x="610" y="219" />
+      <bpmndi:BPMNEdge id="Flow_1txctbm_di" bpmnElement="Flow_1txctbm">
+        <di:waypoint x="720" y="120" />
+        <di:waypoint x="790" y="120" />
+        <di:waypoint x="790" y="219" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_Complaint">
         <dc:Bounds x="179" y="219" width="36" height="36" />
@@ -67,14 +76,17 @@
       <bpmndi:BPMNShape id="Activity_0dg72gn_di" bpmnElement="CallActivity_PSU">
         <dc:Bounds x="270" y="197" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0ri1zjl_di" bpmnElement="Gateway_0ri1zjl" isMarkerVisible="true">
-        <dc:Bounds x="405" y="212" width="50" height="50" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_08j7d6e_di" bpmnElement="Service_ResetComplaintCategories">
         <dc:Bounds x="470" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0ri1zjl_di" bpmnElement="Gateway_0ri1zjl" isMarkerVisible="true">
+        <dc:Bounds x="405" y="212" width="50" height="50" />
+      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_11ig7v2_di" bpmnElement="EndEvent_Complaint">
-        <dc:Bounds x="592" y="219" width="36" height="36" />
+        <dc:Bounds x="772" y="219" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0dommp0_di" bpmnElement="Service_UpdateUKVIDeadline">
+        <dc:Bounds x="620" y="80" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/comp/COMP_PSU_OUTCOME.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/comp/COMP_PSU_OUTCOME.java
@@ -17,6 +17,8 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.digital.ho.hocs.workflow.BpmnService;
 
 import static org.camunda.bpm.engine.test.assertions.bpmn.BpmnAwareTests.withVariables;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -59,6 +61,8 @@ public class COMP_PSU_OUTCOME {
                 .execute();
 
         verify(processScenario).hasCompleted("StartEvent_Outcome");
+        verify(processScenario).hasCompleted("Service_UpdatePsuDeadline");
+        verify(bpmnService).updateDeadlineDays(any(), any(), eq("60"));
         verify(processScenario, times(2)).hasCompleted("Screen_ComplaintOutcome");
         verify(processScenario, times(3)).hasCompleted("Screen_FinalResponse");
         verify(processScenario).hasCompleted("EndEvent_Outcome");

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/psu/PSU_COMP_COMPLAINT.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/psu/PSU_COMP_COMPLAINT.java
@@ -88,6 +88,8 @@ public class PSU_COMP_COMPLAINT {
         verify(bpmnService).blankCaseValues(any(), any(), eq("CompType"), eq("CatAssault"), eq("CatFraud"),
             eq("CatOtherUnprof"), eq("CatRacism"), eq("CatRude"), eq("CatSexAssault"),
             eq("CatTheft"), eq("CatUnfair"));
+        verify(processScenario).hasCompleted("Service_UpdateUKVIDeadline");
+        verify(bpmnService).updateDeadlineDays(any(), any(), eq("20"));
         verify(processScenario).hasCompleted("EndEvent_Complaint");
     }
 }


### PR DESCRIPTION
HOCS-5732 - Currently SLA by default is set to 
20 working days. This PR would help to update SLA 
to 60 working days when case is accepted by PSU and 
when its moved to PSU outcome stage. When the user
reject this case and send it back to UKVI - then
SLA would be updated to 20 working days. Changes
are covered using BPMN changes similar to IEDET 
to PSU workflow stages. 