### PR TITLE
HOCS-6170: UKVI and SMC content updates for registration and QA input

### DIFF
--- a/src/main/resources/screens/live/COMP_REGISTRATION_INPUT.json
+++ b/src/main/resources/screens/live/COMP_REGISTRATION_INPUT.json
@@ -74,7 +74,7 @@
       "props": {},
       "component": "text-area",
       "name": "CaseSummary",
-      "label": "Case Summary"
+      "label": "Case summary"
     },
     {
       "validation": [
@@ -233,14 +233,14 @@
       "props": {},
       "component": "text",
       "name": "PrevUkviRef",
-      "label": "Previous UKVI Complaint Ref"
+      "label": "Previous UKVI complaint reference"
     },
     {
       "validation": [],
       "props": {},
       "component": "text",
       "name": "3rdPartyRef",
-      "label": "Third Party Reference"
+      "label": "Third party reference"
     }
   ],
   "secondaryActions": [

--- a/src/main/resources/screens/live/COMP_SERVICE_QA_INPUT.json
+++ b/src/main/resources/screens/live/COMP_SERVICE_QA_INPUT.json
@@ -21,7 +21,7 @@
       },
       "component": "radio",
       "name": "CctQaResult",
-      "label": "QA Result"
+      "label": "QA result"
     }
   ],
   "secondaryActions": [],

--- a/src/main/resources/screens/live/SMC_REGISTRATION_INPUT.json
+++ b/src/main/resources/screens/live/SMC_REGISTRATION_INPUT.json
@@ -56,7 +56,7 @@
       },
       "component": "dropdown",
       "name": "CompOrigin",
-      "label": "Complaint Origin"
+      "label": "Complaint origin"
     },
     {
       "validation": [],
@@ -71,14 +71,14 @@
       },
       "component": "text",
       "name": "CompOriginOther",
-      "label": "Other Complaint Origin"
+      "label": "Other complaint origin"
     },
     {
       "validation": [],
       "props": {},
       "component": "text-area",
       "name": "InitCaseSummary",
-      "label": "Case Summary"
+      "label": "Case summary"
     },
     {
       "validation": [],
@@ -92,7 +92,7 @@
       },
       "component": "checkbox",
       "name": "InitSafeGuarding",
-      "label": "Additional Information"
+      "label": "Additional information"
     },
     {
       "validation": [],
@@ -106,7 +106,7 @@
       },
       "component": "checkbox",
       "name": "InitVulnerable",
-      "label": "Additional Information"
+      "label": "Additional information"
     },
     {
       "validation": [],
@@ -120,21 +120,21 @@
       },
       "component": "checkbox",
       "name": "InitMinor",
-      "label": "Additional Information"
+      "label": "Additional information"
     },
     {
       "validation": [],
       "props": {},
       "component": "text",
       "name": "PrevUkviRef",
-      "label": "Previous UKVI Complaint Ref"
+      "label": "Previous UKVI complaint reference"
     },
     {
       "validation": [],
       "props": {},
       "component": "text",
       "name": "3rdPartyRef",
-      "label": "Third Party Reference"
+      "label": "Third party reference"
     }
   ],
   "secondaryActions": [


### PR DESCRIPTION
Changed field labels to use sentence case for following screens:

- COMP_SERVICE_QA_INPUT
- COMP_REGISTRATION_INPUT
- SMC_REGISTRATION_INPUT

Have also updated fields to match in accordion and summary (see PR for hocs-casework)