### PR TITLE
HOCS-6232: Fix COMP -> PSU escalation

### DIFF
--- a/src/main/resources/processes/COMP/COMP_EXGRATIA.bpmn
+++ b/src/main/resources/processes/COMP/COMP_EXGRATIA.bpmn
@@ -18,7 +18,7 @@
         <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
         <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
         <camunda:in source="QueueTeamUUID" target="AllocationTeamUUID" />
-        <camunda:out source="CctCompType" target="CompType" />
+        <camunda:out source="CompType" target="CompType" />
         <camunda:out source="CctTriageAccept" target="CctTriageAccept" />
         <camunda:out source="CctTriageResult" target="CctTriageResult" />
       </bpmn:extensionElements>

--- a/src/main/resources/processes/COMP/COMP_EXGRATIA_TRIAGE.bpmn
+++ b/src/main/resources/processes/COMP/COMP_EXGRATIA_TRIAGE.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1o2j0lb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1o2j0lb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.7.0">
   <bpmn:process id="COMP_EXGRATIA_TRIAGE" isExecutable="true">
     <bpmn:startEvent id="StartEvent_EXGRATIA_SERVICE_TRIAGE">
       <bpmn:outgoing>SequenceFlow_1i4bdvl</bpmn:outgoing>
@@ -23,10 +23,10 @@
     </bpmn:exclusiveGateway>
     <bpmn:endEvent id="EndEvent_COMP_SERVICE_TRIAGE">
       <bpmn:incoming>SequenceFlow_0agn1uv</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_1qmzx72</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1uzatlc</bpmn:incoming>
       <bpmn:incoming>Flow_0zg3ezz</bpmn:incoming>
       <bpmn:incoming>Flow_0titkle</bpmn:incoming>
+      <bpmn:incoming>Flow_0gv3d22</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="SequenceFlow_0fad1ra" name="false" sourceRef="ExclusiveGateway_137o870" targetRef="Screen_Input">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
@@ -187,7 +187,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_04c3qrc" sourceRef="ExclusiveGateway_0p13lhi" targetRef="Service_UpdateAllocationNote">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1qmzx72" sourceRef="Service_UpdateAllocationNote" targetRef="EndEvent_COMP_SERVICE_TRIAGE" />
+    <bpmn:sequenceFlow id="SequenceFlow_1qmzx72" sourceRef="Service_UpdateAllocationNote" targetRef="Service_UpdateCompType" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_1d8b0l0" name="Direction check">
       <bpmn:incoming>SequenceFlow_0qtx6he</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1ks3u8a</bpmn:outgoing>
@@ -340,303 +340,14 @@
     <bpmn:sequenceFlow id="Flow_023ybnf" sourceRef="ExclusiveGateway_0cw81i0" targetRef="Activity_ScreenCategorySerious">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CctTriageResult == "PSU"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="Service_UpdateCompType" name="Update complaint type" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;CompType&#34;,  CctCompType)}">
+      <bpmn:incoming>SequenceFlow_1qmzx72</bpmn:incoming>
+      <bpmn:outgoing>Flow_0gv3d22</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0gv3d22" sourceRef="Service_UpdateCompType" targetRef="EndEvent_COMP_SERVICE_TRIAGE" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMP_EXGRATIA_TRIAGE">
-      <bpmndi:BPMNEdge id="Flow_0titkle_di" bpmnElement="Flow_0titkle">
-        <di:waypoint x="1145" y="240" />
-        <di:waypoint x="4333" y="240" />
-        <di:waypoint x="4333" y="467" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1341xlg_di" bpmnElement="Flow_1341xlg">
-        <di:waypoint x="1120" y="215" />
-        <di:waypoint x="1120" y="80" />
-        <di:waypoint x="390" y="80" />
-        <di:waypoint x="390" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1dv1d50_di" bpmnElement="Flow_1dv1d50">
-        <di:waypoint x="800" y="460" />
-        <di:waypoint x="800" y="240" />
-        <di:waypoint x="910" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ht48oe_di" bpmnElement="Flow_0ht48oe">
-        <di:waypoint x="1010" y="240" />
-        <di:waypoint x="1095" y="240" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0g5q4l2_di" bpmnElement="Flow_0g5q4l2">
-        <di:waypoint x="1120" y="215" />
-        <di:waypoint x="1120" y="150" />
-        <di:waypoint x="960" y="150" />
-        <di:waypoint x="960" y="200" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1baxgfx_di" bpmnElement="Flow_1baxgfx">
-        <di:waypoint x="3150" y="970" />
-        <di:waypoint x="3150" y="400" />
-        <di:waypoint x="2308" y="400" />
-        <di:waypoint x="2308" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0zg3ezz_di" bpmnElement="Flow_0zg3ezz">
-        <di:waypoint x="3175" y="995" />
-        <di:waypoint x="4333" y="995" />
-        <di:waypoint x="4333" y="503" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1me6nsz_di" bpmnElement="Flow_1me6nsz">
-        <di:waypoint x="3072" y="995" />
-        <di:waypoint x="3125" y="995" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_154ctj6_di" bpmnElement="Flow_154ctj6">
-        <di:waypoint x="1085" y="485" />
-        <di:waypoint x="1010" y="485" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0y985dc_di" bpmnElement="Flow_0y985dc">
-        <di:waypoint x="1110" y="605" />
-        <di:waypoint x="1110" y="510" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_04bebjc_di" bpmnElement="Flow_04bebjc">
-        <di:waypoint x="1010" y="630" />
-        <di:waypoint x="1085" y="630" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0fh1132_di" bpmnElement="Flow_0fh1132">
-        <di:waypoint x="1110" y="655" />
-        <di:waypoint x="1110" y="770" />
-        <di:waypoint x="390" y="770" />
-        <di:waypoint x="390" y="525" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_07sbg6u_di" bpmnElement="Flow_07sbg6u">
-        <di:waypoint x="960" y="525" />
-        <di:waypoint x="960" y="590" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0uo8pad_di" bpmnElement="Flow_0uo8pad">
-        <di:waypoint x="1135" y="485" />
-        <di:waypoint x="1276" y="485" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1481m2f_di" bpmnElement="SequenceFlow_1481m2f">
-        <di:waypoint x="2743" y="510" />
-        <di:waypoint x="2743" y="995" />
-        <di:waypoint x="2972" y="995" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_057pgsr_di" bpmnElement="SequenceFlow_057pgsr">
-        <di:waypoint x="3545" y="648" />
-        <di:waypoint x="4076" y="648" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1uzatlc_di" bpmnElement="SequenceFlow_1uzatlc">
-        <di:waypoint x="4176" y="648" />
-        <di:waypoint x="4333" y="648" />
-        <di:waypoint x="4333" y="503" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_12rwo2p_di" bpmnElement="SequenceFlow_12rwo2p">
-        <di:waypoint x="3202" y="836" />
-        <di:waypoint x="3202" y="898" />
-        <di:waypoint x="2148" y="898" />
-        <di:waypoint x="2148" y="485" />
-        <di:waypoint x="2218" y="485" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_16htm6i_di" bpmnElement="SequenceFlow_16htm6i">
-        <di:waypoint x="3227" y="648" />
-        <di:waypoint x="3445" y="648" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0g4cz85_di" bpmnElement="SequenceFlow_0g4cz85">
-        <di:waypoint x="3202" y="786" />
-        <di:waypoint x="3202" y="673" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_00ek0nq_di" bpmnElement="SequenceFlow_00ek0nq">
-        <di:waypoint x="3072" y="811" />
-        <di:waypoint x="3177" y="811" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1fqhjfj_di" bpmnElement="SequenceFlow_1fqhjfj">
-        <di:waypoint x="3022" y="688" />
-        <di:waypoint x="3022" y="771" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1e94mue_di" bpmnElement="SequenceFlow_1e94mue">
-        <di:waypoint x="3177" y="648" />
-        <di:waypoint x="3072" y="648" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3161" y="628" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1e6xdxu_di" bpmnElement="SequenceFlow_1e6xdxu">
-        <di:waypoint x="2743" y="510" />
-        <di:waypoint x="2743" y="648" />
-        <di:waypoint x="2972" y="648" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0jpa2yo_di" bpmnElement="SequenceFlow_0jpa2yo">
-        <di:waypoint x="2768" y="485" />
-        <di:waypoint x="4076" y="485" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0a4ih5c_di" bpmnElement="SequenceFlow_0a4ih5c">
-        <di:waypoint x="2007" y="673" />
-        <di:waypoint x="2007" y="820" />
-        <di:waypoint x="1210" y="820" />
-        <di:waypoint x="1210" y="485" />
-        <di:waypoint x="1276" y="485" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1ks3u8a_di" bpmnElement="SequenceFlow_1ks3u8a">
-        <di:waypoint x="2007" y="623" />
-        <di:waypoint x="2007" y="510" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1qmzx72_di" bpmnElement="SequenceFlow_1qmzx72">
-        <di:waypoint x="1877" y="1467" />
-        <di:waypoint x="4333" y="1467" />
-        <di:waypoint x="4333" y="503" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_04c3qrc_di" bpmnElement="SequenceFlow_04c3qrc">
-        <di:waypoint x="1531" y="1467" />
-        <di:waypoint x="1777" y="1467" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0rkrcgg_di" bpmnElement="SequenceFlow_0rkrcgg">
-        <di:waypoint x="1481" y="1467" />
-        <di:waypoint x="1376" y="1467" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1464" y="1448" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0r35fmh_di" bpmnElement="SequenceFlow_0r35fmh">
-        <di:waypoint x="1506" y="1605" />
-        <di:waypoint x="1506" y="1492" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0cwsjfp_di" bpmnElement="SequenceFlow_0cwsjfp">
-        <di:waypoint x="1376" y="1630" />
-        <di:waypoint x="1481" y="1630" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0hmvqg0_di" bpmnElement="SequenceFlow_0hmvqg0">
-        <di:waypoint x="1326" y="1507" />
-        <di:waypoint x="1326" y="1590" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0xp4b20_di" bpmnElement="SequenceFlow_0xp4b20">
-        <di:waypoint x="1531" y="485" />
-        <di:waypoint x="1777" y="485" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0no0b5g_di" bpmnElement="SequenceFlow_0no0b5g">
-        <di:waypoint x="1481" y="485" />
-        <di:waypoint x="1376" y="485" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1464" y="466" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1lhqzzt_di" bpmnElement="SequenceFlow_1lhqzzt">
-        <di:waypoint x="1506" y="623" />
-        <di:waypoint x="1506" y="510" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1fmuvlz_di" bpmnElement="SequenceFlow_1fmuvlz">
-        <di:waypoint x="1376" y="648" />
-        <di:waypoint x="1481" y="648" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_09vlnhp_di" bpmnElement="SequenceFlow_09vlnhp">
-        <di:waypoint x="1326" y="525" />
-        <di:waypoint x="1326" y="608" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0yakx66_di" bpmnElement="SequenceFlow_0yakx66">
-        <di:waypoint x="800" y="510" />
-        <di:waypoint x="800" y="1467" />
-        <di:waypoint x="1276" y="1467" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0iblq8x_di" bpmnElement="SequenceFlow_0iblq8x">
-        <di:waypoint x="825" y="485" />
-        <di:waypoint x="910" y="485" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1x4p222_di" bpmnElement="SequenceFlow_1x4p222">
-        <di:waypoint x="715" y="485" />
-        <di:waypoint x="775" y="485" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1svnpao_di" bpmnElement="SequenceFlow_1svnpao">
-        <di:waypoint x="600" y="648" />
-        <di:waypoint x="690" y="648" />
-        <di:waypoint x="690" y="510" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0m7ioux_di" bpmnElement="SequenceFlow_0m7ioux">
-        <di:waypoint x="440" y="485" />
-        <di:waypoint x="550" y="485" />
-        <di:waypoint x="550" y="608" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0sh6krt_di" bpmnElement="SequenceFlow_0sh6krt">
-        <di:waypoint x="1506" y="1655" />
-        <di:waypoint x="1506" y="1724" />
-        <di:waypoint x="390" y="1724" />
-        <di:waypoint x="390" y="525" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_10va7yr_di" bpmnElement="SequenceFlow_10va7yr">
-        <di:waypoint x="1506" y="673" />
-        <di:waypoint x="1506" y="793" />
-        <di:waypoint x="850" y="793" />
-        <di:waypoint x="850" y="485" />
-        <di:waypoint x="910" y="485" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0zgmsi7_di" bpmnElement="SequenceFlow_0zgmsi7">
-        <di:waypoint x="665" y="485" />
-        <di:waypoint x="440" y="485" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="642" y="465" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1maedm7_di" bpmnElement="SequenceFlow_1maedm7">
-        <di:waypoint x="2448" y="673" />
-        <di:waypoint x="2448" y="850" />
-        <di:waypoint x="1686" y="850" />
-        <di:waypoint x="1686" y="485" />
-        <di:waypoint x="1777" y="485" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0k4auki_di" bpmnElement="SequenceFlow_0k4auki">
-        <di:waypoint x="2448" y="623" />
-        <di:waypoint x="2448" y="510" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0fdheb9_di" bpmnElement="SequenceFlow_0fdheb9">
-        <di:waypoint x="2032" y="485" />
-        <di:waypoint x="2218" y="485" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0qtx6he_di" bpmnElement="SequenceFlow_0qtx6he">
-        <di:waypoint x="1877" y="648" />
-        <di:waypoint x="1982" y="648" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0i97wze_di" bpmnElement="SequenceFlow_0i97wze">
-        <di:waypoint x="1827" y="525" />
-        <di:waypoint x="1827" y="608" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_06an5ir_di" bpmnElement="SequenceFlow_06an5ir">
-        <di:waypoint x="1982" y="485" />
-        <di:waypoint x="1877" y="485" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1966" y="465" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0agn1uv_di" bpmnElement="SequenceFlow_0agn1uv">
-        <di:waypoint x="4176" y="485" />
-        <di:waypoint x="4315" y="485" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0065hi4_di" bpmnElement="SequenceFlow_0065hi4">
-        <di:waypoint x="2743" y="460" />
-        <di:waypoint x="2743" y="371" />
-        <di:waypoint x="2268" y="371" />
-        <di:waypoint x="2268" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1i4bdvl_di" bpmnElement="SequenceFlow_1i4bdvl">
-        <di:waypoint x="188" y="485" />
-        <di:waypoint x="340" y="485" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0afnybj_di" bpmnElement="SequenceFlow_0afnybj">
-        <di:waypoint x="2473" y="485" />
-        <di:waypoint x="2718" y="485" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0hku4ez_di" bpmnElement="SequenceFlow_0hku4ez">
-        <di:waypoint x="2318" y="648" />
-        <di:waypoint x="2423" y="648" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_155xcyu_di" bpmnElement="SequenceFlow_155xcyu">
-        <di:waypoint x="2268" y="525" />
-        <di:waypoint x="2268" y="608" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0fad1ra_di" bpmnElement="SequenceFlow_0fad1ra">
-        <di:waypoint x="2423" y="485" />
-        <di:waypoint x="2318" y="485" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2406" y="465" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_023ybnf_di" bpmnElement="Flow_023ybnf">
-        <di:waypoint x="2743" y="460" />
-        <di:waypoint x="2743" y="310" />
-        <di:waypoint x="960" y="310" />
-        <di:waypoint x="960" y="280" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_EXGRATIA_SERVICE_TRIAGE">
         <dc:Bounds x="152" y="467" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -772,6 +483,308 @@
       <bpmndi:BPMNShape id="Gateway_0ljhrfr_di" bpmnElement="Gateway_0ljhrfr" isMarkerVisible="true">
         <dc:Bounds x="1095" y="215" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1t4v65w_di" bpmnElement="Service_UpdateCompType">
+        <dc:Bounds x="2010" y="1427" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0fad1ra_di" bpmnElement="SequenceFlow_0fad1ra">
+        <di:waypoint x="2423" y="485" />
+        <di:waypoint x="2318" y="485" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2406" y="465" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_155xcyu_di" bpmnElement="SequenceFlow_155xcyu">
+        <di:waypoint x="2268" y="525" />
+        <di:waypoint x="2268" y="608" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hku4ez_di" bpmnElement="SequenceFlow_0hku4ez">
+        <di:waypoint x="2318" y="648" />
+        <di:waypoint x="2423" y="648" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0afnybj_di" bpmnElement="SequenceFlow_0afnybj">
+        <di:waypoint x="2473" y="485" />
+        <di:waypoint x="2718" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1i4bdvl_di" bpmnElement="SequenceFlow_1i4bdvl">
+        <di:waypoint x="188" y="485" />
+        <di:waypoint x="340" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0065hi4_di" bpmnElement="SequenceFlow_0065hi4">
+        <di:waypoint x="2743" y="460" />
+        <di:waypoint x="2743" y="371" />
+        <di:waypoint x="2268" y="371" />
+        <di:waypoint x="2268" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0agn1uv_di" bpmnElement="SequenceFlow_0agn1uv">
+        <di:waypoint x="4176" y="485" />
+        <di:waypoint x="4315" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_06an5ir_di" bpmnElement="SequenceFlow_06an5ir">
+        <di:waypoint x="1982" y="485" />
+        <di:waypoint x="1877" y="485" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1966" y="465" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0i97wze_di" bpmnElement="SequenceFlow_0i97wze">
+        <di:waypoint x="1827" y="525" />
+        <di:waypoint x="1827" y="608" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0qtx6he_di" bpmnElement="SequenceFlow_0qtx6he">
+        <di:waypoint x="1877" y="648" />
+        <di:waypoint x="1982" y="648" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0fdheb9_di" bpmnElement="SequenceFlow_0fdheb9">
+        <di:waypoint x="2032" y="485" />
+        <di:waypoint x="2218" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0k4auki_di" bpmnElement="SequenceFlow_0k4auki">
+        <di:waypoint x="2448" y="623" />
+        <di:waypoint x="2448" y="510" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1maedm7_di" bpmnElement="SequenceFlow_1maedm7">
+        <di:waypoint x="2448" y="673" />
+        <di:waypoint x="2448" y="850" />
+        <di:waypoint x="1686" y="850" />
+        <di:waypoint x="1686" y="485" />
+        <di:waypoint x="1777" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0zgmsi7_di" bpmnElement="SequenceFlow_0zgmsi7">
+        <di:waypoint x="665" y="485" />
+        <di:waypoint x="440" y="485" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="642" y="465" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_10va7yr_di" bpmnElement="SequenceFlow_10va7yr">
+        <di:waypoint x="1506" y="673" />
+        <di:waypoint x="1506" y="793" />
+        <di:waypoint x="850" y="793" />
+        <di:waypoint x="850" y="485" />
+        <di:waypoint x="910" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0sh6krt_di" bpmnElement="SequenceFlow_0sh6krt">
+        <di:waypoint x="1506" y="1655" />
+        <di:waypoint x="1506" y="1724" />
+        <di:waypoint x="390" y="1724" />
+        <di:waypoint x="390" y="525" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0m7ioux_di" bpmnElement="SequenceFlow_0m7ioux">
+        <di:waypoint x="440" y="485" />
+        <di:waypoint x="550" y="485" />
+        <di:waypoint x="550" y="608" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1svnpao_di" bpmnElement="SequenceFlow_1svnpao">
+        <di:waypoint x="600" y="648" />
+        <di:waypoint x="690" y="648" />
+        <di:waypoint x="690" y="510" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1x4p222_di" bpmnElement="SequenceFlow_1x4p222">
+        <di:waypoint x="715" y="485" />
+        <di:waypoint x="775" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0iblq8x_di" bpmnElement="SequenceFlow_0iblq8x">
+        <di:waypoint x="825" y="485" />
+        <di:waypoint x="910" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0yakx66_di" bpmnElement="SequenceFlow_0yakx66">
+        <di:waypoint x="800" y="510" />
+        <di:waypoint x="800" y="1467" />
+        <di:waypoint x="1276" y="1467" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_09vlnhp_di" bpmnElement="SequenceFlow_09vlnhp">
+        <di:waypoint x="1326" y="525" />
+        <di:waypoint x="1326" y="608" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1fmuvlz_di" bpmnElement="SequenceFlow_1fmuvlz">
+        <di:waypoint x="1376" y="648" />
+        <di:waypoint x="1481" y="648" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1lhqzzt_di" bpmnElement="SequenceFlow_1lhqzzt">
+        <di:waypoint x="1506" y="623" />
+        <di:waypoint x="1506" y="510" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0no0b5g_di" bpmnElement="SequenceFlow_0no0b5g">
+        <di:waypoint x="1481" y="485" />
+        <di:waypoint x="1376" y="485" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1464" y="466" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0xp4b20_di" bpmnElement="SequenceFlow_0xp4b20">
+        <di:waypoint x="1531" y="485" />
+        <di:waypoint x="1777" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hmvqg0_di" bpmnElement="SequenceFlow_0hmvqg0">
+        <di:waypoint x="1326" y="1507" />
+        <di:waypoint x="1326" y="1590" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0cwsjfp_di" bpmnElement="SequenceFlow_0cwsjfp">
+        <di:waypoint x="1376" y="1630" />
+        <di:waypoint x="1481" y="1630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0r35fmh_di" bpmnElement="SequenceFlow_0r35fmh">
+        <di:waypoint x="1506" y="1605" />
+        <di:waypoint x="1506" y="1492" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0rkrcgg_di" bpmnElement="SequenceFlow_0rkrcgg">
+        <di:waypoint x="1481" y="1467" />
+        <di:waypoint x="1376" y="1467" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1464" y="1448" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_04c3qrc_di" bpmnElement="SequenceFlow_04c3qrc">
+        <di:waypoint x="1531" y="1467" />
+        <di:waypoint x="1777" y="1467" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1qmzx72_di" bpmnElement="SequenceFlow_1qmzx72">
+        <di:waypoint x="1877" y="1467" />
+        <di:waypoint x="2010" y="1467" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ks3u8a_di" bpmnElement="SequenceFlow_1ks3u8a">
+        <di:waypoint x="2007" y="623" />
+        <di:waypoint x="2007" y="510" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0a4ih5c_di" bpmnElement="SequenceFlow_0a4ih5c">
+        <di:waypoint x="2007" y="673" />
+        <di:waypoint x="2007" y="820" />
+        <di:waypoint x="1210" y="820" />
+        <di:waypoint x="1210" y="485" />
+        <di:waypoint x="1276" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0jpa2yo_di" bpmnElement="SequenceFlow_0jpa2yo">
+        <di:waypoint x="2768" y="485" />
+        <di:waypoint x="4076" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1e6xdxu_di" bpmnElement="SequenceFlow_1e6xdxu">
+        <di:waypoint x="2743" y="510" />
+        <di:waypoint x="2743" y="648" />
+        <di:waypoint x="2972" y="648" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1e94mue_di" bpmnElement="SequenceFlow_1e94mue">
+        <di:waypoint x="3177" y="648" />
+        <di:waypoint x="3072" y="648" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3161" y="628" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1fqhjfj_di" bpmnElement="SequenceFlow_1fqhjfj">
+        <di:waypoint x="3022" y="688" />
+        <di:waypoint x="3022" y="771" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_00ek0nq_di" bpmnElement="SequenceFlow_00ek0nq">
+        <di:waypoint x="3072" y="811" />
+        <di:waypoint x="3177" y="811" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0g4cz85_di" bpmnElement="SequenceFlow_0g4cz85">
+        <di:waypoint x="3202" y="786" />
+        <di:waypoint x="3202" y="673" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_16htm6i_di" bpmnElement="SequenceFlow_16htm6i">
+        <di:waypoint x="3227" y="648" />
+        <di:waypoint x="3445" y="648" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_12rwo2p_di" bpmnElement="SequenceFlow_12rwo2p">
+        <di:waypoint x="3202" y="836" />
+        <di:waypoint x="3202" y="898" />
+        <di:waypoint x="2148" y="898" />
+        <di:waypoint x="2148" y="485" />
+        <di:waypoint x="2218" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1uzatlc_di" bpmnElement="SequenceFlow_1uzatlc">
+        <di:waypoint x="4176" y="648" />
+        <di:waypoint x="4333" y="648" />
+        <di:waypoint x="4333" y="503" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_057pgsr_di" bpmnElement="SequenceFlow_057pgsr">
+        <di:waypoint x="3545" y="648" />
+        <di:waypoint x="4076" y="648" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1481m2f_di" bpmnElement="SequenceFlow_1481m2f">
+        <di:waypoint x="2743" y="510" />
+        <di:waypoint x="2743" y="995" />
+        <di:waypoint x="2972" y="995" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0uo8pad_di" bpmnElement="Flow_0uo8pad">
+        <di:waypoint x="1135" y="485" />
+        <di:waypoint x="1276" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07sbg6u_di" bpmnElement="Flow_07sbg6u">
+        <di:waypoint x="960" y="525" />
+        <di:waypoint x="960" y="590" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fh1132_di" bpmnElement="Flow_0fh1132">
+        <di:waypoint x="1110" y="655" />
+        <di:waypoint x="1110" y="770" />
+        <di:waypoint x="390" y="770" />
+        <di:waypoint x="390" y="525" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_04bebjc_di" bpmnElement="Flow_04bebjc">
+        <di:waypoint x="1010" y="630" />
+        <di:waypoint x="1085" y="630" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0y985dc_di" bpmnElement="Flow_0y985dc">
+        <di:waypoint x="1110" y="605" />
+        <di:waypoint x="1110" y="510" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_154ctj6_di" bpmnElement="Flow_154ctj6">
+        <di:waypoint x="1085" y="485" />
+        <di:waypoint x="1010" y="485" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1me6nsz_di" bpmnElement="Flow_1me6nsz">
+        <di:waypoint x="3072" y="995" />
+        <di:waypoint x="3125" y="995" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zg3ezz_di" bpmnElement="Flow_0zg3ezz">
+        <di:waypoint x="3175" y="995" />
+        <di:waypoint x="4333" y="995" />
+        <di:waypoint x="4333" y="503" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1baxgfx_di" bpmnElement="Flow_1baxgfx">
+        <di:waypoint x="3150" y="970" />
+        <di:waypoint x="3150" y="400" />
+        <di:waypoint x="2308" y="400" />
+        <di:waypoint x="2308" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0g5q4l2_di" bpmnElement="Flow_0g5q4l2">
+        <di:waypoint x="1120" y="215" />
+        <di:waypoint x="1120" y="150" />
+        <di:waypoint x="960" y="150" />
+        <di:waypoint x="960" y="200" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ht48oe_di" bpmnElement="Flow_0ht48oe">
+        <di:waypoint x="1010" y="240" />
+        <di:waypoint x="1095" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dv1d50_di" bpmnElement="Flow_1dv1d50">
+        <di:waypoint x="800" y="460" />
+        <di:waypoint x="800" y="240" />
+        <di:waypoint x="910" y="240" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1341xlg_di" bpmnElement="Flow_1341xlg">
+        <di:waypoint x="1120" y="215" />
+        <di:waypoint x="1120" y="80" />
+        <di:waypoint x="390" y="80" />
+        <di:waypoint x="390" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0titkle_di" bpmnElement="Flow_0titkle">
+        <di:waypoint x="1145" y="240" />
+        <di:waypoint x="4333" y="240" />
+        <di:waypoint x="4333" y="467" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_023ybnf_di" bpmnElement="Flow_023ybnf">
+        <di:waypoint x="2743" y="460" />
+        <di:waypoint x="2743" y="310" />
+        <di:waypoint x="960" y="310" />
+        <di:waypoint x="960" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0gv3d22_di" bpmnElement="Flow_0gv3d22">
+        <di:waypoint x="2110" y="1467" />
+        <di:waypoint x="4333" y="1467" />
+        <di:waypoint x="4333" y="503" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/processes/COMP/COMP_MINORMISCONDUCT.bpmn
+++ b/src/main/resources/processes/COMP/COMP_MINORMISCONDUCT.bpmn
@@ -18,7 +18,7 @@
         <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
         <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
         <camunda:in source="QueueTeamUUID" target="AllocationTeamUUID" />
-        <camunda:out source="CctCompType" target="CompType" />
+        <camunda:out source="CompType" target="CompType" />
         <camunda:out source="CctTriageAccept" target="CctTriageAccept" />
         <camunda:out source="CctTriageResult" target="CctTriageResult" />
       </bpmn:extensionElements>

--- a/src/main/resources/processes/COMP/COMP_MINORMISCONDUCT_TRIAGE.bpmn
+++ b/src/main/resources/processes/COMP/COMP_MINORMISCONDUCT_TRIAGE.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1o2j0lb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1o2j0lb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.7.0">
   <bpmn:process id="COMP_MINORMISCONDUCT_TRIAGE" isExecutable="true">
     <bpmn:startEvent id="StartEvent_EXGRATIA_SERVICE_TRIAGE">
       <bpmn:outgoing>SequenceFlow_1i4bdvl</bpmn:outgoing>
@@ -23,10 +23,10 @@
     </bpmn:exclusiveGateway>
     <bpmn:endEvent id="EndEvent_COMP_SERVICE_TRIAGE">
       <bpmn:incoming>SequenceFlow_0agn1uv</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_1qmzx72</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1uzatlc</bpmn:incoming>
       <bpmn:incoming>Flow_0ap1272</bpmn:incoming>
       <bpmn:incoming>Flow_18b4j3q</bpmn:incoming>
+      <bpmn:incoming>Flow_0fh2fcu</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="SequenceFlow_0fad1ra" name="false" sourceRef="ExclusiveGateway_137o870" targetRef="Screen_Input">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
@@ -181,7 +181,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_04c3qrc" sourceRef="ExclusiveGateway_0p13lhi" targetRef="Service_UpdateAllocationNote">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1qmzx72" sourceRef="Service_UpdateAllocationNote" targetRef="EndEvent_COMP_SERVICE_TRIAGE" />
+    <bpmn:sequenceFlow id="SequenceFlow_1qmzx72" sourceRef="Service_UpdateAllocationNote" targetRef="Service_UpdateCompType" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_1d8b0l0" name="Direction check">
       <bpmn:incoming>SequenceFlow_0qtx6he</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1ks3u8a</bpmn:outgoing>
@@ -335,300 +335,14 @@
     <bpmn:sequenceFlow id="Flow_1rqsqfx" sourceRef="ExclusiveGateway_0cw81i0" targetRef="Activity_ScreenCategorySerious">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CctTriageResult == "PSU"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:serviceTask id="Service_UpdateCompType" name="Update complaint type" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;CompType&#34;,  CctCompType)}">
+      <bpmn:incoming>SequenceFlow_1qmzx72</bpmn:incoming>
+      <bpmn:outgoing>Flow_0fh2fcu</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:sequenceFlow id="Flow_0fh2fcu" sourceRef="Service_UpdateCompType" targetRef="EndEvent_COMP_SERVICE_TRIAGE" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMP_MINORMISCONDUCT_TRIAGE">
-      <bpmndi:BPMNEdge id="Flow_18b4j3q_di" bpmnElement="Flow_18b4j3q">
-        <di:waypoint x="1105" y="230" />
-        <di:waypoint x="4333" y="230" />
-        <di:waypoint x="4333" y="417" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0mmkyle_di" bpmnElement="Flow_0mmkyle">
-        <di:waypoint x="1080" y="205" />
-        <di:waypoint x="1080" y="80" />
-        <di:waypoint x="390" y="80" />
-        <di:waypoint x="390" y="395" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_16nvsf9_di" bpmnElement="Flow_16nvsf9">
-        <di:waypoint x="800" y="410" />
-        <di:waypoint x="800" y="230" />
-        <di:waypoint x="870" y="230" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0mv3si3_di" bpmnElement="Flow_0mv3si3">
-        <di:waypoint x="970" y="230" />
-        <di:waypoint x="1055" y="230" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_06styjg_di" bpmnElement="Flow_06styjg">
-        <di:waypoint x="1080" y="205" />
-        <di:waypoint x="1080" y="140" />
-        <di:waypoint x="920" y="140" />
-        <di:waypoint x="920" y="190" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ap1272_di" bpmnElement="Flow_0ap1272">
-        <di:waypoint x="2985" y="945" />
-        <di:waypoint x="4333" y="945" />
-        <di:waypoint x="4333" y="453" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0mcx7st_di" bpmnElement="Flow_0398tgi">
-        <di:waypoint x="2960" y="920" />
-        <di:waypoint x="2960" y="350" />
-        <di:waypoint x="2290" y="350" />
-        <di:waypoint x="2290" y="395" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1b5ejlt_di" bpmnElement="Flow_1b5ejlt">
-        <di:waypoint x="1140" y="410" />
-        <di:waypoint x="1140" y="340" />
-        <di:waypoint x="920" y="340" />
-        <di:waypoint x="920" y="395" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1aj7oir_di" bpmnElement="Flow_08mxrbd">
-        <di:waypoint x="1030" y="460" />
-        <di:waypoint x="1030" y="700" />
-        <di:waypoint x="390" y="700" />
-        <di:waypoint x="390" y="475" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0n3c3hv_di" bpmnElement="Flow_0n3c3hv">
-        <di:waypoint x="1165" y="435" />
-        <di:waypoint x="1276" y="435" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_041o9jn_di" bpmnElement="Flow_04cmg24">
-        <di:waypoint x="1055" y="435" />
-        <di:waypoint x="1115" y="435" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_10i8nfu_di" bpmnElement="Flow_10i8nfu">
-        <di:waypoint x="970" y="435" />
-        <di:waypoint x="1005" y="435" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1vsmupz_di" bpmnElement="Flow_1vsmupz">
-        <di:waypoint x="2890" y="945" />
-        <di:waypoint x="2935" y="945" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_00q6ews_di" bpmnElement="Flow_00q6ews">
-        <di:waypoint x="825" y="435" />
-        <di:waypoint x="870" y="435" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_10va7yr_di" bpmnElement="SequenceFlow_10va7yr">
-        <di:waypoint x="1506" y="623" />
-        <di:waypoint x="1506" y="743" />
-        <di:waypoint x="920" y="743" />
-        <di:waypoint x="920" y="475" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1481m2f_di" bpmnElement="SequenceFlow_1481m2f">
-        <di:waypoint x="2743" y="460" />
-        <di:waypoint x="2743" y="945" />
-        <di:waypoint x="2790" y="945" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_057pgsr_di" bpmnElement="SequenceFlow_057pgsr">
-        <di:waypoint x="3545" y="598" />
-        <di:waypoint x="4076" y="598" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1uzatlc_di" bpmnElement="SequenceFlow_1uzatlc">
-        <di:waypoint x="4176" y="598" />
-        <di:waypoint x="4333" y="598" />
-        <di:waypoint x="4333" y="453" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_12rwo2p_di" bpmnElement="SequenceFlow_12rwo2p">
-        <di:waypoint x="3202" y="786" />
-        <di:waypoint x="3202" y="848" />
-        <di:waypoint x="2148" y="848" />
-        <di:waypoint x="2148" y="435" />
-        <di:waypoint x="2218" y="435" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_16htm6i_di" bpmnElement="SequenceFlow_16htm6i">
-        <di:waypoint x="3227" y="598" />
-        <di:waypoint x="3445" y="598" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0g4cz85_di" bpmnElement="SequenceFlow_0g4cz85">
-        <di:waypoint x="3202" y="736" />
-        <di:waypoint x="3202" y="623" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_00ek0nq_di" bpmnElement="SequenceFlow_00ek0nq">
-        <di:waypoint x="3072" y="761" />
-        <di:waypoint x="3177" y="761" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1fqhjfj_di" bpmnElement="SequenceFlow_1fqhjfj">
-        <di:waypoint x="3022" y="638" />
-        <di:waypoint x="3022" y="721" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1e94mue_di" bpmnElement="SequenceFlow_1e94mue">
-        <di:waypoint x="3177" y="598" />
-        <di:waypoint x="3072" y="598" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3161" y="578" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1e6xdxu_di" bpmnElement="SequenceFlow_1e6xdxu">
-        <di:waypoint x="2743" y="460" />
-        <di:waypoint x="2743" y="598" />
-        <di:waypoint x="2972" y="598" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0jpa2yo_di" bpmnElement="SequenceFlow_0jpa2yo">
-        <di:waypoint x="2768" y="435" />
-        <di:waypoint x="4076" y="435" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0a4ih5c_di" bpmnElement="SequenceFlow_0a4ih5c">
-        <di:waypoint x="2007" y="623" />
-        <di:waypoint x="2007" y="770" />
-        <di:waypoint x="1210" y="770" />
-        <di:waypoint x="1210" y="435" />
-        <di:waypoint x="1276" y="435" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1ks3u8a_di" bpmnElement="SequenceFlow_1ks3u8a">
-        <di:waypoint x="2007" y="573" />
-        <di:waypoint x="2007" y="460" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1qmzx72_di" bpmnElement="SequenceFlow_1qmzx72">
-        <di:waypoint x="1877" y="1417" />
-        <di:waypoint x="4333" y="1417" />
-        <di:waypoint x="4333" y="453" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_04c3qrc_di" bpmnElement="SequenceFlow_04c3qrc">
-        <di:waypoint x="1531" y="1417" />
-        <di:waypoint x="1777" y="1417" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0rkrcgg_di" bpmnElement="SequenceFlow_0rkrcgg">
-        <di:waypoint x="1481" y="1417" />
-        <di:waypoint x="1376" y="1417" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1464" y="1398" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0r35fmh_di" bpmnElement="SequenceFlow_0r35fmh">
-        <di:waypoint x="1506" y="1555" />
-        <di:waypoint x="1506" y="1442" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0cwsjfp_di" bpmnElement="SequenceFlow_0cwsjfp">
-        <di:waypoint x="1376" y="1580" />
-        <di:waypoint x="1481" y="1580" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0hmvqg0_di" bpmnElement="SequenceFlow_0hmvqg0">
-        <di:waypoint x="1326" y="1457" />
-        <di:waypoint x="1326" y="1540" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0xp4b20_di" bpmnElement="SequenceFlow_0xp4b20">
-        <di:waypoint x="1531" y="435" />
-        <di:waypoint x="1777" y="435" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0no0b5g_di" bpmnElement="SequenceFlow_0no0b5g">
-        <di:waypoint x="1481" y="435" />
-        <di:waypoint x="1376" y="435" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1464" y="416" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1lhqzzt_di" bpmnElement="SequenceFlow_1lhqzzt">
-        <di:waypoint x="1506" y="573" />
-        <di:waypoint x="1506" y="460" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1fmuvlz_di" bpmnElement="SequenceFlow_1fmuvlz">
-        <di:waypoint x="1376" y="598" />
-        <di:waypoint x="1481" y="598" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_09vlnhp_di" bpmnElement="SequenceFlow_09vlnhp">
-        <di:waypoint x="1326" y="475" />
-        <di:waypoint x="1326" y="558" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0yakx66_di" bpmnElement="SequenceFlow_0yakx66">
-        <di:waypoint x="800" y="460" />
-        <di:waypoint x="800" y="1417" />
-        <di:waypoint x="1276" y="1417" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1x4p222_di" bpmnElement="SequenceFlow_1x4p222">
-        <di:waypoint x="715" y="435" />
-        <di:waypoint x="775" y="435" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1svnpao_di" bpmnElement="SequenceFlow_1svnpao">
-        <di:waypoint x="600" y="598" />
-        <di:waypoint x="690" y="598" />
-        <di:waypoint x="690" y="460" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0m7ioux_di" bpmnElement="SequenceFlow_0m7ioux">
-        <di:waypoint x="440" y="435" />
-        <di:waypoint x="550" y="435" />
-        <di:waypoint x="550" y="558" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0sh6krt_di" bpmnElement="SequenceFlow_0sh6krt">
-        <di:waypoint x="1506" y="1605" />
-        <di:waypoint x="1506" y="1674" />
-        <di:waypoint x="370" y="1674" />
-        <di:waypoint x="370" y="475" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0zgmsi7_di" bpmnElement="SequenceFlow_0zgmsi7">
-        <di:waypoint x="665" y="435" />
-        <di:waypoint x="440" y="435" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="642" y="415" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1maedm7_di" bpmnElement="SequenceFlow_1maedm7">
-        <di:waypoint x="2448" y="623" />
-        <di:waypoint x="2448" y="800" />
-        <di:waypoint x="1686" y="800" />
-        <di:waypoint x="1686" y="435" />
-        <di:waypoint x="1777" y="435" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0k4auki_di" bpmnElement="SequenceFlow_0k4auki">
-        <di:waypoint x="2448" y="573" />
-        <di:waypoint x="2448" y="460" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0fdheb9_di" bpmnElement="SequenceFlow_0fdheb9">
-        <di:waypoint x="2032" y="435" />
-        <di:waypoint x="2218" y="435" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0qtx6he_di" bpmnElement="SequenceFlow_0qtx6he">
-        <di:waypoint x="1877" y="598" />
-        <di:waypoint x="1982" y="598" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0i97wze_di" bpmnElement="SequenceFlow_0i97wze">
-        <di:waypoint x="1827" y="475" />
-        <di:waypoint x="1827" y="558" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_06an5ir_di" bpmnElement="SequenceFlow_06an5ir">
-        <di:waypoint x="1982" y="435" />
-        <di:waypoint x="1877" y="435" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1966" y="415" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0agn1uv_di" bpmnElement="SequenceFlow_0agn1uv">
-        <di:waypoint x="4176" y="435" />
-        <di:waypoint x="4315" y="435" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0065hi4_di" bpmnElement="SequenceFlow_0065hi4">
-        <di:waypoint x="2743" y="410" />
-        <di:waypoint x="2743" y="321" />
-        <di:waypoint x="2268" y="321" />
-        <di:waypoint x="2268" y="395" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1i4bdvl_di" bpmnElement="SequenceFlow_1i4bdvl">
-        <di:waypoint x="188" y="435" />
-        <di:waypoint x="340" y="435" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0afnybj_di" bpmnElement="SequenceFlow_0afnybj">
-        <di:waypoint x="2473" y="435" />
-        <di:waypoint x="2718" y="435" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0hku4ez_di" bpmnElement="SequenceFlow_0hku4ez">
-        <di:waypoint x="2318" y="598" />
-        <di:waypoint x="2423" y="598" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_155xcyu_di" bpmnElement="SequenceFlow_155xcyu">
-        <di:waypoint x="2268" y="475" />
-        <di:waypoint x="2268" y="558" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0fad1ra_di" bpmnElement="SequenceFlow_0fad1ra">
-        <di:waypoint x="2423" y="435" />
-        <di:waypoint x="2318" y="435" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2406" y="415" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1rqsqfx_di" bpmnElement="Flow_1rqsqfx">
-        <di:waypoint x="2743" y="410" />
-        <di:waypoint x="2743" y="300" />
-        <di:waypoint x="920" y="300" />
-        <di:waypoint x="920" y="270" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_EXGRATIA_SERVICE_TRIAGE">
         <dc:Bounds x="152" y="417" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -758,6 +472,305 @@
       <bpmndi:BPMNShape id="Gateway_0sb8t2z_di" bpmnElement="Gateway_0sb8t2z" isMarkerVisible="true">
         <dc:Bounds x="1055" y="205" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1t4v65w_di" bpmnElement="Service_UpdateCompType">
+        <dc:Bounds x="2020" y="1377" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0fad1ra_di" bpmnElement="SequenceFlow_0fad1ra">
+        <di:waypoint x="2423" y="435" />
+        <di:waypoint x="2318" y="435" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2406" y="415" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_155xcyu_di" bpmnElement="SequenceFlow_155xcyu">
+        <di:waypoint x="2268" y="475" />
+        <di:waypoint x="2268" y="558" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hku4ez_di" bpmnElement="SequenceFlow_0hku4ez">
+        <di:waypoint x="2318" y="598" />
+        <di:waypoint x="2423" y="598" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0afnybj_di" bpmnElement="SequenceFlow_0afnybj">
+        <di:waypoint x="2473" y="435" />
+        <di:waypoint x="2718" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1i4bdvl_di" bpmnElement="SequenceFlow_1i4bdvl">
+        <di:waypoint x="188" y="435" />
+        <di:waypoint x="340" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0065hi4_di" bpmnElement="SequenceFlow_0065hi4">
+        <di:waypoint x="2743" y="410" />
+        <di:waypoint x="2743" y="321" />
+        <di:waypoint x="2268" y="321" />
+        <di:waypoint x="2268" y="395" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0agn1uv_di" bpmnElement="SequenceFlow_0agn1uv">
+        <di:waypoint x="4176" y="435" />
+        <di:waypoint x="4315" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_06an5ir_di" bpmnElement="SequenceFlow_06an5ir">
+        <di:waypoint x="1982" y="435" />
+        <di:waypoint x="1877" y="435" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1966" y="415" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0i97wze_di" bpmnElement="SequenceFlow_0i97wze">
+        <di:waypoint x="1827" y="475" />
+        <di:waypoint x="1827" y="558" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0qtx6he_di" bpmnElement="SequenceFlow_0qtx6he">
+        <di:waypoint x="1877" y="598" />
+        <di:waypoint x="1982" y="598" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0fdheb9_di" bpmnElement="SequenceFlow_0fdheb9">
+        <di:waypoint x="2032" y="435" />
+        <di:waypoint x="2218" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0k4auki_di" bpmnElement="SequenceFlow_0k4auki">
+        <di:waypoint x="2448" y="573" />
+        <di:waypoint x="2448" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1maedm7_di" bpmnElement="SequenceFlow_1maedm7">
+        <di:waypoint x="2448" y="623" />
+        <di:waypoint x="2448" y="800" />
+        <di:waypoint x="1686" y="800" />
+        <di:waypoint x="1686" y="435" />
+        <di:waypoint x="1777" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0zgmsi7_di" bpmnElement="SequenceFlow_0zgmsi7">
+        <di:waypoint x="665" y="435" />
+        <di:waypoint x="440" y="435" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="642" y="415" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0sh6krt_di" bpmnElement="SequenceFlow_0sh6krt">
+        <di:waypoint x="1506" y="1605" />
+        <di:waypoint x="1506" y="1674" />
+        <di:waypoint x="370" y="1674" />
+        <di:waypoint x="370" y="475" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0m7ioux_di" bpmnElement="SequenceFlow_0m7ioux">
+        <di:waypoint x="440" y="435" />
+        <di:waypoint x="550" y="435" />
+        <di:waypoint x="550" y="558" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1svnpao_di" bpmnElement="SequenceFlow_1svnpao">
+        <di:waypoint x="600" y="598" />
+        <di:waypoint x="690" y="598" />
+        <di:waypoint x="690" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1x4p222_di" bpmnElement="SequenceFlow_1x4p222">
+        <di:waypoint x="715" y="435" />
+        <di:waypoint x="775" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0yakx66_di" bpmnElement="SequenceFlow_0yakx66">
+        <di:waypoint x="800" y="460" />
+        <di:waypoint x="800" y="1417" />
+        <di:waypoint x="1276" y="1417" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_09vlnhp_di" bpmnElement="SequenceFlow_09vlnhp">
+        <di:waypoint x="1326" y="475" />
+        <di:waypoint x="1326" y="558" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1fmuvlz_di" bpmnElement="SequenceFlow_1fmuvlz">
+        <di:waypoint x="1376" y="598" />
+        <di:waypoint x="1481" y="598" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1lhqzzt_di" bpmnElement="SequenceFlow_1lhqzzt">
+        <di:waypoint x="1506" y="573" />
+        <di:waypoint x="1506" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0no0b5g_di" bpmnElement="SequenceFlow_0no0b5g">
+        <di:waypoint x="1481" y="435" />
+        <di:waypoint x="1376" y="435" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1464" y="416" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0xp4b20_di" bpmnElement="SequenceFlow_0xp4b20">
+        <di:waypoint x="1531" y="435" />
+        <di:waypoint x="1777" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hmvqg0_di" bpmnElement="SequenceFlow_0hmvqg0">
+        <di:waypoint x="1326" y="1457" />
+        <di:waypoint x="1326" y="1540" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0cwsjfp_di" bpmnElement="SequenceFlow_0cwsjfp">
+        <di:waypoint x="1376" y="1580" />
+        <di:waypoint x="1481" y="1580" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0r35fmh_di" bpmnElement="SequenceFlow_0r35fmh">
+        <di:waypoint x="1506" y="1555" />
+        <di:waypoint x="1506" y="1442" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0rkrcgg_di" bpmnElement="SequenceFlow_0rkrcgg">
+        <di:waypoint x="1481" y="1417" />
+        <di:waypoint x="1376" y="1417" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1464" y="1398" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_04c3qrc_di" bpmnElement="SequenceFlow_04c3qrc">
+        <di:waypoint x="1531" y="1417" />
+        <di:waypoint x="1777" y="1417" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1qmzx72_di" bpmnElement="SequenceFlow_1qmzx72">
+        <di:waypoint x="1877" y="1417" />
+        <di:waypoint x="2020" y="1417" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ks3u8a_di" bpmnElement="SequenceFlow_1ks3u8a">
+        <di:waypoint x="2007" y="573" />
+        <di:waypoint x="2007" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0a4ih5c_di" bpmnElement="SequenceFlow_0a4ih5c">
+        <di:waypoint x="2007" y="623" />
+        <di:waypoint x="2007" y="770" />
+        <di:waypoint x="1210" y="770" />
+        <di:waypoint x="1210" y="435" />
+        <di:waypoint x="1276" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0jpa2yo_di" bpmnElement="SequenceFlow_0jpa2yo">
+        <di:waypoint x="2768" y="435" />
+        <di:waypoint x="4076" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1e6xdxu_di" bpmnElement="SequenceFlow_1e6xdxu">
+        <di:waypoint x="2743" y="460" />
+        <di:waypoint x="2743" y="598" />
+        <di:waypoint x="2972" y="598" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1e94mue_di" bpmnElement="SequenceFlow_1e94mue">
+        <di:waypoint x="3177" y="598" />
+        <di:waypoint x="3072" y="598" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3161" y="578" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1fqhjfj_di" bpmnElement="SequenceFlow_1fqhjfj">
+        <di:waypoint x="3022" y="638" />
+        <di:waypoint x="3022" y="721" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_00ek0nq_di" bpmnElement="SequenceFlow_00ek0nq">
+        <di:waypoint x="3072" y="761" />
+        <di:waypoint x="3177" y="761" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0g4cz85_di" bpmnElement="SequenceFlow_0g4cz85">
+        <di:waypoint x="3202" y="736" />
+        <di:waypoint x="3202" y="623" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_16htm6i_di" bpmnElement="SequenceFlow_16htm6i">
+        <di:waypoint x="3227" y="598" />
+        <di:waypoint x="3445" y="598" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_12rwo2p_di" bpmnElement="SequenceFlow_12rwo2p">
+        <di:waypoint x="3202" y="786" />
+        <di:waypoint x="3202" y="848" />
+        <di:waypoint x="2148" y="848" />
+        <di:waypoint x="2148" y="435" />
+        <di:waypoint x="2218" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1uzatlc_di" bpmnElement="SequenceFlow_1uzatlc">
+        <di:waypoint x="4176" y="598" />
+        <di:waypoint x="4333" y="598" />
+        <di:waypoint x="4333" y="453" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_057pgsr_di" bpmnElement="SequenceFlow_057pgsr">
+        <di:waypoint x="3545" y="598" />
+        <di:waypoint x="4076" y="598" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1481m2f_di" bpmnElement="SequenceFlow_1481m2f">
+        <di:waypoint x="2743" y="460" />
+        <di:waypoint x="2743" y="945" />
+        <di:waypoint x="2790" y="945" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_10va7yr_di" bpmnElement="SequenceFlow_10va7yr">
+        <di:waypoint x="1506" y="623" />
+        <di:waypoint x="1506" y="743" />
+        <di:waypoint x="920" y="743" />
+        <di:waypoint x="920" y="475" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_00q6ews_di" bpmnElement="Flow_00q6ews">
+        <di:waypoint x="825" y="435" />
+        <di:waypoint x="870" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vsmupz_di" bpmnElement="Flow_1vsmupz">
+        <di:waypoint x="2890" y="945" />
+        <di:waypoint x="2935" y="945" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10i8nfu_di" bpmnElement="Flow_10i8nfu">
+        <di:waypoint x="970" y="435" />
+        <di:waypoint x="1005" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_041o9jn_di" bpmnElement="Flow_04cmg24">
+        <di:waypoint x="1055" y="435" />
+        <di:waypoint x="1115" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0n3c3hv_di" bpmnElement="Flow_0n3c3hv">
+        <di:waypoint x="1165" y="435" />
+        <di:waypoint x="1276" y="435" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1aj7oir_di" bpmnElement="Flow_08mxrbd">
+        <di:waypoint x="1030" y="460" />
+        <di:waypoint x="1030" y="700" />
+        <di:waypoint x="390" y="700" />
+        <di:waypoint x="390" y="475" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1b5ejlt_di" bpmnElement="Flow_1b5ejlt">
+        <di:waypoint x="1140" y="410" />
+        <di:waypoint x="1140" y="340" />
+        <di:waypoint x="920" y="340" />
+        <di:waypoint x="920" y="395" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mcx7st_di" bpmnElement="Flow_0398tgi">
+        <di:waypoint x="2960" y="920" />
+        <di:waypoint x="2960" y="350" />
+        <di:waypoint x="2290" y="350" />
+        <di:waypoint x="2290" y="395" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ap1272_di" bpmnElement="Flow_0ap1272">
+        <di:waypoint x="2985" y="945" />
+        <di:waypoint x="4333" y="945" />
+        <di:waypoint x="4333" y="453" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06styjg_di" bpmnElement="Flow_06styjg">
+        <di:waypoint x="1080" y="205" />
+        <di:waypoint x="1080" y="140" />
+        <di:waypoint x="920" y="140" />
+        <di:waypoint x="920" y="190" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mv3si3_di" bpmnElement="Flow_0mv3si3">
+        <di:waypoint x="970" y="230" />
+        <di:waypoint x="1055" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16nvsf9_di" bpmnElement="Flow_16nvsf9">
+        <di:waypoint x="800" y="410" />
+        <di:waypoint x="800" y="230" />
+        <di:waypoint x="870" y="230" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0mmkyle_di" bpmnElement="Flow_0mmkyle">
+        <di:waypoint x="1080" y="205" />
+        <di:waypoint x="1080" y="80" />
+        <di:waypoint x="390" y="80" />
+        <di:waypoint x="390" y="395" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_18b4j3q_di" bpmnElement="Flow_18b4j3q">
+        <di:waypoint x="1105" y="230" />
+        <di:waypoint x="4333" y="230" />
+        <di:waypoint x="4333" y="417" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rqsqfx_di" bpmnElement="Flow_1rqsqfx">
+        <di:waypoint x="2743" y="410" />
+        <di:waypoint x="2743" y="300" />
+        <di:waypoint x="920" y="300" />
+        <di:waypoint x="920" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0fh2fcu_di" bpmnElement="Flow_0fh2fcu">
+        <di:waypoint x="2120" y="1417" />
+        <di:waypoint x="4333" y="1417" />
+        <di:waypoint x="4333" y="453" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/processes/COMP/COMP_SERVICE.bpmn
+++ b/src/main/resources/processes/COMP/COMP_SERVICE.bpmn
@@ -18,7 +18,7 @@
         <camunda:out sourceExpression="ALLOCATE_TEAM" target="EmailType" />
         <camunda:out source="QueueTeamUUID" target="QueueTeamUUID" />
         <camunda:in source="QueueTeamUUID" target="AllocationTeamUUID" />
-        <camunda:out source="CctCompType" target="CompType" />
+        <camunda:out source="CompType" target="CompType" />
         <camunda:out source="CctTriageAccept" target="CctTriageAccept" />
         <camunda:out source="CctTriageResult" target="CctTriageResult" />
       </bpmn:extensionElements>
@@ -166,8 +166,8 @@
     <bpmn:endEvent id="EndEvent_COMP_SERVICE">
       <bpmn:incoming>Flow_1mwjz8c</bpmn:incoming>
       <bpmn:incoming>Flow_0obwvkt</bpmn:incoming>
-      <bpmn:incoming>Flow_1542qmp</bpmn:incoming>
       <bpmn:incoming>Flow_0y6fvuj</bpmn:incoming>
+      <bpmn:incoming>Flow_1542qmp</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_1mwjz8c" sourceRef="CallActivity_COMP_SERVICE_SEND" targetRef="EndEvent_COMP_SERVICE" />
     <bpmn:sequenceFlow id="Flow_0obwvkt" sourceRef="ExclusiveGateway_0j0zx2i" targetRef="EndEvent_COMP_SERVICE" />
@@ -291,15 +291,15 @@
         <di:waypoint x="2180" y="100" />
         <di:waypoint x="2180" y="226" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0y6fvuj_di" bpmnElement="Flow_0y6fvuj">
-        <di:waypoint x="1628" y="531" />
-        <di:waypoint x="1628" y="600" />
-        <di:waypoint x="2180" y="600" />
-        <di:waypoint x="2180" y="262" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1542qmp_di" bpmnElement="Flow_1542qmp">
         <di:waypoint x="882" y="531" />
         <di:waypoint x="882" y="600" />
+        <di:waypoint x="2180" y="600" />
+        <di:waypoint x="2180" y="262" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0y6fvuj_di" bpmnElement="Flow_0y6fvuj">
+        <di:waypoint x="1628" y="531" />
+        <di:waypoint x="1628" y="600" />
         <di:waypoint x="2180" y="600" />
         <di:waypoint x="2180" y="262" />
       </bpmndi:BPMNEdge>

--- a/src/main/resources/processes/COMP/COMP_SERVICE_TRIAGE.bpmn
+++ b/src/main/resources/processes/COMP/COMP_SERVICE_TRIAGE.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1o2j0lb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.2.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1o2j0lb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.7.0">
   <bpmn:process id="COMP_SERVICE_TRIAGE" isExecutable="true">
     <bpmn:startEvent id="StartEvent_COMP_SERVICE_TRIAGE">
       <bpmn:outgoing>SequenceFlow_1i4bdvl</bpmn:outgoing>
@@ -23,10 +23,10 @@
     </bpmn:exclusiveGateway>
     <bpmn:endEvent id="EndEvent_COMP_SERVICE_TRIAGE">
       <bpmn:incoming>SequenceFlow_0agn1uv</bpmn:incoming>
-      <bpmn:incoming>SequenceFlow_1qmzx72</bpmn:incoming>
       <bpmn:incoming>SequenceFlow_1uzatlc</bpmn:incoming>
       <bpmn:incoming>Flow_1d0ekym</bpmn:incoming>
       <bpmn:incoming>Flow_07zq4ms</bpmn:incoming>
+      <bpmn:incoming>Flow_02v4zg9</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="SequenceFlow_0fad1ra" name="false" sourceRef="ExclusiveGateway_137o870" targetRef="Screen_Input">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == false}</bpmn:conditionExpression>
@@ -187,7 +187,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_04c3qrc" sourceRef="ExclusiveGateway_0p13lhi" targetRef="Service_UpdateAllocationNote">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_1qmzx72" sourceRef="Service_UpdateAllocationNote" targetRef="EndEvent_COMP_SERVICE_TRIAGE" />
+    <bpmn:sequenceFlow id="SequenceFlow_1qmzx72" sourceRef="Service_UpdateAllocationNote" targetRef="Service_UpdateCompType" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_1d8b0l0" name="Direction check">
       <bpmn:incoming>SequenceFlow_0qtx6he</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_1ks3u8a</bpmn:outgoing>
@@ -340,303 +340,14 @@
     <bpmn:sequenceFlow id="Flow_0ipmqsa" sourceRef="ExclusiveGateway_0cw81i0" targetRef="Activity_ScreenCategorySerious">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${CctTriageResult == "PSU"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="Flow_02v4zg9" sourceRef="Service_UpdateCompType" targetRef="EndEvent_COMP_SERVICE_TRIAGE" />
+    <bpmn:serviceTask id="Service_UpdateCompType" name="Update complaint type" camunda:expression="${bpmnService.updateValue(execution.getVariable(&#34;CaseUUID&#34;), execution.processBusinessKey, &#34;CompType&#34;,  CctCompType)}">
+      <bpmn:incoming>SequenceFlow_1qmzx72</bpmn:incoming>
+      <bpmn:outgoing>Flow_02v4zg9</bpmn:outgoing>
+    </bpmn:serviceTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="COMP_SERVICE_TRIAGE">
-      <bpmndi:BPMNEdge id="Flow_145d27f_di" bpmnElement="Flow_145d27f">
-        <di:waypoint x="880" y="195" />
-        <di:waypoint x="880" y="80" />
-        <di:waypoint x="370" y="80" />
-        <di:waypoint x="370" y="405" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_16e41yf_di" bpmnElement="Flow_16e41yf">
-        <di:waypoint x="880" y="195" />
-        <di:waypoint x="880" y="130" />
-        <di:waypoint x="720" y="130" />
-        <di:waypoint x="720" y="180" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_07zq4ms_di" bpmnElement="Flow_07zq4ms">
-        <di:waypoint x="905" y="220" />
-        <di:waypoint x="4173" y="220" />
-        <di:waypoint x="4173" y="427" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1yughtb_di" bpmnElement="Flow_1yughtb">
-        <di:waypoint x="770" y="220" />
-        <di:waypoint x="855" y="220" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0awqg68_di" bpmnElement="Flow_0awqg68">
-        <di:waypoint x="590" y="420" />
-        <di:waypoint x="590" y="220" />
-        <di:waypoint x="670" y="220" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1cy3k9m_di" bpmnElement="Flow_1cy3k9m">
-        <di:waypoint x="2760" y="1025" />
-        <di:waypoint x="2760" y="360" />
-        <di:waypoint x="2150" y="360" />
-        <di:waypoint x="2150" y="406" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1d0ekym_di" bpmnElement="Flow_1d0ekym">
-        <di:waypoint x="2785" y="1050" />
-        <di:waypoint x="4173" y="1050" />
-        <di:waypoint x="4173" y="463" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ye972a_di" bpmnElement="Flow_0ye972a">
-        <di:waypoint x="2633" y="1050" />
-        <di:waypoint x="2735" y="1050" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0vhq73z_di" bpmnElement="Flow_0vhq73z">
-        <di:waypoint x="880" y="633" />
-        <di:waypoint x="880" y="740" />
-        <di:waypoint x="250" y="740" />
-        <di:waypoint x="250" y="445" />
-        <di:waypoint x="320" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1vaihyy_di" bpmnElement="Flow_1vaihyy">
-        <di:waypoint x="855" y="445" />
-        <di:waypoint x="770" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_14u1ay7_di" bpmnElement="Flow_14u1ay7">
-        <di:waypoint x="880" y="583" />
-        <di:waypoint x="880" y="470" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_08afffp_di" bpmnElement="Flow_08afffp">
-        <di:waypoint x="770" y="608" />
-        <di:waypoint x="855" y="608" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ts8ogf_di" bpmnElement="Flow_0ts8ogf">
-        <di:waypoint x="720" y="485" />
-        <di:waypoint x="720" y="568" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1y7l41k_di" bpmnElement="Flow_1y7l41k">
-        <di:waypoint x="905" y="445" />
-        <di:waypoint x="1116" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1481m2f_di" bpmnElement="SequenceFlow_1481m2f">
-        <di:waypoint x="2583" y="470" />
-        <di:waypoint x="2583" y="1010" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_057pgsr_di" bpmnElement="SequenceFlow_057pgsr">
-        <di:waypoint x="3385" y="608" />
-        <di:waypoint x="3916" y="608" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1uzatlc_di" bpmnElement="SequenceFlow_1uzatlc">
-        <di:waypoint x="4016" y="608" />
-        <di:waypoint x="4173" y="608" />
-        <di:waypoint x="4173" y="463" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_12rwo2p_di" bpmnElement="SequenceFlow_12rwo2p">
-        <di:waypoint x="3042" y="796" />
-        <di:waypoint x="3042" y="858" />
-        <di:waypoint x="1988" y="858" />
-        <di:waypoint x="1988" y="445" />
-        <di:waypoint x="2058" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_16htm6i_di" bpmnElement="SequenceFlow_16htm6i">
-        <di:waypoint x="3067" y="608" />
-        <di:waypoint x="3285" y="608" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0g4cz85_di" bpmnElement="SequenceFlow_0g4cz85">
-        <di:waypoint x="3042" y="746" />
-        <di:waypoint x="3042" y="633" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_00ek0nq_di" bpmnElement="SequenceFlow_00ek0nq">
-        <di:waypoint x="2912" y="771" />
-        <di:waypoint x="3017" y="771" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1fqhjfj_di" bpmnElement="SequenceFlow_1fqhjfj">
-        <di:waypoint x="2862" y="648" />
-        <di:waypoint x="2862" y="731" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1e94mue_di" bpmnElement="SequenceFlow_1e94mue">
-        <di:waypoint x="3017" y="608" />
-        <di:waypoint x="2912" y="608" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3001" y="588" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1e6xdxu_di" bpmnElement="SequenceFlow_1e6xdxu">
-        <di:waypoint x="2583" y="470" />
-        <di:waypoint x="2583" y="608" />
-        <di:waypoint x="2812" y="608" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0jpa2yo_di" bpmnElement="SequenceFlow_0jpa2yo">
-        <di:waypoint x="2608" y="445" />
-        <di:waypoint x="3916" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0a4ih5c_di" bpmnElement="SequenceFlow_0a4ih5c">
-        <di:waypoint x="1847" y="633" />
-        <di:waypoint x="1847" y="794" />
-        <di:waypoint x="1013" y="794" />
-        <di:waypoint x="1013" y="445" />
-        <di:waypoint x="1116" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1ks3u8a_di" bpmnElement="SequenceFlow_1ks3u8a">
-        <di:waypoint x="1847" y="583" />
-        <di:waypoint x="1847" y="470" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1qmzx72_di" bpmnElement="SequenceFlow_1qmzx72">
-        <di:waypoint x="1717" y="1427" />
-        <di:waypoint x="4173" y="1427" />
-        <di:waypoint x="4173" y="463" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_04c3qrc_di" bpmnElement="SequenceFlow_04c3qrc">
-        <di:waypoint x="1371" y="1427" />
-        <di:waypoint x="1617" y="1427" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0rkrcgg_di" bpmnElement="SequenceFlow_0rkrcgg">
-        <di:waypoint x="1321" y="1427" />
-        <di:waypoint x="1216" y="1427" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1304" y="1408" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0r35fmh_di" bpmnElement="SequenceFlow_0r35fmh">
-        <di:waypoint x="1346" y="1565" />
-        <di:waypoint x="1346" y="1452" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0cwsjfp_di" bpmnElement="SequenceFlow_0cwsjfp">
-        <di:waypoint x="1216" y="1590" />
-        <di:waypoint x="1321" y="1590" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0hmvqg0_di" bpmnElement="SequenceFlow_0hmvqg0">
-        <di:waypoint x="1166" y="1467" />
-        <di:waypoint x="1166" y="1550" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0xp4b20_di" bpmnElement="SequenceFlow_0xp4b20">
-        <di:waypoint x="1371" y="445" />
-        <di:waypoint x="1617" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0no0b5g_di" bpmnElement="SequenceFlow_0no0b5g">
-        <di:waypoint x="1321" y="445" />
-        <di:waypoint x="1216" y="445" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1304" y="426" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1lhqzzt_di" bpmnElement="SequenceFlow_1lhqzzt">
-        <di:waypoint x="1346" y="583" />
-        <di:waypoint x="1346" y="470" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1fmuvlz_di" bpmnElement="SequenceFlow_1fmuvlz">
-        <di:waypoint x="1216" y="608" />
-        <di:waypoint x="1321" y="608" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_09vlnhp_di" bpmnElement="SequenceFlow_09vlnhp">
-        <di:waypoint x="1166" y="485" />
-        <di:waypoint x="1166" y="568" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0yakx66_di" bpmnElement="SequenceFlow_0yakx66">
-        <di:waypoint x="590" y="470" />
-        <di:waypoint x="590" y="1427" />
-        <di:waypoint x="1116" y="1427" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0iblq8x_di" bpmnElement="SequenceFlow_0iblq8x">
-        <di:waypoint x="615" y="445" />
-        <di:waypoint x="670" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1x4p222_di" bpmnElement="SequenceFlow_1x4p222">
-        <di:waypoint x="525" y="445" />
-        <di:waypoint x="565" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1svnpao_di" bpmnElement="SequenceFlow_1svnpao">
-        <di:waypoint x="420" y="608" />
-        <di:waypoint x="500" y="608" />
-        <di:waypoint x="500" y="470" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0m7ioux_di" bpmnElement="SequenceFlow_0m7ioux">
-        <di:waypoint x="370" y="485" />
-        <di:waypoint x="370" y="568" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0sh6krt_di" bpmnElement="SequenceFlow_0sh6krt">
-        <di:waypoint x="1346" y="1615" />
-        <di:waypoint x="1346" y="1684" />
-        <di:waypoint x="250" y="1684" />
-        <di:waypoint x="250" y="445" />
-        <di:waypoint x="320" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_10va7yr_di" bpmnElement="SequenceFlow_10va7yr">
-        <di:waypoint x="1346" y="633" />
-        <di:waypoint x="1346" y="770" />
-        <di:waypoint x="630" y="770" />
-        <di:waypoint x="630" y="445" />
-        <di:waypoint x="670" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0zgmsi7_di" bpmnElement="SequenceFlow_0zgmsi7">
-        <di:waypoint x="475" y="445" />
-        <di:waypoint x="420" y="445" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="461" y="425" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1maedm7_di" bpmnElement="SequenceFlow_1maedm7">
-        <di:waypoint x="2288" y="633" />
-        <di:waypoint x="2288" y="739" />
-        <di:waypoint x="1526" y="739" />
-        <di:waypoint x="1526" y="445" />
-        <di:waypoint x="1617" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0k4auki_di" bpmnElement="SequenceFlow_0k4auki">
-        <di:waypoint x="2288" y="583" />
-        <di:waypoint x="2288" y="470" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0fdheb9_di" bpmnElement="SequenceFlow_0fdheb9">
-        <di:waypoint x="1872" y="445" />
-        <di:waypoint x="2058" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0qtx6he_di" bpmnElement="SequenceFlow_0qtx6he">
-        <di:waypoint x="1717" y="608" />
-        <di:waypoint x="1822" y="608" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0i97wze_di" bpmnElement="SequenceFlow_0i97wze">
-        <di:waypoint x="1667" y="485" />
-        <di:waypoint x="1667" y="568" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_06an5ir_di" bpmnElement="SequenceFlow_06an5ir">
-        <di:waypoint x="1822" y="445" />
-        <di:waypoint x="1717" y="445" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1806" y="425" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0agn1uv_di" bpmnElement="SequenceFlow_0agn1uv">
-        <di:waypoint x="4016" y="445" />
-        <di:waypoint x="4155" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0065hi4_di" bpmnElement="SequenceFlow_0065hi4">
-        <di:waypoint x="2583" y="420" />
-        <di:waypoint x="2583" y="331" />
-        <di:waypoint x="2108" y="331" />
-        <di:waypoint x="2108" y="405" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1i4bdvl_di" bpmnElement="SequenceFlow_1i4bdvl">
-        <di:waypoint x="188" y="445" />
-        <di:waypoint x="320" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0afnybj_di" bpmnElement="SequenceFlow_0afnybj">
-        <di:waypoint x="2313" y="445" />
-        <di:waypoint x="2558" y="445" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0hku4ez_di" bpmnElement="SequenceFlow_0hku4ez">
-        <di:waypoint x="2158" y="608" />
-        <di:waypoint x="2263" y="608" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_155xcyu_di" bpmnElement="SequenceFlow_155xcyu">
-        <di:waypoint x="2108" y="485" />
-        <di:waypoint x="2108" y="568" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0fad1ra_di" bpmnElement="SequenceFlow_0fad1ra">
-        <di:waypoint x="2263" y="445" />
-        <di:waypoint x="2158" y="445" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2246" y="425" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ipmqsa_di" bpmnElement="Flow_0ipmqsa">
-        <di:waypoint x="2583" y="420" />
-        <di:waypoint x="2583" y="290" />
-        <di:waypoint x="720" y="290" />
-        <di:waypoint x="720" y="260" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_COMP_SERVICE_TRIAGE">
         <dc:Bounds x="152" y="427" width="36" height="36" />
       </bpmndi:BPMNShape>
@@ -772,6 +483,308 @@
       <bpmndi:BPMNShape id="Gateway_00jsldm_di" bpmnElement="Gateway_00jsldm" isMarkerVisible="true">
         <dc:Bounds x="855" y="195" width="50" height="50" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1t4v65w_di" bpmnElement="Service_UpdateCompType">
+        <dc:Bounds x="1910" y="1387" width="100" height="80" />
+        <bpmndi:BPMNLabel />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0fad1ra_di" bpmnElement="SequenceFlow_0fad1ra">
+        <di:waypoint x="2263" y="445" />
+        <di:waypoint x="2158" y="445" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2246" y="425" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_155xcyu_di" bpmnElement="SequenceFlow_155xcyu">
+        <di:waypoint x="2108" y="485" />
+        <di:waypoint x="2108" y="568" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hku4ez_di" bpmnElement="SequenceFlow_0hku4ez">
+        <di:waypoint x="2158" y="608" />
+        <di:waypoint x="2263" y="608" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0afnybj_di" bpmnElement="SequenceFlow_0afnybj">
+        <di:waypoint x="2313" y="445" />
+        <di:waypoint x="2558" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1i4bdvl_di" bpmnElement="SequenceFlow_1i4bdvl">
+        <di:waypoint x="188" y="445" />
+        <di:waypoint x="320" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0065hi4_di" bpmnElement="SequenceFlow_0065hi4">
+        <di:waypoint x="2583" y="420" />
+        <di:waypoint x="2583" y="331" />
+        <di:waypoint x="2108" y="331" />
+        <di:waypoint x="2108" y="405" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0agn1uv_di" bpmnElement="SequenceFlow_0agn1uv">
+        <di:waypoint x="4016" y="445" />
+        <di:waypoint x="4155" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_06an5ir_di" bpmnElement="SequenceFlow_06an5ir">
+        <di:waypoint x="1822" y="445" />
+        <di:waypoint x="1717" y="445" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1806" y="425" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0i97wze_di" bpmnElement="SequenceFlow_0i97wze">
+        <di:waypoint x="1667" y="485" />
+        <di:waypoint x="1667" y="568" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0qtx6he_di" bpmnElement="SequenceFlow_0qtx6he">
+        <di:waypoint x="1717" y="608" />
+        <di:waypoint x="1822" y="608" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0fdheb9_di" bpmnElement="SequenceFlow_0fdheb9">
+        <di:waypoint x="1872" y="445" />
+        <di:waypoint x="2058" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0k4auki_di" bpmnElement="SequenceFlow_0k4auki">
+        <di:waypoint x="2288" y="583" />
+        <di:waypoint x="2288" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1maedm7_di" bpmnElement="SequenceFlow_1maedm7">
+        <di:waypoint x="2288" y="633" />
+        <di:waypoint x="2288" y="739" />
+        <di:waypoint x="1526" y="739" />
+        <di:waypoint x="1526" y="445" />
+        <di:waypoint x="1617" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0zgmsi7_di" bpmnElement="SequenceFlow_0zgmsi7">
+        <di:waypoint x="475" y="445" />
+        <di:waypoint x="420" y="445" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="461" y="425" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_10va7yr_di" bpmnElement="SequenceFlow_10va7yr">
+        <di:waypoint x="1346" y="633" />
+        <di:waypoint x="1346" y="770" />
+        <di:waypoint x="630" y="770" />
+        <di:waypoint x="630" y="445" />
+        <di:waypoint x="670" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0sh6krt_di" bpmnElement="SequenceFlow_0sh6krt">
+        <di:waypoint x="1346" y="1615" />
+        <di:waypoint x="1346" y="1684" />
+        <di:waypoint x="250" y="1684" />
+        <di:waypoint x="250" y="445" />
+        <di:waypoint x="320" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0m7ioux_di" bpmnElement="SequenceFlow_0m7ioux">
+        <di:waypoint x="370" y="485" />
+        <di:waypoint x="370" y="568" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1svnpao_di" bpmnElement="SequenceFlow_1svnpao">
+        <di:waypoint x="420" y="608" />
+        <di:waypoint x="500" y="608" />
+        <di:waypoint x="500" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1x4p222_di" bpmnElement="SequenceFlow_1x4p222">
+        <di:waypoint x="525" y="445" />
+        <di:waypoint x="565" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0iblq8x_di" bpmnElement="SequenceFlow_0iblq8x">
+        <di:waypoint x="615" y="445" />
+        <di:waypoint x="670" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0yakx66_di" bpmnElement="SequenceFlow_0yakx66">
+        <di:waypoint x="590" y="470" />
+        <di:waypoint x="590" y="1427" />
+        <di:waypoint x="1116" y="1427" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_09vlnhp_di" bpmnElement="SequenceFlow_09vlnhp">
+        <di:waypoint x="1166" y="485" />
+        <di:waypoint x="1166" y="568" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1fmuvlz_di" bpmnElement="SequenceFlow_1fmuvlz">
+        <di:waypoint x="1216" y="608" />
+        <di:waypoint x="1321" y="608" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1lhqzzt_di" bpmnElement="SequenceFlow_1lhqzzt">
+        <di:waypoint x="1346" y="583" />
+        <di:waypoint x="1346" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0no0b5g_di" bpmnElement="SequenceFlow_0no0b5g">
+        <di:waypoint x="1321" y="445" />
+        <di:waypoint x="1216" y="445" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1304" y="426" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0xp4b20_di" bpmnElement="SequenceFlow_0xp4b20">
+        <di:waypoint x="1371" y="445" />
+        <di:waypoint x="1617" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hmvqg0_di" bpmnElement="SequenceFlow_0hmvqg0">
+        <di:waypoint x="1166" y="1467" />
+        <di:waypoint x="1166" y="1550" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0cwsjfp_di" bpmnElement="SequenceFlow_0cwsjfp">
+        <di:waypoint x="1216" y="1590" />
+        <di:waypoint x="1321" y="1590" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0r35fmh_di" bpmnElement="SequenceFlow_0r35fmh">
+        <di:waypoint x="1346" y="1565" />
+        <di:waypoint x="1346" y="1452" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0rkrcgg_di" bpmnElement="SequenceFlow_0rkrcgg">
+        <di:waypoint x="1321" y="1427" />
+        <di:waypoint x="1216" y="1427" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1304" y="1408" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_04c3qrc_di" bpmnElement="SequenceFlow_04c3qrc">
+        <di:waypoint x="1371" y="1427" />
+        <di:waypoint x="1617" y="1427" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1qmzx72_di" bpmnElement="SequenceFlow_1qmzx72">
+        <di:waypoint x="1717" y="1427" />
+        <di:waypoint x="1910" y="1427" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ks3u8a_di" bpmnElement="SequenceFlow_1ks3u8a">
+        <di:waypoint x="1847" y="583" />
+        <di:waypoint x="1847" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0a4ih5c_di" bpmnElement="SequenceFlow_0a4ih5c">
+        <di:waypoint x="1847" y="633" />
+        <di:waypoint x="1847" y="794" />
+        <di:waypoint x="1013" y="794" />
+        <di:waypoint x="1013" y="445" />
+        <di:waypoint x="1116" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0jpa2yo_di" bpmnElement="SequenceFlow_0jpa2yo">
+        <di:waypoint x="2608" y="445" />
+        <di:waypoint x="3916" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1e6xdxu_di" bpmnElement="SequenceFlow_1e6xdxu">
+        <di:waypoint x="2583" y="470" />
+        <di:waypoint x="2583" y="608" />
+        <di:waypoint x="2812" y="608" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1e94mue_di" bpmnElement="SequenceFlow_1e94mue">
+        <di:waypoint x="3017" y="608" />
+        <di:waypoint x="2912" y="608" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3001" y="588" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1fqhjfj_di" bpmnElement="SequenceFlow_1fqhjfj">
+        <di:waypoint x="2862" y="648" />
+        <di:waypoint x="2862" y="731" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_00ek0nq_di" bpmnElement="SequenceFlow_00ek0nq">
+        <di:waypoint x="2912" y="771" />
+        <di:waypoint x="3017" y="771" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0g4cz85_di" bpmnElement="SequenceFlow_0g4cz85">
+        <di:waypoint x="3042" y="746" />
+        <di:waypoint x="3042" y="633" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_16htm6i_di" bpmnElement="SequenceFlow_16htm6i">
+        <di:waypoint x="3067" y="608" />
+        <di:waypoint x="3285" y="608" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_12rwo2p_di" bpmnElement="SequenceFlow_12rwo2p">
+        <di:waypoint x="3042" y="796" />
+        <di:waypoint x="3042" y="858" />
+        <di:waypoint x="1988" y="858" />
+        <di:waypoint x="1988" y="445" />
+        <di:waypoint x="2058" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1uzatlc_di" bpmnElement="SequenceFlow_1uzatlc">
+        <di:waypoint x="4016" y="608" />
+        <di:waypoint x="4173" y="608" />
+        <di:waypoint x="4173" y="463" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_057pgsr_di" bpmnElement="SequenceFlow_057pgsr">
+        <di:waypoint x="3385" y="608" />
+        <di:waypoint x="3916" y="608" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1481m2f_di" bpmnElement="SequenceFlow_1481m2f">
+        <di:waypoint x="2583" y="470" />
+        <di:waypoint x="2583" y="1010" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1y7l41k_di" bpmnElement="Flow_1y7l41k">
+        <di:waypoint x="905" y="445" />
+        <di:waypoint x="1116" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ts8ogf_di" bpmnElement="Flow_0ts8ogf">
+        <di:waypoint x="720" y="485" />
+        <di:waypoint x="720" y="568" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_08afffp_di" bpmnElement="Flow_08afffp">
+        <di:waypoint x="770" y="608" />
+        <di:waypoint x="855" y="608" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_14u1ay7_di" bpmnElement="Flow_14u1ay7">
+        <di:waypoint x="880" y="583" />
+        <di:waypoint x="880" y="470" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1vaihyy_di" bpmnElement="Flow_1vaihyy">
+        <di:waypoint x="855" y="445" />
+        <di:waypoint x="770" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0vhq73z_di" bpmnElement="Flow_0vhq73z">
+        <di:waypoint x="880" y="633" />
+        <di:waypoint x="880" y="740" />
+        <di:waypoint x="250" y="740" />
+        <di:waypoint x="250" y="445" />
+        <di:waypoint x="320" y="445" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ye972a_di" bpmnElement="Flow_0ye972a">
+        <di:waypoint x="2633" y="1050" />
+        <di:waypoint x="2735" y="1050" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1d0ekym_di" bpmnElement="Flow_1d0ekym">
+        <di:waypoint x="2785" y="1050" />
+        <di:waypoint x="4173" y="1050" />
+        <di:waypoint x="4173" y="463" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1cy3k9m_di" bpmnElement="Flow_1cy3k9m">
+        <di:waypoint x="2760" y="1025" />
+        <di:waypoint x="2760" y="360" />
+        <di:waypoint x="2150" y="360" />
+        <di:waypoint x="2150" y="406" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0awqg68_di" bpmnElement="Flow_0awqg68">
+        <di:waypoint x="590" y="420" />
+        <di:waypoint x="590" y="220" />
+        <di:waypoint x="670" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1yughtb_di" bpmnElement="Flow_1yughtb">
+        <di:waypoint x="770" y="220" />
+        <di:waypoint x="855" y="220" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07zq4ms_di" bpmnElement="Flow_07zq4ms">
+        <di:waypoint x="905" y="220" />
+        <di:waypoint x="4173" y="220" />
+        <di:waypoint x="4173" y="427" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16e41yf_di" bpmnElement="Flow_16e41yf">
+        <di:waypoint x="880" y="195" />
+        <di:waypoint x="880" y="130" />
+        <di:waypoint x="720" y="130" />
+        <di:waypoint x="720" y="180" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_145d27f_di" bpmnElement="Flow_145d27f">
+        <di:waypoint x="880" y="195" />
+        <di:waypoint x="880" y="80" />
+        <di:waypoint x="370" y="80" />
+        <di:waypoint x="370" y="405" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ipmqsa_di" bpmnElement="Flow_0ipmqsa">
+        <di:waypoint x="2583" y="420" />
+        <di:waypoint x="2583" y="290" />
+        <di:waypoint x="720" y="290" />
+        <di:waypoint x="720" y="260" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_02v4zg9_di" bpmnElement="Flow_02v4zg9">
+        <di:waypoint x="2010" y="1427" />
+        <di:waypoint x="4173" y="1427" />
+        <di:waypoint x="4173" y="463" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/comp/COMP_EX_GRATIA_TRIAGE.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/comp/COMP_EX_GRATIA_TRIAGE.java
@@ -51,7 +51,7 @@ public class COMP_EX_GRATIA_TRIAGE {
     public void testRejectTriage() {
         when(exGratiaTriageProcess.waitsAtUserTask("Validate_Accept")).thenReturn(
             task -> task.complete(withVariables("valid", false))).thenReturn(
-            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "No")));
+            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "No", "CctCompType", "CCH")));
 
         when(exGratiaTriageProcess.waitsAtUserTask("Validate_Transfer")).thenReturn(
             task -> task.complete(withVariables("valid", false, "DIRECTION", "BACKWARD"))).thenReturn(
@@ -64,7 +64,9 @@ public class COMP_EX_GRATIA_TRIAGE {
         verify(exGratiaTriageProcess, times(3)).hasCompleted("Screen_Accept");
         verify(exGratiaTriageProcess, times(3)).hasCompleted("Screen_Transfer");
         verify(exGratiaTriageProcess).hasCompleted("Service_UpdateAllocationNote");
+        verify(exGratiaTriageProcess).hasCompleted("Service_UpdateCompType");
         verify(bpmnService).updateAllocationNote(any(), any(), eq("Reject"), eq("REJECT"));
+        verify(bpmnService).updateValue(any(), any(), eq("CompType"), eq("CCH"));
     }
 
     @Test
@@ -167,7 +169,7 @@ public class COMP_EX_GRATIA_TRIAGE {
     public void testTriageAcceptCch() {
         when(exGratiaTriageProcess.waitsAtUserTask("Validate_Accept")).thenReturn(
             task -> task.complete(withVariables("valid", false))).thenReturn(
-            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "CCH")));
+            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "CCH", "CctCompType", "CCH")));
 
         when(exGratiaTriageProcess.waitsAtUserTask("Validate_Transfer")).thenReturn(
             task -> task.complete(withVariables("valid", false, "DIRECTION", "BACKWARD"))).thenReturn(
@@ -180,14 +182,16 @@ public class COMP_EX_GRATIA_TRIAGE {
         verify(exGratiaTriageProcess, times(3)).hasCompleted("Screen_Accept");
         verify(exGratiaTriageProcess, times(3)).hasCompleted("Screen_Transfer");
         verify(exGratiaTriageProcess).hasCompleted("Service_UpdateAllocationNote");
+        verify(exGratiaTriageProcess).hasCompleted("Service_UpdateCompType");
         verify(bpmnService).updateAllocationNote(any(), any(), eq("Reject"), eq("REJECT"));
+        verify(bpmnService).updateValue(any(), any(), eq("CompType"), eq("CCH"));
     }
 
     @Test
     public void testTriageAcceptOldValue() {
         when(exGratiaTriageProcess.waitsAtUserTask("Validate_Accept")).thenReturn(
             task -> task.complete(withVariables("valid", false))).thenReturn(
-            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "No")));
+            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "No", "CctCompType", "CCH")));
 
         when(exGratiaTriageProcess.waitsAtUserTask("Validate_Transfer")).thenReturn(
             task -> task.complete(withVariables("valid", false, "DIRECTION", "BACKWARD"))).thenReturn(
@@ -200,7 +204,9 @@ public class COMP_EX_GRATIA_TRIAGE {
         verify(exGratiaTriageProcess, times(3)).hasCompleted("Screen_Accept");
         verify(exGratiaTriageProcess, times(3)).hasCompleted("Screen_Transfer");
         verify(exGratiaTriageProcess).hasCompleted("Service_UpdateAllocationNote");
+        verify(exGratiaTriageProcess).hasCompleted("Service_UpdateCompType");
         verify(bpmnService).updateAllocationNote(any(), any(), eq("Reject"), eq("REJECT"));
+        verify(bpmnService).updateValue(any(), any(), eq("CompType"), eq("CCH"));
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/comp/COMP_MINORMISCONDUCT_TRIAGE.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/comp/COMP_MINORMISCONDUCT_TRIAGE.java
@@ -51,7 +51,7 @@ public class COMP_MINORMISCONDUCT_TRIAGE {
     public void testRejectTriage() {
         when(minorMisconductTriageProcess.waitsAtUserTask("Validate_Accept")).thenReturn(
             task -> task.complete(withVariables("valid", false))).thenReturn(
-            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "No")));
+            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "No", "CctCompType", "CCH")));
 
         when(minorMisconductTriageProcess.waitsAtUserTask("Validate_Transfer")).thenReturn(
             task -> task.complete(withVariables("valid", false, "DIRECTION", "BACKWARD"))).thenReturn(
@@ -64,7 +64,9 @@ public class COMP_MINORMISCONDUCT_TRIAGE {
         verify(minorMisconductTriageProcess, times(3)).hasCompleted("Screen_Accept");
         verify(minorMisconductTriageProcess, times(3)).hasCompleted("Screen_Transfer");
         verify(minorMisconductTriageProcess).hasCompleted("Service_UpdateAllocationNote");
+        verify(minorMisconductTriageProcess).hasCompleted("Service_UpdateCompType");
         verify(bpmnService).updateAllocationNote(any(), any(), eq("Reject"), eq("REJECT"));
+        verify(bpmnService).updateValue(any(), any(), eq("CompType"), eq("CCH"));
     }
 
     @Test
@@ -164,7 +166,7 @@ public class COMP_MINORMISCONDUCT_TRIAGE {
     public void testTriageAcceptCch() {
         when(minorMisconductTriageProcess.waitsAtUserTask("Validate_Accept")).thenReturn(
             task -> task.complete(withVariables("valid", false))).thenReturn(
-            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "CCH")));
+            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "CCH", "CctCompType", "CCH")));
 
         when(minorMisconductTriageProcess.waitsAtUserTask("Validate_Transfer")).thenReturn(
             task -> task.complete(withVariables("valid", false, "DIRECTION", "BACKWARD"))).thenReturn(
@@ -184,7 +186,7 @@ public class COMP_MINORMISCONDUCT_TRIAGE {
     public void testTriageAcceptOldValue() {
         when(minorMisconductTriageProcess.waitsAtUserTask("Validate_Accept")).thenReturn(
             task -> task.complete(withVariables("valid", false))).thenReturn(
-            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "No")));
+            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "No", "CctCompType", "CCH")));
 
         when(minorMisconductTriageProcess.waitsAtUserTask("Validate_Transfer")).thenReturn(
             task -> task.complete(withVariables("valid", false, "DIRECTION", "BACKWARD"))).thenReturn(
@@ -197,7 +199,9 @@ public class COMP_MINORMISCONDUCT_TRIAGE {
         verify(minorMisconductTriageProcess, times(3)).hasCompleted("Screen_Accept");
         verify(minorMisconductTriageProcess, times(3)).hasCompleted("Screen_Transfer");
         verify(minorMisconductTriageProcess).hasCompleted("Service_UpdateAllocationNote");
+        verify(minorMisconductTriageProcess).hasCompleted("Service_UpdateCompType");
         verify(bpmnService).updateAllocationNote(any(), any(), eq("Reject"), eq("REJECT"));
+        verify(bpmnService).updateValue(any(), any(), eq("CompType"), eq("CCH"));
     }
 
     @Test

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/comp/COMP_SERVICE_TRIAGE.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/comp/COMP_SERVICE_TRIAGE.java
@@ -51,7 +51,7 @@ public class COMP_SERVICE_TRIAGE {
     public void testTriageAcceptCch() {
         when(compServiceTriageProcess.waitsAtUserTask("Validate_Accept")).thenReturn(
             task -> task.complete(withVariables("valid", false))).thenReturn(
-            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "CCH")));
+            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "CCH", "CctCompType", "CCH")));
 
         when(compServiceTriageProcess.waitsAtUserTask("Validate_Transfer")).thenReturn(
             task -> task.complete(withVariables("valid", false, "DIRECTION", "BACKWARD"))).thenReturn(
@@ -64,14 +64,16 @@ public class COMP_SERVICE_TRIAGE {
         verify(compServiceTriageProcess, times(3)).hasCompleted("Screen_Accept");
         verify(compServiceTriageProcess, times(3)).hasCompleted("Screen_Transfer");
         verify(compServiceTriageProcess).hasCompleted("Service_UpdateAllocationNote");
+        verify(compServiceTriageProcess).hasCompleted("Service_UpdateCompType");
         verify(bpmnService).updateAllocationNote(any(), any(), eq("Reject"), eq("REJECT"));
+        verify(bpmnService).updateValue(any(), any(), eq("CompType"), eq("CCH"));
     }
 
     @Test
     public void testTriageAcceptOldValue() {
         when(compServiceTriageProcess.waitsAtUserTask("Validate_Accept")).thenReturn(
             task -> task.complete(withVariables("valid", false))).thenReturn(
-            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "No")));
+            task -> task.complete(withVariables("valid", true, "CctTriageAccept", "No", "CctCompType", "CCH")));
 
         when(compServiceTriageProcess.waitsAtUserTask("Validate_Transfer")).thenReturn(
             task -> task.complete(withVariables("valid", false, "DIRECTION", "BACKWARD"))).thenReturn(
@@ -84,7 +86,9 @@ public class COMP_SERVICE_TRIAGE {
         verify(compServiceTriageProcess, times(3)).hasCompleted("Screen_Accept");
         verify(compServiceTriageProcess, times(3)).hasCompleted("Screen_Transfer");
         verify(compServiceTriageProcess).hasCompleted("Service_UpdateAllocationNote");
+        verify(compServiceTriageProcess).hasCompleted("Service_UpdateCompType");
         verify(bpmnService).updateAllocationNote(any(), any(), eq("Reject"), eq("REJECT"));
+        verify(bpmnService).updateValue(any(), any(), eq("CompType"), eq("CCH"));
     }
 
     @Test


### PR DESCRIPTION
This fixes the issue with comp cases going to the COMP_OTHER stage instead of PSU due to the CompType being unintentionally set to blank during triage