### PR TITLE
HOCS-4148: add HomeSecReply fields to screens

### DIFF
--- a/src/main/resources/screens/live/DCU_ANSWERING.json
+++ b/src/main/resources/screens/live/DCU_ANSWERING.json
@@ -45,6 +45,29 @@
       "component": "text",
       "name": "DraftingTeamName",
       "label": "Initial Draft Team"
+    },
+    {
+      "validation": [
+        {
+          "type": "required",
+          "message": "Select yes if the Home Secretary may reply to this case"
+        }
+      ],
+      "props": {
+        "choices": [
+          {
+            "label": "Yes",
+            "value": "TRUE"
+          },
+          {
+            "label": "No",
+            "value": "FALSE"
+          }
+        ]
+      },
+      "component": "radio",
+      "name": "HomeSecReply",
+      "label": "Is this a potential Home Secretary Reply case?"
     }
   ],
   "secondaryActions": [

--- a/src/main/resources/screens/live/DCU_FAQ_ANSWERING.json
+++ b/src/main/resources/screens/live/DCU_FAQ_ANSWERING.json
@@ -27,6 +27,29 @@
       "component": "text",
       "name": "POTeamName",
       "label": "Private Office Team"
+    },
+    {
+      "validation": [
+        {
+          "type": "required",
+          "message": "Select yes if the Home Secretary may reply to this case"
+        }
+      ],
+      "props": {
+        "choices": [
+          {
+            "label": "Yes",
+            "value": "TRUE"
+          },
+          {
+            "label": "No",
+            "value": "FALSE"
+          }
+        ]
+      },
+      "component": "radio",
+      "name": "HomeSecReply",
+      "label": "Is this a potential Home Secretary Reply case?"
     }
   ],
   "secondaryActions": [


### PR DESCRIPTION
Add the `HomeSecReply` field to the associated screens to aid the simplification of tagging Home Secretary reply cases.