### PR TITLE
HOCS-6261: add hint text to first somu-list shown on screen

### DIFF
--- a/src/main/resources/screens/bf-psu/BF2_TRIAGE_BUSAREA.json
+++ b/src/main/resources/screens/bf-psu/BF2_TRIAGE_BUSAREA.json
@@ -295,7 +295,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "BFContributions",

--- a/src/main/resources/screens/bf-psu/BF_TRIAGE_BUSAREA.json
+++ b/src/main/resources/screens/bf-psu/BF_TRIAGE_BUSAREA.json
@@ -370,7 +370,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "BFContributions",

--- a/src/main/resources/screens/live/BF2_TRIAGE_BUSAREA.json
+++ b/src/main/resources/screens/live/BF2_TRIAGE_BUSAREA.json
@@ -295,7 +295,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "BFContributions",

--- a/src/main/resources/screens/live/BF_TRIAGE_BUSAREA.json
+++ b/src/main/resources/screens/live/BF_TRIAGE_BUSAREA.json
@@ -390,7 +390,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "BFContributions",

--- a/src/main/resources/screens/live/COMP2_EX_GRATIA_ESCALATE_INPUT.json
+++ b/src/main/resources/screens/live/COMP2_EX_GRATIA_ESCALATE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Confirm’ to save them."
       },
       "component": "somu-list",
       "name": "Comp2Contributions",

--- a/src/main/resources/screens/live/COMP2_EX_GRATIA_TRIAGE_INPUT.json
+++ b/src/main/resources/screens/live/COMP2_EX_GRATIA_TRIAGE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Continue’ to save them."
       },
       "component": "somu-list",
       "name": "Comp2Contributions",

--- a/src/main/resources/screens/live/COMP2_SERVICE_ESCALATE_INPUT.json
+++ b/src/main/resources/screens/live/COMP2_SERVICE_ESCALATE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Continue’ to save them."
       },
       "component": "somu-list",
       "name": "Comp2Contributions",

--- a/src/main/resources/screens/live/COMP2_SERVICE_TRIAGE_INPUT.json
+++ b/src/main/resources/screens/live/COMP2_SERVICE_TRIAGE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Continue’ to save them."
       },
       "component": "somu-list",
       "name": "Comp2Contributions",

--- a/src/main/resources/screens/live/COMP_SERVICE_ESCALATE_INPUT.json
+++ b/src/main/resources/screens/live/COMP_SERVICE_ESCALATE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Confirm’ to save them."
       },
       "component": "somu-list",
       "name": "CompContributions",

--- a/src/main/resources/screens/live/COMP_SERVICE_TRIAGE_INPUT.json
+++ b/src/main/resources/screens/live/COMP_SERVICE_TRIAGE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Continue’ to save them."
       },
       "component": "somu-list",
       "name": "CompContributions",

--- a/src/main/resources/screens/live/EX_GRATIA_ESCALATE_INPUT.json
+++ b/src/main/resources/screens/live/EX_GRATIA_ESCALATE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Confirm’ to save them."
       },
       "component": "somu-list",
       "name": "CompContributions",

--- a/src/main/resources/screens/live/EX_GRATIA_TRIAGE_INPUT.json
+++ b/src/main/resources/screens/live/EX_GRATIA_TRIAGE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Continue’ to save them."
       },
       "component": "somu-list",
       "name": "CompContributions",

--- a/src/main/resources/screens/live/POGR2_GRO_INVESTIGATION.json
+++ b/src/main/resources/screens/live/POGR2_GRO_INVESTIGATION.json
@@ -284,7 +284,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "ComplainantContributions",

--- a/src/main/resources/screens/live/POGR2_HMPO_INVESTIGATION.json
+++ b/src/main/resources/screens/live/POGR2_HMPO_INVESTIGATION.json
@@ -336,7 +336,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "ComplainantContributions",

--- a/src/main/resources/screens/live/POGR_GRO_INVESTIGATION.json
+++ b/src/main/resources/screens/live/POGR_GRO_INVESTIGATION.json
@@ -284,7 +284,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "ComplainantContributions",

--- a/src/main/resources/screens/live/POGR_HMPO_INVESTIGATION.json
+++ b/src/main/resources/screens/live/POGR_HMPO_INVESTIGATION.json
@@ -336,7 +336,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "ComplainantContributions",

--- a/src/main/resources/screens/live/TO_DISPATCH_FINAL_RESPONSE.json
+++ b/src/main/resources/screens/live/TO_DISPATCH_FINAL_RESPONSE.json
@@ -213,7 +213,8 @@
             "conditionPropertyName": "BusinessArea",
             "conditionPropertyValue": "HMPO"
           }
-        ]
+        ],
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "CaseContributions",
@@ -239,7 +240,8 @@
             "conditionPropertyName": "BusinessArea",
             "conditionPropertyValue": "BF"
           }
-        ]
+        ],
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "CaseContributions",

--- a/src/main/resources/screens/live/TO_DRAFT_UPLOAD_DOC.json
+++ b/src/main/resources/screens/live/TO_DRAFT_UPLOAD_DOC.json
@@ -229,7 +229,8 @@
             "conditionPropertyName": "BusinessArea",
             "conditionPropertyValue": "HMPO"
           }
-        ]
+        ],
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "CaseContributions",
@@ -255,7 +256,8 @@
             "conditionPropertyName": "BusinessArea",
             "conditionPropertyValue": "BF"
           }
-        ]
+        ],
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "CaseContributions",

--- a/src/main/resources/screens/live/TO_HOME_SECRETARY_APPROVAL.json
+++ b/src/main/resources/screens/live/TO_HOME_SECRETARY_APPROVAL.json
@@ -187,7 +187,8 @@
             "conditionPropertyName": "BusinessArea",
             "conditionPropertyValue": "HMPO"
           }
-        ]
+        ],
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "CaseContributions",
@@ -213,7 +214,8 @@
             "conditionPropertyName": "BusinessArea",
             "conditionPropertyValue": "BF"
           }
-        ]
+        ],
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "CaseContributions",

--- a/src/main/resources/screens/live/TO_QA_STATUS.json
+++ b/src/main/resources/screens/live/TO_QA_STATUS.json
@@ -235,7 +235,8 @@
             "conditionPropertyName": "BusinessArea",
             "conditionPropertyValue": "HMPO"
           }
-        ]
+        ],
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "CaseContributions",
@@ -271,7 +272,8 @@
             "conditionPropertyName": "BusinessArea",
             "conditionPropertyValue": "BF"
           }
-        ]
+        ],
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "CaseContributions",

--- a/src/main/resources/screens/live/TO_STOP_LIST_INPUT.json
+++ b/src/main/resources/screens/live/TO_STOP_LIST_INPUT.json
@@ -243,7 +243,8 @@
             "conditionPropertyName": "BusinessArea",
             "conditionPropertyValue": "HMPO"
           }
-        ]
+        ],
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Confirm’ to save them."
       },
       "component": "somu-list",
       "name": "CaseContributions",
@@ -279,7 +280,8 @@
             "conditionPropertyName": "BusinessArea",
             "conditionPropertyValue": "BF"
           }
-        ]
+        ],
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Confirm’ to save them."
       },
       "component": "somu-list",
       "name": "CaseContributions",

--- a/src/main/resources/screens/live/TO_TRIAGE_INPUT.json
+++ b/src/main/resources/screens/live/TO_TRIAGE_INPUT.json
@@ -257,7 +257,8 @@
             "conditionPropertyName": "BusinessArea",
             "conditionPropertyValue": "HMPO"
           }
-        ]
+        ],
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "CaseContributions",
@@ -293,7 +294,8 @@
             "conditionPropertyName": "BusinessArea",
             "conditionPropertyValue": "BF"
           }
-        ]
+        ],
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Finish’ to save them."
       },
       "component": "somu-list",
       "name": "CaseContributions",

--- a/src/main/resources/screens/live/TROF_CAMPAIGN_INPUT.json
+++ b/src/main/resources/screens/live/TROF_CAMPAIGN_INPUT.json
@@ -244,7 +244,8 @@
             "conditionPropertyName": "BusinessArea",
             "conditionPropertyValue": "HMPO"
           }
-        ]
+        ],
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Confirm’ to save them."
       },
       "component": "somu-list",
       "name": "CaseContributions",
@@ -280,7 +281,8 @@
             "conditionPropertyName": "BusinessArea",
             "conditionPropertyValue": "BF"
           }
-        ]
+        ],
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Confirm’ to save them."
       },
       "component": "somu-list",
       "name": "CaseContributions",

--- a/src/main/resources/screens/ukvi-psu/COMP2_EX_GRATIA_ESCALATE_INPUT.json
+++ b/src/main/resources/screens/ukvi-psu/COMP2_EX_GRATIA_ESCALATE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Confirm’ to save them."
       },
       "component": "somu-list",
       "name": "Comp2Contributions",

--- a/src/main/resources/screens/ukvi-psu/COMP2_EX_GRATIA_TRIAGE_INPUT.json
+++ b/src/main/resources/screens/ukvi-psu/COMP2_EX_GRATIA_TRIAGE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Continue’ to save them."
       },
       "component": "somu-list",
       "name": "Comp2Contributions",

--- a/src/main/resources/screens/ukvi-psu/COMP2_SERVICE_ESCALATE_INPUT.json
+++ b/src/main/resources/screens/ukvi-psu/COMP2_SERVICE_ESCALATE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Continue’ to save them."
       },
       "component": "somu-list",
       "name": "Comp2Contributions",

--- a/src/main/resources/screens/ukvi-psu/COMP2_SERVICE_TRIAGE_INPUT.json
+++ b/src/main/resources/screens/ukvi-psu/COMP2_SERVICE_TRIAGE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Continue’ to save them."
       },
       "component": "somu-list",
       "name": "Comp2Contributions",

--- a/src/main/resources/screens/ukvi-psu/COMP_SERVICE_ESCALATE_INPUT.json
+++ b/src/main/resources/screens/ukvi-psu/COMP_SERVICE_ESCALATE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Confirm’ to save them."
       },
       "component": "somu-list",
       "name": "CompContributions",

--- a/src/main/resources/screens/ukvi-psu/COMP_SERVICE_TRIAGE_INPUT.json
+++ b/src/main/resources/screens/ukvi-psu/COMP_SERVICE_TRIAGE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Continue’ to save them."
       },
       "component": "somu-list",
       "name": "CompContributions",

--- a/src/main/resources/screens/ukvi-psu/EX_GRATIA_ESCALATE_INPUT.json
+++ b/src/main/resources/screens/ukvi-psu/EX_GRATIA_ESCALATE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Confirm’ to save them."
       },
       "component": "somu-list",
       "name": "CompContributions",

--- a/src/main/resources/screens/ukvi-psu/EX_GRATIA_TRIAGE_INPUT.json
+++ b/src/main/resources/screens/ukvi-psu/EX_GRATIA_TRIAGE_INPUT.json
@@ -23,7 +23,8 @@
         "primaryLink": {
           "label": "Add complainant contribution",
           "action": "addRequest"
-        }
+        },
+        "hint": "If you’ve made any changes on this page, before adding or editing contributions select 'Save changes’ and 'Continue’ to save them."
       },
       "component": "somu-list",
       "name": "CompContributions",


### PR DESCRIPTION
When users click to add/edit a somu item through the somu-list it redirects the user. Any inputted information at that stage is lost. This is expected behaviour as the product does not support real-time data updates.

This change adds hint text to the first somu-list shown on a page where other fields are present and can be updated.