### PR TITLE
HOCS-5824: change comp category screens

### DIFF
--- a/src/main/resources/screens/live/COMP_REGISTRATION_CATEGORY.json
+++ b/src/main/resources/screens/live/COMP_REGISTRATION_CATEGORY.json
@@ -1,7 +1,7 @@
 {
   "props": {},
-  "title": "Complaint Category",
-  "defaultActionLabel": "Finish",
+  "title": "Complaint category",
+  "defaultActionLabel": "Continue",
   "fields": [
     {
       "validation": [],
@@ -15,59 +15,49 @@
       "props": {
         "choices": [
           {
+            "label": "Admin / process error",
+            "value": "AdminErr",
+            "name": "CatAdminErr"
+          },
+          {
+            "label": "Availability of service",
+            "value": "CCAvail",
+            "name": "CatCCAvail"
+          },
+          {
+            "label": "Complaint handling",
+            "value": "CCHandle",
+            "name": "CatCCHandle"
+          },
+          {
             "label": "Delay",
             "value": "Delay",
             "name": "CatDelay"
           },
           {
-            "label": "Admin / Process Error",
-            "value": "AdminErr",
-            "name": "CatAdminErr"
-          },
-          {
-            "label": "Poor Communication",
-            "value": "PoorComm",
-            "name": "CatPoorComm"
-          },
-          {
-            "label": "Wrong Information",
-            "value": "WrongInfo",
-            "name": "CatWrongInfo"
-          },
-          {
-            "label": "Properties and Lost Documents",
+            "label": "Lost property or documents",
             "value": "Lost",
             "name": "CatLost"
           },
           {
-            "label": "CC - Physical Environment",
+            "label": "Physical environment",
             "value": "CCPhy",
             "name": "CatCCPhy"
           },
           {
-            "label": "CC - Availability of Service",
-            "value": "CCAvail",
-            "name": "CatCCAvail"
+            "label": "Poor communication",
+            "value": "PoorComm",
+            "name": "CatPoorComm"
           },
           {
-            "label": "CC - Provision for Minors",
+            "label": "Provision for minors",
             "value": "CCProvMinor",
             "name": "CatCCProvMinor"
           },
           {
-            "label": "CC - Complaint Handling",
-            "value": "CCHandle",
-            "name": "CatCCHandle"
-          },
-          {
-            "label": "Damage (BF)",
-            "value": "DamBF",
-            "name": "CatDamBF"
-          },
-          {
-            "label": "Custody (BF)",
-            "value": "CustodyBF",
-            "name": "CatCustodyBF"
+            "label": "Wrong information",
+            "value": "WrongInfo",
+            "name": "CatWrongInfo"
           }
         ],
         "showLabel": false,
@@ -81,26 +71,26 @@
       "validation": [],
       "props": {},
       "component": "accordion",
-      "label": "Serious and Minor"
+      "label": "Serious and minor misconduct"
     },
     {
       "validation": [],
       "props": {
         "choices": [
           {
+            "label": "Other unprofessionalism",
+            "value": "OtherUnprof",
+            "name": "CatOtherUnprof"
+          },
+          {
             "label": "Rudeness",
             "value": "Rude",
             "name": "CatRude"
           },
           {
-            "label": "Unfair Treatment",
+            "label": "Unfair treatment",
             "value": "Unfair",
             "name": "CatUnfair"
-          },
-          {
-            "label": "Other Unprofessional",
-            "value": "OtherUnprof",
-            "name": "CatOtherUnprof"
           }
         ],
         "showLabel": false,
@@ -114,36 +104,36 @@
       "validation": [],
       "props": {},
       "component": "accordion",
-      "label": "Serious"
+      "label": "Serious misconduct"
     },
     {
       "validation": [],
       "props": {
         "choices": [
           {
-            "label": "Theft",
-            "value": "Theft",
-            "name": "CatTheft"
-          },
-          {
             "label": "Assault",
             "value": "Assault",
             "name": "CatAssault"
           },
           {
-            "label": "Sexual Assault",
-            "value": "SexAssault",
-            "name": "CatSexAssault"
-          },
-          {
-            "label": "Fraud / Corruption",
+            "label": "Fraud / corruption",
             "value": "Fraud",
             "name": "CatFraud"
           },
           {
-            "label": "Racism and Other Discrimination",
+            "label": "Racism / discrimination",
             "value": "Racism",
             "name": "CatRacism"
+          },
+          {
+            "label": "Sexual assault",
+            "value": "SexAssault",
+            "name": "CatSexAssault"
+          },
+          {
+            "label": "Theft",
+            "value": "Theft",
+            "name": "CatTheft"
           }
         ],
         "showLabel": false,
@@ -157,17 +147,6 @@
       "validation": [],
       "props": {},
       "component": "accordion-end"
-    },
-    {
-      "validation": [
-        "required"
-      ],
-      "props": {
-        "choices": "S_COMP_CSU_LIST"
-      },
-      "component": "dropdown",
-      "name": "OwningCSU",
-      "label": "Owning CSU"
     }
   ],
   "secondaryActions": [
@@ -179,5 +158,5 @@
       "label": "Back"
     }
   ],
-  "validation": "{\"linkTo\": \"ServiceAccordion\", \"message\": \"Select at least one complaint type option\", \"options\": [\"CatDelay\", \"CatAdminErr\", \"CatPoorComm\", \"CatWrongInfo\", \"CatLost\", \"CatCCPhy\", \"CatCCAvail\", \"CatCCProvMinor\", \"CatCCHandle\", \"CatDamBF\", \"CatCustodyBF\", \"CatRude\", \"CatUnfair\", \"CatOtherUnprof\", \"CatTheft\", \"CatAssault\", \"CatSexAssault\", \"CatFraud\", \"CatRacism\"], \"validator\": \"oneOf\"}"
+  "validation": "{\"linkTo\": \"ServiceAccordion\", \"message\": \"Select at least one complaint type option\", \"options\": [\"CatDelay\", \"CatAdminErr\", \"CatPoorComm\", \"CatWrongInfo\", \"CatLost\", \"CatCCPhy\", \"CatCCAvail\", \"CatCCProvMinor\", \"CatCCHandle\", \"CatRude\", \"CatUnfair\", \"CatOtherUnprof\", \"CatTheft\", \"CatAssault\", \"CatSexAssault\", \"CatFraud\", \"CatRacism\"], \"validator\": \"oneOf\"}"
 }

--- a/src/main/resources/screens/live/SERVICE_CATEGORY.json
+++ b/src/main/resources/screens/live/SERVICE_CATEGORY.json
@@ -1,6 +1,6 @@
 {
   "props": {},
-  "title": "Complaint Category",
+  "title": "Complaint category",
   "defaultActionLabel": "Continue",
   "fields": [
     {
@@ -15,59 +15,49 @@
       "props": {
         "choices": [
           {
+            "label": "Admin / process error",
+            "value": "AdminErr",
+            "name": "CatAdminErr"
+          },
+          {
+            "label": "Availability of service",
+            "value": "CCAvail",
+            "name": "CatCCAvail"
+          },
+          {
+            "label": "Complaint handling",
+            "value": "CCHandle",
+            "name": "CatCCHandle"
+          },
+          {
             "label": "Delay",
             "value": "Delay",
             "name": "CatDelay"
           },
           {
-            "label": "Admin / Process Error",
-            "value": "AdminErr",
-            "name": "CatAdminErr"
-          },
-          {
-            "label": "Poor Communication",
-            "value": "PoorComm",
-            "name": "CatPoorComm"
-          },
-          {
-            "label": "Wrong Information",
-            "value": "WrongInfo",
-            "name": "CatWrongInfo"
-          },
-          {
-            "label": "Properties and Lost Documents",
+            "label": "Lost property or documents",
             "value": "Lost",
             "name": "CatLost"
           },
           {
-            "label": "CC - Physical Environment",
+            "label": "Physical environment",
             "value": "CCPhy",
             "name": "CatCCPhy"
           },
           {
-            "label": "CC - Availability of Service",
-            "value": "CCAvail",
-            "name": "CatCCAvail"
+            "label": "Poor communication",
+            "value": "PoorComm",
+            "name": "CatPoorComm"
           },
           {
-            "label": "CC - Provision for Minors",
+            "label": "Provision for minors",
             "value": "CCProvMinor",
             "name": "CatCCProvMinor"
           },
           {
-            "label": "CC - Complaint Handling",
-            "value": "CCHandle",
-            "name": "CatCCHandle"
-          },
-          {
-            "label": "Damage (BF)",
-            "value": "DamBF",
-            "name": "CatDamBF"
-          },
-          {
-            "label": "Custody (BF)",
-            "value": "CustodyBF",
-            "name": "CatCustodyBF"
+            "label": "Wrong information",
+            "value": "WrongInfo",
+            "name": "CatWrongInfo"
           }
         ],
         "showLabel": false,
@@ -81,26 +71,26 @@
       "validation": [],
       "props": {},
       "component": "accordion",
-      "label": "Serious and Minor"
+      "label": "Serious and minor misconduct"
     },
     {
       "validation": [],
       "props": {
         "choices": [
           {
+            "label": "Other unprofessionalism",
+            "value": "OtherUnprof",
+            "name": "CatOtherUnprof"
+          },
+          {
             "label": "Rudeness",
             "value": "Rude",
             "name": "CatRude"
           },
           {
-            "label": "Unfair Treatment",
+            "label": "Unfair treatment",
             "value": "Unfair",
             "name": "CatUnfair"
-          },
-          {
-            "label": "Other Unprofessional",
-            "value": "OtherUnprof",
-            "name": "CatOtherUnprof"
           }
         ],
         "showLabel": false,
@@ -114,36 +104,36 @@
       "validation": [],
       "props": {},
       "component": "accordion",
-      "label": "Serious"
+      "label": "Serious misconduct"
     },
     {
       "validation": [],
       "props": {
         "choices": [
           {
-            "label": "Theft",
-            "value": "Theft",
-            "name": "CatTheft"
-          },
-          {
             "label": "Assault",
             "value": "Assault",
             "name": "CatAssault"
           },
           {
-            "label": "Sexual Assault",
-            "value": "SexAssault",
-            "name": "CatSexAssault"
-          },
-          {
-            "label": "Fraud / Corruption",
+            "label": "Fraud / corruption",
             "value": "Fraud",
             "name": "CatFraud"
           },
           {
-            "label": "Racism and Other Discrimination",
+            "label": "Racism / discrimination",
             "value": "Racism",
             "name": "CatRacism"
+          },
+          {
+            "label": "Sexual assault",
+            "value": "SexAssault",
+            "name": "CatSexAssault"
+          },
+          {
+            "label": "Theft",
+            "value": "Theft",
+            "name": "CatTheft"
           }
         ],
         "showLabel": false,
@@ -157,17 +147,6 @@
       "validation": [],
       "props": {},
       "component": "accordion-end"
-    },
-    {
-      "validation": [
-        "required"
-      ],
-      "props": {
-        "choices": "S_COMP_CSU_LIST"
-      },
-      "component": "dropdown",
-      "name": "OwningCSU",
-      "label": "Owning CSU"
     }
   ],
   "secondaryActions": [


### PR DESCRIPTION
This change reworks the category screens to better fit user needs. This includes removing the OwningCSU field as its not required. It also includes reordering of checkboxes into alphabetical order to allow better visual scrolling.