### PR TITLE
HOCS-5838: refactor out accordion

### DIFF
--- a/src/main/resources/screens/live/COMP_REGISTRATION_CATEGORY.json
+++ b/src/main/resources/screens/live/COMP_REGISTRATION_CATEGORY.json
@@ -5,10 +5,12 @@
   "fields": [
     {
       "validation": [],
-      "props": {},
-      "component": "accordion",
-      "name": "ServiceAccordion",
-      "label": "Service"
+      "props": {
+        "children": "Select all that apply."
+      },
+      "component": "paragraph",
+      "name": "CategoryInset",
+      "label": ""
     },
     {
       "validation": [],
@@ -60,18 +62,12 @@
             "name": "CatWrongInfo"
           }
         ],
-        "showLabel": false,
+        "showLabel": true,
         "saveSeparately": true
       },
       "component": "checkbox",
       "name": "CategoriesService",
       "label": "Service"
-    },
-    {
-      "validation": [],
-      "props": {},
-      "component": "accordion",
-      "label": "Serious and minor misconduct"
     },
     {
       "validation": [],
@@ -93,18 +89,12 @@
             "name": "CatUnfair"
           }
         ],
-        "showLabel": false,
+        "showLabel": true,
         "saveSeparately": true
       },
       "component": "checkbox",
       "name": "CategoriesSeriousAndMinor",
-      "label": "Serious and Minor"
-    },
-    {
-      "validation": [],
-      "props": {},
-      "component": "accordion",
-      "label": "Serious misconduct"
+      "label": "Serious and minor misconduct"
     },
     {
       "validation": [],
@@ -136,17 +126,12 @@
             "name": "CatTheft"
           }
         ],
-        "showLabel": false,
+        "showLabel": true,
         "saveSeparately": true
       },
       "component": "checkbox",
       "name": "CategoriesSerious",
-      "label": "Serious"
-    },
-    {
-      "validation": [],
-      "props": {},
-      "component": "accordion-end"
+      "label": "Serious misconduct"
     }
   ],
   "secondaryActions": [
@@ -158,5 +143,5 @@
       "label": "Back"
     }
   ],
-  "validation": "{\"linkTo\": \"ServiceAccordion\", \"message\": \"Select at least one complaint type option\", \"options\": [\"CatDelay\", \"CatAdminErr\", \"CatPoorComm\", \"CatWrongInfo\", \"CatLost\", \"CatCCPhy\", \"CatCCAvail\", \"CatCCProvMinor\", \"CatCCHandle\", \"CatRude\", \"CatUnfair\", \"CatOtherUnprof\", \"CatTheft\", \"CatAssault\", \"CatSexAssault\", \"CatFraud\", \"CatRacism\"], \"validator\": \"oneOf\"}"
+  "validation": "{\"linkTo\": \"CategoriesService\", \"message\": \"Select at least one complaint type option\", \"options\": [\"CatDelay\", \"CatAdminErr\", \"CatPoorComm\", \"CatWrongInfo\", \"CatLost\", \"CatCCPhy\", \"CatCCAvail\", \"CatCCProvMinor\", \"CatCCHandle\", \"CatRude\", \"CatUnfair\", \"CatOtherUnprof\", \"CatTheft\", \"CatAssault\", \"CatSexAssault\", \"CatFraud\", \"CatRacism\"], \"validator\": \"oneOf\"}"
 }

--- a/src/main/resources/screens/live/EXGRATIA_CATEGORY.json
+++ b/src/main/resources/screens/live/EXGRATIA_CATEGORY.json
@@ -5,10 +5,12 @@
   "fields": [
     {
       "validation": [],
-      "props": {},
-      "component": "accordion",
-      "name": "ServiceAccordion",
-      "label": "Service"
+      "props": {
+        "children": "Select all that apply."
+      },
+      "component": "paragraph",
+      "name": "CategoryInset",
+      "label": ""
     },
     {
       "validation": [],
@@ -60,18 +62,12 @@
             "name": "CatWrongInfo"
           }
         ],
-        "showLabel": false,
+        "showLabel": true,
         "saveSeparately": true
       },
       "component": "checkbox",
       "name": "CategoriesService",
       "label": "Service"
-    },
-    {
-      "validation": [],
-      "props": {},
-      "component": "accordion",
-      "label": "Serious and minor misconduct"
     },
     {
       "validation": [],
@@ -93,18 +89,12 @@
             "name": "CatUnfair"
           }
         ],
-        "showLabel": false,
+        "showLabel": true,
         "saveSeparately": true
       },
       "component": "checkbox",
       "name": "CategoriesSeriousAndMinor",
-      "label": "Serious and Minor"
-    },
-    {
-      "validation": [],
-      "props": {},
-      "component": "accordion",
-      "label": "Serious misconduct"
+      "label": "Serious and minor misconduct"
     },
     {
       "validation": [],
@@ -136,19 +126,12 @@
             "name": "CatTheft"
           }
         ],
-        "showLabel": false,
+        "showLabel": true,
         "saveSeparately": true
       },
       "component": "checkbox",
       "name": "CategoriesSerious",
-      "label": "Serious"
-    },
-    {
-      "validation": [],
-      "props": {},
-      "component": "accordion",
-      "name": "ExGratiaAccordian",
-      "label": "Ex-Gratia"
+      "label": "Serious misconduct"
     },
     {
       "validation": [],
@@ -205,17 +188,12 @@
             "name": "CatStage3"
           }
         ],
-        "showLabel": false,
+        "showLabel": true,
         "saveSeparately": true
       },
       "component": "checkbox",
       "name": "CategoriesExGratia",
       "label": "Ex-Gratia"
-    },
-    {
-      "validation": [],
-      "props": {},
-      "component": "accordion-end"
     }
   ],
   "secondaryActions": [
@@ -227,5 +205,5 @@
       "label": "Back"
     }
   ],
-  "validation": "{\"linkTo\": \"ExGratiaAccordian\", \"message\": \"Select at least one Ex-Gratia option\", \"options\": [\"CatChaser\", \"CatOffer\", \"CatLitigation\", \"CatMPAMPOffer\", \"CatNewClaimC\", \"CatNewClaimSF\", \"CatPHSO\", \"CatProject\", \"CatReconsideration\", \"CatStage3\"], \"validator\": \"oneOf\"}"
+  "validation": "{\"linkTo\": \"CategoriesExGratia\", \"message\": \"Select at least one Ex-Gratia option\", \"options\": [\"CatChaser\", \"CatOffer\", \"CatLitigation\", \"CatMPAMPOffer\", \"CatNewClaimC\", \"CatNewClaimSF\", \"CatPHSO\", \"CatProject\", \"CatReconsideration\", \"CatStage3\"], \"validator\": \"oneOf\"}"
 }

--- a/src/main/resources/screens/live/MM_CATEGORY.json
+++ b/src/main/resources/screens/live/MM_CATEGORY.json
@@ -5,10 +5,12 @@
   "fields": [
     {
       "validation": [],
-      "props": {},
-      "component": "accordion",
-      "name": "ServiceAccordion",
-      "label": "Service"
+      "props": {
+        "children": "Select all that apply."
+      },
+      "component": "paragraph",
+      "name": "CategoryInset",
+      "label": ""
     },
     {
       "validation": [],
@@ -60,19 +62,12 @@
             "name": "CatWrongInfo"
           }
         ],
-        "showLabel": false,
+        "showLabel": true,
         "saveSeparately": true
       },
       "component": "checkbox",
       "name": "CategoriesService",
       "label": "Service"
-    },
-    {
-      "validation": [],
-      "props": {},
-      "component": "accordion",
-      "name": "SeriousMinorAccordian",
-      "label": "Serious and minor misconduct"
     },
     {
       "validation": [],
@@ -94,18 +89,12 @@
             "name": "CatUnfair"
           }
         ],
-        "showLabel": false,
+        "showLabel": true,
         "saveSeparately": true
       },
       "component": "checkbox",
       "name": "CategoriesSeriousAndMinor",
-      "label": "Serious and Minor"
-    },
-    {
-      "validation": [],
-      "props": {},
-      "component": "accordion",
-      "label": "Serious misconduct"
+      "label": "Serious and minor misconduct"
     },
     {
       "validation": [],
@@ -137,19 +126,12 @@
             "name": "CatTheft"
           }
         ],
-        "showLabel": false,
+        "showLabel": true,
         "saveSeparately": true
       },
       "component": "checkbox",
       "name": "CategoriesSerious",
-      "label": "Serious"
-    },
-    {
-      "validation": [],
-      "props": {},
-      "component": "accordion",
-      "name": "ExGratiaAccordian",
-      "label": "Ex-Gratia"
+      "label": "Serious misconduct"
     },
     {
       "validation": [],
@@ -206,19 +188,14 @@
             "name": "CatStage3"
           }
         ],
-        "showLabel": false,
+        "showLabel": true,
         "saveSeparately": true
       },
       "component": "checkbox",
       "name": "CategoriesExGratia",
       "label": "Ex-Gratia"
-    },
-    {
-      "validation": [],
-      "props": {},
-      "component": "accordion-end"
     }
   ],
   "secondaryActions": [],
-  "validation": "{\"linkTo\": \"SeriousMinorAccordian\", \"message\": \"Select at least one option from Serious and Minor\", \"options\": [\"CatRude\", \"CatUnfair\", \"CatOtherUnprof\"], \"validator\": \"oneOf\"}"
+  "validation": "{\"linkTo\": \"CategoriesSeriousAndMinor\", \"message\": \"Select at least one option from Serious and Minor\", \"options\": [\"CatRude\", \"CatUnfair\", \"CatOtherUnprof\"], \"validator\": \"oneOf\"}"
 }

--- a/src/main/resources/screens/live/SERVICE_CATEGORY.json
+++ b/src/main/resources/screens/live/SERVICE_CATEGORY.json
@@ -5,10 +5,12 @@
   "fields": [
     {
       "validation": [],
-      "props": {},
-      "component": "accordion",
-      "name": "ServiceAccordion",
-      "label": "Service"
+      "props": {
+        "children": "Select all that apply."
+      },
+      "component": "paragraph",
+      "name": "CategoryInset",
+      "label": ""
     },
     {
       "validation": [],
@@ -60,18 +62,12 @@
             "name": "CatWrongInfo"
           }
         ],
-        "showLabel": false,
+        "showLabel": true,
         "saveSeparately": true
       },
       "component": "checkbox",
       "name": "CategoriesService",
       "label": "Service"
-    },
-    {
-      "validation": [],
-      "props": {},
-      "component": "accordion",
-      "label": "Serious and minor misconduct"
     },
     {
       "validation": [],
@@ -93,18 +89,12 @@
             "name": "CatUnfair"
           }
         ],
-        "showLabel": false,
+        "showLabel": true,
         "saveSeparately": true
       },
       "component": "checkbox",
       "name": "CategoriesSeriousAndMinor",
-      "label": "Serious and Minor"
-    },
-    {
-      "validation": [],
-      "props": {},
-      "component": "accordion",
-      "label": "Serious misconduct"
+      "label": "Serious and minor misconduct"
     },
     {
       "validation": [],
@@ -136,17 +126,12 @@
             "name": "CatTheft"
           }
         ],
-        "showLabel": false,
+        "showLabel": true,
         "saveSeparately": true
       },
       "component": "checkbox",
       "name": "CategoriesSerious",
-      "label": "Serious"
-    },
-    {
-      "validation": [],
-      "props": {},
-      "component": "accordion-end"
+      "label": "Serious misconduct"
     }
   ],
   "secondaryActions": [


### PR DESCRIPTION
Remove all the accordions from category screens as its not required and enforces more actions from the users. This change uses the checkbox group label instead.