### PR TITLE
HOCS-6542: remove conditional choice logic

### DIFF
--- a/src/main/resources/screens/live/COMP_SERVICE_TRIAGE_BUSAREA.json
+++ b/src/main/resources/screens/live/COMP_SERVICE_TRIAGE_BUSAREA.json
@@ -8,74 +8,30 @@
         "required"
       ],
       "props": {
-        "conditionChoices": [
+        "choices": [
           {
-            "choices": [
-              {
-                "label": "IandP",
-                "value": "IandP"
-              },
-              {
-                "label": "RASI",
-                "value": "RASI"
-              },
-              {
-                "label": "VCIC",
-                "value": "VCIC"
-              },
-              {
-                "label": "VCOS",
-                "value": "VCOS"
-              },
-              {
-                "label": "Other",
-                "value": "Other"
-              },
-              {
-                "label": "EUSS FP",
-                "value": "EUSSFP"
-              }
-            ],
-            "conditionPropertyName": "OwningCSU",
-            "conditionPropertyValue": "UKVI"
+            "label": "IandP",
+            "value": "IandP"
           },
           {
-            "choices": [
-              {
-                "label": "CI",
-                "value": "CI"
-              },
-              {
-                "label": "FNORC",
-                "value": "FNORC"
-              },
-              {
-                "label": "Detention",
-                "value": "Detention"
-              },
-              {
-                "label": "ICE Teams",
-                "value": "ICETeams"
-              },
-              {
-                "label": "Other",
-                "value": "Other"
-              },
-              {
-                "label": "NRC",
-                "value": "NRC"
-              },
-              {
-                "label": "Reporting Centres",
-                "value": "ReportingCentres"
-              },
-              {
-                "label": "Returns Preparation",
-                "value": "ReturnsPreparation"
-              }
-            ],
-            "conditionPropertyName": "OwningCSU",
-            "conditionPropertyValue": "IE"
+            "label": "RASI",
+            "value": "RASI"
+          },
+          {
+            "label": "VCIC",
+            "value": "VCIC"
+          },
+          {
+            "label": "VCOS",
+            "value": "VCOS"
+          },
+          {
+            "label": "Other",
+            "value": "Other"
+          },
+          {
+            "label": "EUSS FP",
+            "value": "EUSSFP"
           }
         ]
       },
@@ -115,99 +71,9 @@
             "conditionPropertyValue": "EUSSFP"
           },
           {
-            "choices": [
-              {
-                "label": "",
-                "value": ""
-              }
-            ],
-            "conditionPropertyName": "Directorate",
-            "conditionPropertyValue": "VandCInternational"
-          },
-          {
-            "choices": [
-              {
-                "label": "",
-                "value": ""
-              }
-            ],
-            "conditionPropertyName": "Directorate",
-            "conditionPropertyValue": "VandCInCountry"
-          },
-          {
-            "choices": [
-              {
-                "label": "Crime Investigations",
-                "value": "CrimeInvestigations"
-              }
-            ],
-            "conditionPropertyName": "Directorate",
-            "conditionPropertyValue": "CI"
-          },
-          {
-            "choices": [
-              {
-                "label": "FNORC (IE)",
-                "value": "FNORC(IE)"
-              }
-            ],
-            "conditionPropertyName": "Directorate",
-            "conditionPropertyValue": "FNORC"
-          },
-          {
-            "choices": [
-              {
-                "label": "Detention Services",
-                "value": "DetentionServices"
-              }
-            ],
-            "conditionPropertyName": "Directorate",
-            "conditionPropertyValue": "Detention"
-          },
-          {
-            "choices": [
-              {
-                "label": "ICE Teams",
-                "value": "ICETeams"
-              }
-            ],
-            "conditionPropertyName": "Directorate",
-            "conditionPropertyValue": "ICETeams"
-          },
-          {
             "choices": "COMP_OTHER_BUS_AREA",
             "conditionPropertyName": "Directorate",
             "conditionPropertyValue": "Other"
-          },
-          {
-            "choices": [
-              {
-                "label": "NRC (detained removal casework)",
-                "value": "NRC"
-              }
-            ],
-            "conditionPropertyName": "Directorate",
-            "conditionPropertyValue": "NRC"
-          },
-          {
-            "choices": [
-              {
-                "label": "Reporting Centres",
-                "value": "ReportingCentres"
-              }
-            ],
-            "conditionPropertyName": "Directorate",
-            "conditionPropertyValue": "ReportingCentres"
-          },
-          {
-            "choices": [
-              {
-                "label": "Returns Preparations (non detained removal casework)",
-                "value": "ReturnsPreparations"
-              }
-            ],
-            "conditionPropertyName": "Directorate",
-            "conditionPropertyValue": "ReturnsPreparation"
           }
         ]
       },


### PR DESCRIPTION
Remove conditional choice logic around Owning CSU for COMP(2) cases as this was removed due to not being required under HOCS-5824.