### PR TITLE
HOCS-6550: support live cases ministerial sign off

### DIFF
--- a/src/main/resources/processes/DCU/DCU_MIN.bpmn
+++ b/src/main/resources/processes/DCU/DCU_MIN.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.2">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.10.0">
   <bpmn:process id="MIN" isExecutable="true">
     <bpmn:startEvent id="DCU_MIN_START" name="Start Case">
       <bpmn:outgoing>SequenceFlow_1pepep6</bpmn:outgoing>
@@ -234,7 +234,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_1fy5blc" name="REJECT" sourceRef="ExclusiveGateway_19ar4c1" targetRef="POSignOff_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${DispatchDecision == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="ExclusiveGateway_1mq7rz0">
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1mq7rz0" default="SequenceFlow_0gdfx58">
       <bpmn:incoming>SequenceFlow_19kv4zf</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_042tt22</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0gdfx58</bpmn:outgoing>
@@ -243,9 +243,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_042tt22" name="REJECT" sourceRef="ExclusiveGateway_1mq7rz0" targetRef="InitialDraft_CallActivity">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${MinisterSignOffDecision == "REJECT"}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0gdfx58" name="ACCEPT" sourceRef="ExclusiveGateway_1mq7rz0" targetRef="CallActivity_1rowgu5">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${MinisterSignOffDecision == "ACCEPT_WET" ||  MinisterSignOffDecision == "ACCEPT_DIGITAL" }</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_0gdfx58" name="ACCEPT" sourceRef="ExclusiveGateway_1mq7rz0" targetRef="CallActivity_1rowgu5" />
     <bpmn:sequenceFlow id="SequenceFlow_1bi7lza" sourceRef="CallActivity_0ttmlei" targetRef="ExclusiveGateway_0aomnup" />
     <bpmn:exclusiveGateway id="ExclusiveGateway_0aomnup">
       <bpmn:incoming>SequenceFlow_1bi7lza</bpmn:incoming>
@@ -346,304 +344,6 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MIN">
-      <bpmndi:BPMNEdge id="SequenceFlow_1gnfbua_di" bpmnElement="SequenceFlow_1gnfbua">
-        <di:waypoint x="2958" y="416" />
-        <di:waypoint x="2958" y="272" />
-        <di:waypoint x="2427" y="272" />
-        <di:waypoint x="2427" y="401" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2651" y="254" width="84" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0dbzkcf_di" bpmnElement="SequenceFlow_0dbzkcf">
-        <di:waypoint x="2188" y="441" />
-        <di:waypoint x="2225" y="441" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_161sh1e_di" bpmnElement="SequenceFlow_161sh1e">
-        <di:waypoint x="1820" y="441" />
-        <di:waypoint x="1871" y="441" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0842fwm_di" bpmnElement="SequenceFlow_0842fwm">
-        <di:waypoint x="928" y="416" />
-        <di:waypoint x="928" y="329" />
-        <di:waypoint x="347" y="329" />
-        <di:waypoint x="347" y="401" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="891" y="362" width="21" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0b8hmwm_di" bpmnElement="SequenceFlow_0b8hmwm">
-        <di:waypoint x="3707" y="441" />
-        <di:waypoint x="3847" y="441" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_18o5t1m_di" bpmnElement="SequenceFlow_18o5t1m">
-        <di:waypoint x="1105" y="992" />
-        <di:waypoint x="3657" y="992" />
-        <di:waypoint x="3657" y="481" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3613.5" y="1149.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0br3a39_di" bpmnElement="SequenceFlow_0br3a39">
-        <di:waypoint x="1080" y="992" />
-        <di:waypoint x="549" y="992" />
-        <di:waypoint x="549" y="481" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2229" y="1149.5" width="0" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1yygtaq_di" bpmnElement="SequenceFlow_1yygtaq">
-        <di:waypoint x="2604" y="416" />
-        <di:waypoint x="2604" y="343" />
-        <di:waypoint x="2427" y="343" />
-        <di:waypoint x="2427" y="401" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2493" y="322" width="49" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_163tdrh_di" bpmnElement="SequenceFlow_163tdrh">
-        <di:waypoint x="3539" y="591" />
-        <di:waypoint x="3657" y="591" />
-        <di:waypoint x="3657" y="481" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="4663" y="716" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0y4nfck_di" bpmnElement="SequenceFlow_0y4nfck">
-        <di:waypoint x="3489" y="466" />
-        <di:waypoint x="3489" y="551" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3500" y="474" width="19" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0x3d1ed_di" bpmnElement="SequenceFlow_0x3d1ed">
-        <di:waypoint x="3514" y="441" />
-        <di:waypoint x="3607" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3507" y="409" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_08od3ei_di" bpmnElement="SequenceFlow_08od3ei">
-        <di:waypoint x="1896" y="416" />
-        <di:waypoint x="1896" y="174" />
-        <di:waypoint x="2427" y="174" />
-        <di:waypoint x="2427" y="401" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1906" y="336" width="51" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_17blyfx_di" bpmnElement="SequenceFlow_17blyfx">
-        <di:waypoint x="1921" y="441" />
-        <di:waypoint x="1955" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3062" y="595" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0qz7pb4_di" bpmnElement="SequenceFlow_0qz7pb4">
-        <di:waypoint x="1636" y="416" />
-        <di:waypoint x="1636" y="81" />
-        <di:waypoint x="3657" y="81" />
-        <di:waypoint x="3657" y="401" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1559" y="329" width="69" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0e38st4_di" bpmnElement="SequenceFlow_0e38st4">
-        <di:waypoint x="1661" y="441" />
-        <di:waypoint x="1720" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1646" y="399" width="68" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0tcxf89_di" bpmnElement="SequenceFlow_0tcxf89">
-        <di:waypoint x="776" y="876" />
-        <di:waypoint x="3657" y="876" />
-        <di:waypoint x="3657" y="481" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3467" y="1033" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1ii85y3_di" bpmnElement="SequenceFlow_1ii85y3">
-        <di:waypoint x="751" y="876" />
-        <di:waypoint x="549" y="876" />
-        <di:waypoint x="549" y="481" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2082.5" y="1033" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1h7ckog_di" bpmnElement="SequenceFlow_1h7ckog">
-        <di:waypoint x="1105" y="781" />
-        <di:waypoint x="1105" y="967" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2365" y="914.5" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1bi7lza_di" bpmnElement="SequenceFlow_1bi7lza">
-        <di:waypoint x="751" y="781" />
-        <di:waypoint x="751" y="851" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2162" y="913.5" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0gdfx58_di" bpmnElement="SequenceFlow_0gdfx58">
-        <di:waypoint x="2983" y="441" />
-        <di:waypoint x="3085" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2984" y="409" width="45" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_042tt22_di" bpmnElement="SequenceFlow_042tt22">
-        <di:waypoint x="2958" y="466" />
-        <di:waypoint x="2958" y="786" />
-        <di:waypoint x="1307" y="786" />
-        <di:waypoint x="1307" y="481" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2961" y="513" width="43" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1fy5blc_di" bpmnElement="SequenceFlow_1fy5blc">
-        <di:waypoint x="3312" y="416" />
-        <di:waypoint x="3312" y="219" />
-        <di:waypoint x="2427" y="219" />
-        <di:waypoint x="2427" y="401" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3315" y="337" width="43" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0hrswjv_di" bpmnElement="SequenceFlow_0hrswjv">
-        <di:waypoint x="3337" y="441" />
-        <di:waypoint x="3464" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3354" y="410" width="45" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1p4ijz3_di" bpmnElement="SequenceFlow_1p4ijz3">
-        <di:waypoint x="3185" y="441" />
-        <di:waypoint x="3287" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="4314" y="595" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_19kv4zf_di" bpmnElement="SequenceFlow_19kv4zf">
-        <di:waypoint x="2831" y="441" />
-        <di:waypoint x="2933" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3976" y="595" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0ln7eru_di" bpmnElement="SequenceFlow_0ln7eru">
-        <di:waypoint x="2629" y="441" />
-        <di:waypoint x="2731" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2625" y="409" width="45" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1tlbpjq_di" bpmnElement="SequenceFlow_1tlbpjq">
-        <di:waypoint x="2604" y="466" />
-        <di:waypoint x="2604" y="672" />
-        <di:waypoint x="1307" y="672" />
-        <di:waypoint x="1307" y="481" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2607" y="513" width="43" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1dvsqnt_di" bpmnElement="SequenceFlow_1dvsqnt">
-        <di:waypoint x="2477" y="441" />
-        <di:waypoint x="2579" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3622" y="595" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_094as2e_di" bpmnElement="SequenceFlow_094as2e">
-        <di:waypoint x="2250" y="466" />
-        <di:waypoint x="2250" y="562" />
-        <di:waypoint x="1307" y="562" />
-        <di:waypoint x="1307" y="481" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2253" y="512" width="43" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0y1hwz5_di" bpmnElement="SequenceFlow_0y1hwz5">
-        <di:waypoint x="2275" y="441" />
-        <di:waypoint x="2377" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2270" y="409" width="47" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1gic80p_di" bpmnElement="SequenceFlow_1gic80p">
-        <di:waypoint x="2055" y="441" />
-        <di:waypoint x="2088" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="3268" y="595" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0hodmse_di" bpmnElement="SequenceFlow_0hodmse">
-        <di:waypoint x="1509" y="441" />
-        <di:waypoint x="1611" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1508" y="409" width="45" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0lq9cg0_di" bpmnElement="SequenceFlow_0lq9cg0">
-        <di:waypoint x="911" y="449" />
-        <di:waypoint x="751" y="521" />
-        <di:waypoint x="751" y="701" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="867" y="478" width="24" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0occ9ef_di" bpmnElement="SequenceFlow_0occ9ef">
-        <di:waypoint x="1484" y="416" />
-        <di:waypoint x="1484" y="269" />
-        <di:waypoint x="549" y="269" />
-        <di:waypoint x="549" y="401" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1487" y="362" width="43" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1no0ocj_di" bpmnElement="SequenceFlow_1no0ocj">
-        <di:waypoint x="1357" y="441" />
-        <di:waypoint x="1459" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2609" y="595" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_18mb2fq_di" bpmnElement="SequenceFlow_18mb2fq">
-        <di:waypoint x="397" y="441" />
-        <di:waypoint x="499" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1528" y="595" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1kbehe7_di" bpmnElement="SequenceFlow_1kbehe7">
-        <di:waypoint x="599" y="441" />
-        <di:waypoint x="903" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="2058" y="595" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_04i3gn3_di" bpmnElement="SequenceFlow_04i3gn3">
-        <di:waypoint x="953" y="441" />
-        <di:waypoint x="1257" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="986" y="407" width="48" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_058p133_di" bpmnElement="SequenceFlow_058p133">
-        <di:waypoint x="945" y="449" />
-        <di:waypoint x="1105" y="519" />
-        <di:waypoint x="1105" y="701" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="967" y="475" width="26" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1pepep6_di" bpmnElement="SequenceFlow_1pepep6">
-        <di:waypoint x="200" y="441" />
-        <di:waypoint x="297" y="441" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1102.5" y="595" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="DCU_MIN_START">
         <dc:Bounds x="164" y="423" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -761,6 +461,304 @@
       <bpmndi:BPMNShape id="ServiceTask_0agee0y_di" bpmnElement="ServiceTask_0agee0y">
         <dc:Bounds x="2088" y="401" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1pepep6_di" bpmnElement="SequenceFlow_1pepep6">
+        <di:waypoint x="200" y="441" />
+        <di:waypoint x="297" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1102.5" y="595" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_058p133_di" bpmnElement="SequenceFlow_058p133">
+        <di:waypoint x="945" y="449" />
+        <di:waypoint x="1105" y="519" />
+        <di:waypoint x="1105" y="701" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="967" y="475" width="26" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_04i3gn3_di" bpmnElement="SequenceFlow_04i3gn3">
+        <di:waypoint x="953" y="441" />
+        <di:waypoint x="1257" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="986" y="407" width="48" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1kbehe7_di" bpmnElement="SequenceFlow_1kbehe7">
+        <di:waypoint x="599" y="441" />
+        <di:waypoint x="903" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2058" y="595" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_18mb2fq_di" bpmnElement="SequenceFlow_18mb2fq">
+        <di:waypoint x="397" y="441" />
+        <di:waypoint x="499" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1528" y="595" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1no0ocj_di" bpmnElement="SequenceFlow_1no0ocj">
+        <di:waypoint x="1357" y="441" />
+        <di:waypoint x="1459" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2609" y="595" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0occ9ef_di" bpmnElement="SequenceFlow_0occ9ef">
+        <di:waypoint x="1484" y="416" />
+        <di:waypoint x="1484" y="269" />
+        <di:waypoint x="549" y="269" />
+        <di:waypoint x="549" y="401" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1487" y="362" width="43" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0lq9cg0_di" bpmnElement="SequenceFlow_0lq9cg0">
+        <di:waypoint x="911" y="449" />
+        <di:waypoint x="751" y="521" />
+        <di:waypoint x="751" y="701" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="867" y="478" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hodmse_di" bpmnElement="SequenceFlow_0hodmse">
+        <di:waypoint x="1509" y="441" />
+        <di:waypoint x="1611" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1508" y="409" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1gic80p_di" bpmnElement="SequenceFlow_1gic80p">
+        <di:waypoint x="2055" y="441" />
+        <di:waypoint x="2088" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3268" y="595" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0y1hwz5_di" bpmnElement="SequenceFlow_0y1hwz5">
+        <di:waypoint x="2275" y="441" />
+        <di:waypoint x="2377" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2270" y="409" width="47" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_094as2e_di" bpmnElement="SequenceFlow_094as2e">
+        <di:waypoint x="2250" y="466" />
+        <di:waypoint x="2250" y="562" />
+        <di:waypoint x="1307" y="562" />
+        <di:waypoint x="1307" y="481" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2253" y="512" width="43" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1dvsqnt_di" bpmnElement="SequenceFlow_1dvsqnt">
+        <di:waypoint x="2477" y="441" />
+        <di:waypoint x="2579" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3622" y="595" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1tlbpjq_di" bpmnElement="SequenceFlow_1tlbpjq">
+        <di:waypoint x="2604" y="466" />
+        <di:waypoint x="2604" y="672" />
+        <di:waypoint x="1307" y="672" />
+        <di:waypoint x="1307" y="481" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2607" y="513" width="43" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0ln7eru_di" bpmnElement="SequenceFlow_0ln7eru">
+        <di:waypoint x="2629" y="441" />
+        <di:waypoint x="2731" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2625" y="409" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_19kv4zf_di" bpmnElement="SequenceFlow_19kv4zf">
+        <di:waypoint x="2831" y="441" />
+        <di:waypoint x="2933" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3976" y="595" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1p4ijz3_di" bpmnElement="SequenceFlow_1p4ijz3">
+        <di:waypoint x="3185" y="441" />
+        <di:waypoint x="3287" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="4314" y="595" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0hrswjv_di" bpmnElement="SequenceFlow_0hrswjv">
+        <di:waypoint x="3337" y="441" />
+        <di:waypoint x="3464" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3354" y="410" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1fy5blc_di" bpmnElement="SequenceFlow_1fy5blc">
+        <di:waypoint x="3312" y="416" />
+        <di:waypoint x="3312" y="219" />
+        <di:waypoint x="2427" y="219" />
+        <di:waypoint x="2427" y="401" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3315" y="337" width="43" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_042tt22_di" bpmnElement="SequenceFlow_042tt22">
+        <di:waypoint x="2958" y="466" />
+        <di:waypoint x="2958" y="786" />
+        <di:waypoint x="1307" y="786" />
+        <di:waypoint x="1307" y="481" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2961" y="513" width="43" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0gdfx58_di" bpmnElement="SequenceFlow_0gdfx58">
+        <di:waypoint x="2983" y="441" />
+        <di:waypoint x="3085" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3007" y="414" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1bi7lza_di" bpmnElement="SequenceFlow_1bi7lza">
+        <di:waypoint x="751" y="781" />
+        <di:waypoint x="751" y="851" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2162" y="913.5" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1h7ckog_di" bpmnElement="SequenceFlow_1h7ckog">
+        <di:waypoint x="1105" y="781" />
+        <di:waypoint x="1105" y="967" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2365" y="914.5" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1ii85y3_di" bpmnElement="SequenceFlow_1ii85y3">
+        <di:waypoint x="751" y="876" />
+        <di:waypoint x="549" y="876" />
+        <di:waypoint x="549" y="481" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2082.5" y="1033" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0tcxf89_di" bpmnElement="SequenceFlow_0tcxf89">
+        <di:waypoint x="776" y="876" />
+        <di:waypoint x="3657" y="876" />
+        <di:waypoint x="3657" y="481" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3467" y="1033" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0e38st4_di" bpmnElement="SequenceFlow_0e38st4">
+        <di:waypoint x="1661" y="441" />
+        <di:waypoint x="1720" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1646" y="399" width="68" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0qz7pb4_di" bpmnElement="SequenceFlow_0qz7pb4">
+        <di:waypoint x="1636" y="416" />
+        <di:waypoint x="1636" y="81" />
+        <di:waypoint x="3657" y="81" />
+        <di:waypoint x="3657" y="401" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1559" y="329" width="69" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_17blyfx_di" bpmnElement="SequenceFlow_17blyfx">
+        <di:waypoint x="1921" y="441" />
+        <di:waypoint x="1955" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3062" y="595" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_08od3ei_di" bpmnElement="SequenceFlow_08od3ei">
+        <di:waypoint x="1896" y="416" />
+        <di:waypoint x="1896" y="174" />
+        <di:waypoint x="2427" y="174" />
+        <di:waypoint x="2427" y="401" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1906" y="336" width="51" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0x3d1ed_di" bpmnElement="SequenceFlow_0x3d1ed">
+        <di:waypoint x="3514" y="441" />
+        <di:waypoint x="3607" y="441" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3507" y="409" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0y4nfck_di" bpmnElement="SequenceFlow_0y4nfck">
+        <di:waypoint x="3489" y="466" />
+        <di:waypoint x="3489" y="551" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3500" y="474" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_163tdrh_di" bpmnElement="SequenceFlow_163tdrh">
+        <di:waypoint x="3539" y="591" />
+        <di:waypoint x="3657" y="591" />
+        <di:waypoint x="3657" y="481" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="4663" y="716" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1yygtaq_di" bpmnElement="SequenceFlow_1yygtaq">
+        <di:waypoint x="2604" y="416" />
+        <di:waypoint x="2604" y="343" />
+        <di:waypoint x="2427" y="343" />
+        <di:waypoint x="2427" y="401" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2493" y="322" width="49" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0br3a39_di" bpmnElement="SequenceFlow_0br3a39">
+        <di:waypoint x="1080" y="992" />
+        <di:waypoint x="549" y="992" />
+        <di:waypoint x="549" y="481" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2229" y="1149.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_18o5t1m_di" bpmnElement="SequenceFlow_18o5t1m">
+        <di:waypoint x="1105" y="992" />
+        <di:waypoint x="3657" y="992" />
+        <di:waypoint x="3657" y="481" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="3613.5" y="1149.5" width="0" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0b8hmwm_di" bpmnElement="SequenceFlow_0b8hmwm">
+        <di:waypoint x="3707" y="441" />
+        <di:waypoint x="3847" y="441" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0842fwm_di" bpmnElement="SequenceFlow_0842fwm">
+        <di:waypoint x="928" y="416" />
+        <di:waypoint x="928" y="329" />
+        <di:waypoint x="347" y="329" />
+        <di:waypoint x="347" y="401" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="891" y="362" width="21" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_161sh1e_di" bpmnElement="SequenceFlow_161sh1e">
+        <di:waypoint x="1820" y="441" />
+        <di:waypoint x="1871" y="441" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0dbzkcf_di" bpmnElement="SequenceFlow_0dbzkcf">
+        <di:waypoint x="2188" y="441" />
+        <di:waypoint x="2225" y="441" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1gnfbua_di" bpmnElement="SequenceFlow_1gnfbua">
+        <di:waypoint x="2958" y="416" />
+        <di:waypoint x="2958" y="272" />
+        <di:waypoint x="2427" y="272" />
+        <di:waypoint x="2427" y="401" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="2651" y="254" width="84" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/processes/DCU/DCU_MIN_MINISTER_SIGN_OFF.bpmn
+++ b/src/main/resources/processes/DCU/DCU_MIN_MINISTER_SIGN_OFF.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.2">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="5.10.0">
   <bpmn:process id="DCU_MIN_MINISTER_SIGN_OFF" isExecutable="true">
     <bpmn:startEvent id="DCU_MIN_MINISTER_SIGN_OFF_START" name="Start Stage">
       <bpmn:outgoing>SequenceFlow_0tk7wiu</bpmn:outgoing>
@@ -34,7 +34,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_1m80riu" sourceRef="ExclusiveGateway_1ly97el" targetRef="ExclusiveGateway_1fdgu8r">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:exclusiveGateway id="ExclusiveGateway_1fdgu8r">
+    <bpmn:exclusiveGateway id="ExclusiveGateway_1fdgu8r" default="SequenceFlow_0vvcr6s">
       <bpmn:incoming>SequenceFlow_1m80riu</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_04mk3q2</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0vvcr6s</bpmn:outgoing>
@@ -65,9 +65,7 @@
     <bpmn:sequenceFlow id="SequenceFlow_1i8jp3w" sourceRef="ExclusiveGateway_0vgcsi9" targetRef="ServiceTask_0jszrec">
       <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${valid == true}</bpmn:conditionExpression>
     </bpmn:sequenceFlow>
-    <bpmn:sequenceFlow id="SequenceFlow_0vvcr6s" name="ACCEPT" sourceRef="ExclusiveGateway_1fdgu8r" targetRef="DCU_MIN_MINISTER_SIGN_OFF_END">
-      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${MinisterSignOffDecision == "ACCEPT_WET" ||  MinisterSignOffDecision == "ACCEPT_DIGITAL" }</bpmn:conditionExpression>
-    </bpmn:sequenceFlow>
+    <bpmn:sequenceFlow id="SequenceFlow_0vvcr6s" name="ACCEPT" sourceRef="ExclusiveGateway_1fdgu8r" targetRef="DCU_MIN_MINISTER_SIGN_OFF_END" />
     <bpmn:sequenceFlow id="SequenceFlow_0pmykdc" sourceRef="ServiceTask_0jszrec" targetRef="DCU_MIN_MINISTER_SIGN_OFF_END" />
     <bpmn:serviceTask id="ServiceTask_0jszrec" name="Save Allocation Note" camunda:expression="${bpmnService.updateAllocationNote(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey, execution.getVariable(&#34;CaseNote_MinisterReject&#34;), &#34;REJECT&#34;)}">
       <bpmn:incoming>SequenceFlow_1i8jp3w</bpmn:incoming>
@@ -128,151 +126,6 @@
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="DCU_MIN_MINISTER_SIGN_OFF">
-      <bpmndi:BPMNEdge id="SequenceFlow_0em8g2w_di" bpmnElement="SequenceFlow_0em8g2w">
-        <di:waypoint x="1414" y="320" />
-        <di:waypoint x="1617" y="320" />
-        <di:waypoint x="1617" y="525" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0xt7akb_di" bpmnElement="SequenceFlow_0xt7akb">
-        <di:waypoint x="1165" y="320" />
-        <di:waypoint x="1314" y="320" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1dyxlhg_di" bpmnElement="Flow_1dyxlhg">
-        <di:waypoint x="1140" y="345" />
-        <di:waypoint x="1140" y="380" />
-        <di:waypoint x="955" y="380" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0nddnfk_di" bpmnElement="Flow_0nddnfk">
-        <di:waypoint x="1140" y="185" />
-        <di:waypoint x="1140" y="80" />
-        <di:waypoint x="280" y="80" />
-        <di:waypoint x="280" y="460" />
-        <di:waypoint x="370" y="460" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0t0wrxq_di" bpmnElement="SequenceFlow_0t0wrxq">
-        <di:waypoint x="1140" y="235" />
-        <di:waypoint x="1140" y="295" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0onzll0_di" bpmnElement="SequenceFlow_0onzll0">
-        <di:waypoint x="955" y="210" />
-        <di:waypoint x="1115" y="210" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0i9n1wo_di" bpmnElement="SequenceFlow_0i9n1wo">
-        <di:waypoint x="905" y="340" />
-        <di:waypoint x="905" y="250" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0bde3r9_di" bpmnElement="SequenceFlow_0bde3r9">
-        <di:waypoint x="905" y="518" />
-        <di:waypoint x="905" y="420" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="882" y="466" width="84" height="27" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0fpf85z_di" bpmnElement="SequenceFlow_0fpf85z">
-        <di:waypoint x="1147" y="939" />
-        <di:waypoint x="1147" y="997" />
-        <di:waypoint x="281" y="997" />
-        <di:waypoint x="281" y="460" />
-        <di:waypoint x="371" y="460" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1kpuhf7_di" bpmnElement="SequenceFlow_1kpuhf7">
-        <di:waypoint x="1147" y="889" />
-        <di:waypoint x="1147" y="854" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0pmykdc_di" bpmnElement="SequenceFlow_0pmykdc">
-        <di:waypoint x="1414" y="829" />
-        <di:waypoint x="1617" y="829" />
-        <di:waypoint x="1617" y="561" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1483" y="469.5" width="90" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0vvcr6s_di" bpmnElement="SequenceFlow_0vvcr6s">
-        <di:waypoint x="930" y="543" />
-        <di:waypoint x="1599" y="543" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1243" y="522" width="45" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1i8jp3w_di" bpmnElement="SequenceFlow_1i8jp3w">
-        <di:waypoint x="1172" y="829" />
-        <di:waypoint x="1314" y="829" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1210.5" y="468.5" width="90" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1sj5pfh_di" bpmnElement="SequenceFlow_1sj5pfh">
-        <di:waypoint x="955" y="914" />
-        <di:waypoint x="1122" y="914" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1006" y="552.5" width="90" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1tsg7ba_di" bpmnElement="SequenceFlow_1tsg7ba">
-        <di:waypoint x="905" y="784" />
-        <di:waypoint x="905" y="829" />
-        <di:waypoint x="905" y="829" />
-        <di:waypoint x="905" y="874" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="875" y="482.5" width="90" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0kfy7lp_di" bpmnElement="SequenceFlow_0kfy7lp">
-        <di:waypoint x="1147" y="804" />
-        <di:waypoint x="1147" y="744" />
-        <di:waypoint x="955" y="744" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="1117" y="427.5" width="90" height="13" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_04mk3q2_di" bpmnElement="SequenceFlow_04mk3q2">
-        <di:waypoint x="905" y="568" />
-        <di:waypoint x="905" y="636" />
-        <di:waypoint x="905" y="636" />
-        <di:waypoint x="905" y="704" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="919" y="664" width="43" height="14" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_1m80riu_di" bpmnElement="SequenceFlow_1m80riu">
-        <di:waypoint x="688" y="543" />
-        <di:waypoint x="880" y="543" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="739" y="178" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0rdfff2_di" bpmnElement="SequenceFlow_0rdfff2">
-        <di:waypoint x="663" y="518" />
-        <di:waypoint x="663" y="460" />
-        <di:waypoint x="471" y="460" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="633" y="139" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0cfzgc9_di" bpmnElement="SequenceFlow_0cfzgc9">
-        <di:waypoint x="471" y="623" />
-        <di:waypoint x="663" y="623" />
-        <di:waypoint x="663" y="568" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="522" y="258" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_12nuv9n_di" bpmnElement="SequenceFlow_12nuv9n">
-        <di:waypoint x="421" y="500" />
-        <di:waypoint x="421" y="542" />
-        <di:waypoint x="421" y="542" />
-        <di:waypoint x="421" y="583" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="391" y="192" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="SequenceFlow_0tk7wiu_di" bpmnElement="SequenceFlow_0tk7wiu">
-        <di:waypoint x="209" y="460" />
-        <di:waypoint x="371" y="460" />
-        <bpmndi:BPMNLabel>
-          <dc:Bounds x="245" y="95" width="90" height="20" />
-        </bpmndi:BPMNLabel>
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="DCU_MIN_MINISTER_SIGN_OFF_START">
         <dc:Bounds x="173" y="442" width="36" height="36" />
         <bpmndi:BPMNLabel>
@@ -342,6 +195,151 @@
       <bpmndi:BPMNShape id="Activity_1kllc7w_di" bpmnElement="ServiceTask_1kllc7w">
         <dc:Bounds x="1314" y="280" width="100" height="80" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_0tk7wiu_di" bpmnElement="SequenceFlow_0tk7wiu">
+        <di:waypoint x="209" y="460" />
+        <di:waypoint x="371" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="245" y="95" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_12nuv9n_di" bpmnElement="SequenceFlow_12nuv9n">
+        <di:waypoint x="421" y="500" />
+        <di:waypoint x="421" y="542" />
+        <di:waypoint x="421" y="542" />
+        <di:waypoint x="421" y="583" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="391" y="192" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0cfzgc9_di" bpmnElement="SequenceFlow_0cfzgc9">
+        <di:waypoint x="471" y="623" />
+        <di:waypoint x="663" y="623" />
+        <di:waypoint x="663" y="568" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="522" y="258" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0rdfff2_di" bpmnElement="SequenceFlow_0rdfff2">
+        <di:waypoint x="663" y="518" />
+        <di:waypoint x="663" y="460" />
+        <di:waypoint x="471" y="460" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="633" y="139" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1m80riu_di" bpmnElement="SequenceFlow_1m80riu">
+        <di:waypoint x="688" y="543" />
+        <di:waypoint x="880" y="543" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="739" y="178" width="90" height="20" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_04mk3q2_di" bpmnElement="SequenceFlow_04mk3q2">
+        <di:waypoint x="905" y="568" />
+        <di:waypoint x="905" y="636" />
+        <di:waypoint x="905" y="636" />
+        <di:waypoint x="905" y="704" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="919" y="664" width="43" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0kfy7lp_di" bpmnElement="SequenceFlow_0kfy7lp">
+        <di:waypoint x="1147" y="804" />
+        <di:waypoint x="1147" y="744" />
+        <di:waypoint x="955" y="744" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1117" y="427.5" width="90" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1tsg7ba_di" bpmnElement="SequenceFlow_1tsg7ba">
+        <di:waypoint x="905" y="784" />
+        <di:waypoint x="905" y="829" />
+        <di:waypoint x="905" y="829" />
+        <di:waypoint x="905" y="874" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="875" y="482.5" width="90" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sj5pfh_di" bpmnElement="SequenceFlow_1sj5pfh">
+        <di:waypoint x="955" y="914" />
+        <di:waypoint x="1122" y="914" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1006" y="552.5" width="90" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1i8jp3w_di" bpmnElement="SequenceFlow_1i8jp3w">
+        <di:waypoint x="1172" y="829" />
+        <di:waypoint x="1314" y="829" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1210.5" y="468.5" width="90" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0vvcr6s_di" bpmnElement="SequenceFlow_0vvcr6s">
+        <di:waypoint x="930" y="543" />
+        <di:waypoint x="1599" y="543" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1243" y="522" width="45" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0pmykdc_di" bpmnElement="SequenceFlow_0pmykdc">
+        <di:waypoint x="1414" y="829" />
+        <di:waypoint x="1617" y="829" />
+        <di:waypoint x="1617" y="561" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1483" y="469.5" width="90" height="13" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1kpuhf7_di" bpmnElement="SequenceFlow_1kpuhf7">
+        <di:waypoint x="1147" y="889" />
+        <di:waypoint x="1147" y="854" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0fpf85z_di" bpmnElement="SequenceFlow_0fpf85z">
+        <di:waypoint x="1147" y="939" />
+        <di:waypoint x="1147" y="997" />
+        <di:waypoint x="281" y="997" />
+        <di:waypoint x="281" y="460" />
+        <di:waypoint x="371" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0bde3r9_di" bpmnElement="SequenceFlow_0bde3r9">
+        <di:waypoint x="905" y="518" />
+        <di:waypoint x="905" y="420" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="882" y="466" width="84" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0i9n1wo_di" bpmnElement="SequenceFlow_0i9n1wo">
+        <di:waypoint x="905" y="340" />
+        <di:waypoint x="905" y="250" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0onzll0_di" bpmnElement="SequenceFlow_0onzll0">
+        <di:waypoint x="955" y="210" />
+        <di:waypoint x="1115" y="210" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0t0wrxq_di" bpmnElement="SequenceFlow_0t0wrxq">
+        <di:waypoint x="1140" y="235" />
+        <di:waypoint x="1140" y="295" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0nddnfk_di" bpmnElement="Flow_0nddnfk">
+        <di:waypoint x="1140" y="185" />
+        <di:waypoint x="1140" y="80" />
+        <di:waypoint x="280" y="80" />
+        <di:waypoint x="280" y="460" />
+        <di:waypoint x="370" y="460" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dyxlhg_di" bpmnElement="Flow_1dyxlhg">
+        <di:waypoint x="1140" y="345" />
+        <di:waypoint x="1140" y="380" />
+        <di:waypoint x="955" y="380" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xt7akb_di" bpmnElement="SequenceFlow_0xt7akb">
+        <di:waypoint x="1165" y="320" />
+        <di:waypoint x="1314" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_0em8g2w_di" bpmnElement="SequenceFlow_0em8g2w">
+        <di:waypoint x="1414" y="320" />
+        <di:waypoint x="1617" y="320" />
+        <di:waypoint x="1617" y="525" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/src/main/resources/screens/live/APPROVE_MINISTER_SIGN_OFF.json
+++ b/src/main/resources/screens/live/APPROVE_MINISTER_SIGN_OFF.json
@@ -10,6 +10,10 @@
       "props": {
         "choices": [
           {
+            "label": "Yes (Legacy)",
+            "value": "ACCEPT"
+          },
+          {
             "label": "Yes - with a wet signature",
             "value": "ACCEPT_WET"
           },


### PR DESCRIPTION
HOCS-6199 broke backwards compatibility with existing cases on old live process versions. This change aims to re-add backwards compatibility into this flow and screens to allow these cases to progress.

The caveat is that cases created since the last release will have a small timeframe where `ACCEPT` won't work. As this option is for existing cases, they will be able to reselect the relevant new option.