### PR TITLE
[HOCS-6963]  Add endpoints for process variables

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
 
     implementation 'org.postgresql:postgresql:42.7.2'
 
+    implementation('com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.17.2')
+
     implementation "org.projectlombok:lombok:${lombokVersion}"
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowResource.java
@@ -3,9 +3,7 @@ package uk.gov.digital.ho.hocs.workflow.api;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
 import org.springframework.web.bind.annotation.*;
 import uk.gov.digital.ho.hocs.workflow.BpmnService;
 import uk.gov.digital.ho.hocs.workflow.api.dto.*;
@@ -153,6 +151,24 @@ class WorkflowResource {
     public ResponseEntity closeCase(@PathVariable UUID caseUUID) throws UnsupportedEncodingException {
         ResponseEntity response = workflowService.closeCase(caseUUID);
         return response;
+    }
+
+    @Authorised(accessLevel = AccessLevel.READ)
+    @GetMapping(value = "/case/{caseUUID}/process/variables")
+    public ResponseEntity<GetProcessVariablesResponse> getProcessVariablesForCase(@PathVariable UUID caseUUID) {
+        return ResponseEntity.ok(workflowService.getAllTaskVariablesForCase(caseUUID));
+    }
+
+    @SuppressWarnings("unused") // Case UUID needs to be bound to an argument for @Authorised to work
+    @Authorised(accessLevel = AccessLevel.WRITE)
+    @PutMapping(value = "/case/{caseUUID}/process/{processKey}/variables")
+    public ResponseEntity<GetProcessVariablesResponse> updateProcessVariables(
+        @PathVariable UUID caseUUID,
+        @PathVariable String processKey,
+        @RequestBody Map<String, String> variables
+    ) {
+        workflowService.updateProcessVariables(processKey, variables);
+        return ResponseEntity.ok().build();
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowResource.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowResource.java
@@ -156,18 +156,28 @@ class WorkflowResource {
     @Authorised(accessLevel = AccessLevel.READ)
     @GetMapping(value = "/case/{caseUUID}/process/variables")
     public ResponseEntity<GetProcessVariablesResponse> getProcessVariablesForCase(@PathVariable UUID caseUUID) {
-        return ResponseEntity.ok(workflowService.getAllTaskVariablesForCase(caseUUID));
+        return ResponseEntity.ok(workflowService.getAllProcessVariablesForCase(caseUUID));
     }
 
-    @SuppressWarnings("unused") // Case UUID needs to be bound to an argument for @Authorised to work
-    @Authorised(accessLevel = AccessLevel.WRITE)
-    @PutMapping(value = "/case/{caseUUID}/process/{processKey}/variables")
-    public ResponseEntity<GetProcessVariablesResponse> updateProcessVariables(
+    @Authorised(accessLevel = AccessLevel.READ)
+    @GetMapping(value = "/case/{caseUUID}/process/{processInstanceId}/variables")
+    public ResponseEntity<ProcessVariables> getProcessVariablesForInstance(
+        @SuppressWarnings("unused") // Case UUID needs to be bound to first argument for @Authorised to work
         @PathVariable UUID caseUUID,
-        @PathVariable String processKey,
+        @PathVariable String processInstanceId
+    ) {
+        return ResponseEntity.ok(workflowService.getProcessVariablesForInstance(processInstanceId));
+    }
+
+    @Authorised(accessLevel = AccessLevel.WRITE)
+    @PutMapping(value = "/case/{caseUUID}/process/{processInstanceId}/variables")
+    public ResponseEntity<GetProcessVariablesResponse> updateProcessVariables(
+        @SuppressWarnings("unused") // Case UUID needs to be bound to first argument for @Authorised to work
+        @PathVariable UUID caseUUID,
+        @PathVariable String processInstanceId,
         @RequestBody Map<String, String> variables
     ) {
-        workflowService.updateProcessVariables(processKey, variables);
+        workflowService.updateProcessVariables(processInstanceId, variables);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowService.java
@@ -461,16 +461,20 @@ public class WorkflowService {
             receivedData.get(WorkflowConstants.CHANNEL_COMP_ORIGINATEDFROM), WorkflowConstants.CHANNEL_COMP_WEBFORM);
     }
 
-    public GetProcessVariablesResponse getAllTaskVariablesForCase(UUID caseUUID) {
+    public GetProcessVariablesResponse getAllProcessVariablesForCase(UUID caseUUID) {
         Optional<StageDto> activeStage = caseworkClient.getActiveStage(caseUUID);
-
         UUID stageUUID = activeStage.map(StageDto::getUuid).orElse(null);
+
         List<ProcessVariables> variables = camundaClient.getProcessVariablesForCase(caseUUID, stageUUID);
 
         return new GetProcessVariablesResponse(caseUUID, stageUUID, variables);
     }
 
-    public void updateProcessVariables(String processKey, Map<String, String> variables) {
-        camundaClient.updateProcessVariables(processKey, variables);
+    public ProcessVariables getProcessVariablesForInstance(String processInstanceId) {
+        return camundaClient.getProcessVariablesForInstance(processInstanceId);
+    }
+
+    public void updateProcessVariables(String processInstanceId, Map<String, String> variables) {
+        camundaClient.updateProcessVariables(processInstanceId, variables);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowService.java
@@ -14,6 +14,8 @@ import uk.gov.digital.ho.hocs.workflow.api.dto.FieldDto;
 import uk.gov.digital.ho.hocs.workflow.api.dto.GetCaseDetailsResponse;
 import uk.gov.digital.ho.hocs.workflow.api.dto.GetCaseResponse;
 import uk.gov.digital.ho.hocs.workflow.api.dto.GetStageResponse;
+import uk.gov.digital.ho.hocs.workflow.api.dto.GetProcessVariablesResponse;
+import uk.gov.digital.ho.hocs.workflow.api.dto.ProcessVariables;
 import uk.gov.digital.ho.hocs.workflow.api.dto.SchemaDto;
 import uk.gov.digital.ho.hocs.workflow.client.camundaclient.CamundaClient;
 import uk.gov.digital.ho.hocs.workflow.client.caseworkclient.CaseworkClient;
@@ -35,10 +37,7 @@ import uk.gov.digital.ho.hocs.workflow.domain.model.forms.HocsCaseSchema;
 import uk.gov.digital.ho.hocs.workflow.domain.model.forms.HocsForm;
 import uk.gov.digital.ho.hocs.workflow.domain.model.forms.HocsFormAccordion;
 import uk.gov.digital.ho.hocs.workflow.domain.model.forms.HocsFormField;
-import uk.gov.digital.ho.hocs.workflow.domain.model.forms.HocsFormSecondaryAction;
 import uk.gov.digital.ho.hocs.workflow.domain.model.forms.HocsSchema;
-import uk.gov.digital.ho.hocs.workflow.domain.repositories.ScreenRepository;
-import uk.gov.digital.ho.hocs.workflow.domain.repositories.entity.Schema;
 import uk.gov.digital.ho.hocs.workflow.security.UserPermissionsService;
 import uk.gov.digital.ho.hocs.workflow.util.NoteType;
 import uk.gov.digital.ho.hocs.workflow.util.UuidUtils;
@@ -400,7 +399,7 @@ public class WorkflowService {
         camundaClient.completeTask(stageUUID, values);
     }
 
-    public ResponseEntity closeCase(UUID caseUUID) throws UnsupportedEncodingException {
+    public ResponseEntity<String> closeCase(UUID caseUUID) throws UnsupportedEncodingException {
         GetCaseworkCaseDataResponse caseDetails = caseworkClient.getCase(caseUUID);
 
         //Get stage uuid from casework
@@ -462,4 +461,16 @@ public class WorkflowService {
             receivedData.get(WorkflowConstants.CHANNEL_COMP_ORIGINATEDFROM), WorkflowConstants.CHANNEL_COMP_WEBFORM);
     }
 
+    public GetProcessVariablesResponse getAllTaskVariablesForCase(UUID caseUUID) {
+        Optional<StageDto> activeStage = caseworkClient.getActiveStage(caseUUID);
+
+        UUID stageUUID = activeStage.map(StageDto::getUuid).orElse(null);
+        List<ProcessVariables> variables = camundaClient.getProcessVariablesForCase(caseUUID, stageUUID);
+
+        return new GetProcessVariablesResponse(caseUUID, stageUUID, variables);
+    }
+
+    public void updateProcessVariables(String processKey, Map<String, String> variables) {
+        camundaClient.updateProcessVariables(processKey, variables);
+    }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/api/dto/GetProcessVariablesResponse.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/api/dto/GetProcessVariablesResponse.java
@@ -1,0 +1,11 @@
+package uk.gov.digital.ho.hocs.workflow.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.UUID;
+
+public record GetProcessVariablesResponse(
+    @JsonProperty("caseUUID") UUID caseUUID,
+    @JsonProperty("stageUUID") UUID stageUUID,
+    @JsonProperty("processes") List<ProcessVariables> processes) {}

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/api/dto/ProcessVariables.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/api/dto/ProcessVariables.java
@@ -1,0 +1,12 @@
+package uk.gov.digital.ho.hocs.workflow.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.lang.Nullable;
+
+import java.util.Map;
+import java.util.Optional;
+
+public record ProcessVariables(@JsonProperty("processKey") String processKey,
+                               @JsonProperty("businessKey") String businessKey,
+                               @JsonProperty("rootProcessKey") @Nullable String rootProcessKey,
+                               @JsonProperty("variables") Map<String, Optional<String>> variables) {}

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/api/dto/ProcessVariables.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/api/dto/ProcessVariables.java
@@ -6,7 +6,7 @@ import org.springframework.lang.Nullable;
 import java.util.Map;
 import java.util.Optional;
 
-public record ProcessVariables(@JsonProperty("processKey") String processKey,
+public record ProcessVariables(@JsonProperty("processInstanceId") String processInstanceId,
                                @JsonProperty("businessKey") String businessKey,
-                               @JsonProperty("rootProcessKey") @Nullable String rootProcessKey,
+                               @JsonProperty("rootProcessInstanceId") @Nullable String rootProcessInstanceId,
                                @JsonProperty("variables") Map<String, Optional<String>> variables) {}

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/application/SpringConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/application/SpringConfiguration.java
@@ -3,6 +3,7 @@ package uk.gov.digital.ho.hocs.workflow.application;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
 import java.time.Clock;
@@ -38,6 +39,7 @@ public class SpringConfiguration implements WebMvcConfigurer {
         ObjectMapper m = new ObjectMapper();
         m.setDateFormat(new SimpleDateFormat("yyyy-MM-dd"));
         m.registerModule(new JavaTimeModule());
+        m.registerModule(new Jdk8Module());
         m.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
         m.enable(SerializationFeature.INDENT_OUTPUT);
         m.enable(DeserializationFeature.ACCEPT_EMPTY_STRING_AS_NULL_OBJECT);

--- a/src/main/java/uk/gov/digital/ho/hocs/workflow/client/camundaclient/CamundaClient.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/workflow/client/camundaclient/CamundaClient.java
@@ -182,6 +182,11 @@ public class CamundaClient {
                      .toList();
     }
 
+    public ProcessVariables getProcessVariablesForInstance(String processInstanceId) {
+        ProcessInstance instance = runtimeService.createProcessInstanceQuery().processInstanceId(processInstanceId).singleResult();
+        return getProcessVariables(instance);
+    }
+
     private Stream<ProcessInstance> streamProcessInstancesForBusinessKey(String key) {
         return runtimeService
             .createProcessInstanceQuery()
@@ -202,11 +207,12 @@ public class CamundaClient {
                     Collectors.toMap(
                         Map.Entry::getKey,
                         entry -> Optional.ofNullable(entry.getValue()).map(Objects::toString)
-                    ))
+                    )
+                )
         );
     }
 
-    public void updateProcessVariables(String processKey, Map<String, ?> processVariables) {
-        runtimeService.setVariables(processKey, processVariables);
+    public void updateProcessVariables(String processInstanceId, Map<String, ?> processVariables) {
+        runtimeService.setVariables(processInstanceId, processVariables);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowResourceWebMvcTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowResourceWebMvcTest.java
@@ -1,0 +1,110 @@
+package uk.gov.digital.ho.hocs.workflow.api;
+
+
+import org.apache.http.entity.ContentType;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.digital.ho.hocs.workflow.BpmnService;
+import uk.gov.digital.ho.hocs.workflow.api.dto.GetProcessVariablesResponse;
+import uk.gov.digital.ho.hocs.workflow.api.dto.ProcessVariables;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@WebMvcTest(WorkflowResource.class)
+@RunWith(SpringRunner.class)
+public class WorkflowResourceWebMvcTest {
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private WorkflowService workflowService;
+    @MockBean
+    private BpmnService bpmnService;
+
+    @Test
+    public void requestingProcessVariables_returnsTheExpectedJSON() throws Exception {
+        UUID caseUUID = UUID.randomUUID();
+
+        when(workflowService.getAllTaskVariablesForCase(caseUUID))
+            .thenReturn(buildExampleGetProcessVariablesResponse(caseUUID));
+
+        mockMvc
+            .perform(get("/case/%s/process/variables".formatted(caseUUID.toString())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.caseUUID", is(caseUUID.toString())))
+            .andExpect(jsonPath("$.stageUUID", nullValue()))
+            .andExpect(jsonPath("$.processes[0].processKey", is("process-key")))
+            .andExpect(jsonPath("$.processes[0].rootProcessKey", is("root-process-key")))
+            .andExpect(jsonPath("$.processes[0].businessKey", is(caseUUID.toString())))
+            .andExpect(jsonPath("$.processes[0].variables.present", is("String")))
+            .andExpect(jsonPath("$.processes[0].variables.empty", nullValue()));
+    }
+
+    private static @NotNull GetProcessVariablesResponse buildExampleGetProcessVariablesResponse(UUID caseUUID) {
+        return new GetProcessVariablesResponse(
+            caseUUID,
+            null,
+            List.of(
+                new ProcessVariables(
+                    "process-key",
+                    caseUUID.toString(),
+                    "root-process-key",
+                    Map.of(
+                        "present", Optional.of("String"),
+                        "empty", Optional.empty()
+                    )
+                )
+            )
+        );
+    }
+
+    @Test
+    public void puttingProcessVariables_updatesTheVariablesForThatProcess() throws Exception {
+        UUID caseUUID = UUID.randomUUID();
+        String processKey = "process-key";
+
+        String jsonVariables = """
+            {
+              "present": "String",
+              "empty": null
+            }""";
+
+        Map<String, String> expectedVariables = new HashMap<>() {
+            {
+                put("present", "String");
+                put("empty", null);
+            }
+        };
+
+        mockMvc
+            .perform(
+                put("/case/%s/process/%s/variables".formatted(caseUUID.toString(), processKey))
+                    .contentType(ContentType.APPLICATION_JSON.toString())
+                    .content(jsonVariables)
+            )
+            .andExpect(status().isOk());
+
+        verify(workflowService).updateProcessVariables(eq(processKey), eq(expectedVariables));
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/api/WorkflowServiceTest.java
@@ -976,7 +976,7 @@ public class WorkflowServiceTest {
     }
 
     @Test
-    public void getAllTaskVariablesForCase_mapsCamundaDataToTheExpectedDTO() {
+    public void getAllProcessVariablesForCase_mapsCamundaDataToTheExpectedDTO() {
         // given
         UUID caseUUID = UUID.randomUUID();
         UUID stageUUID = UUID.randomUUID();
@@ -993,7 +993,7 @@ public class WorkflowServiceTest {
         when(camundaClient.getProcessVariablesForCase(caseUUID, stageUUID)).thenReturn(processVariables);
 
         // when
-        GetProcessVariablesResponse dto = workflowService.getAllTaskVariablesForCase(caseUUID);
+        GetProcessVariablesResponse dto = workflowService.getAllProcessVariablesForCase(caseUUID);
 
         //then
         assertThat(dto.caseUUID()).isEqualTo(caseUUID);
@@ -1002,7 +1002,7 @@ public class WorkflowServiceTest {
     }
 
     @Test
-    public void getAllTaskVariablesForCase_mapsCamundaDataToTheExpectedDTO_whenThereIsNoActiveStage() {
+    public void getAllProcessVariablesForCase_mapsCamundaDataToTheExpectedDTO_whenThereIsNoActiveStage() {
         // given
         UUID caseUUID = UUID.randomUUID();
 
@@ -1012,7 +1012,7 @@ public class WorkflowServiceTest {
         when(camundaClient.getProcessVariablesForCase(caseUUID, null)).thenReturn(processVariables);
 
         // when
-        GetProcessVariablesResponse dto = workflowService.getAllTaskVariablesForCase(caseUUID);
+        GetProcessVariablesResponse dto = workflowService.getAllProcessVariablesForCase(caseUUID);
 
         //then
         assertThat(dto.caseUUID()).isEqualTo(caseUUID);
@@ -1021,8 +1021,19 @@ public class WorkflowServiceTest {
     }
 
     @Test
+    public void getVariablesForProcessInstanceId_passesRequestAndResponseDirectly() {
+        String processInstanceId = "process-instance-id";
+        ProcessVariables processVariables = mock(ProcessVariables.class);
+        when(camundaClient.getProcessVariablesForInstance(processInstanceId)).thenReturn(processVariables);
+
+        ProcessVariables result = workflowService.getProcessVariablesForInstance(processInstanceId);
+
+        assertThat(result).isEqualTo(processVariables);
+    }
+
+    @Test
     public void updateProcessVariables_passesTheArgumentsToCamundaClient() {
-        String processKey = "process-key";
+        String processInstanceId = "process-instance-id";
         Map<String, String> variables = new HashMap<>(){
             {
                 put("present", "String");
@@ -1030,9 +1041,9 @@ public class WorkflowServiceTest {
             }
         };
 
-        workflowService.updateProcessVariables(processKey, variables);
+        workflowService.updateProcessVariables(processInstanceId, variables);
 
-        verify(camundaClient).updateProcessVariables(eq(processKey), eq(variables));
+        verify(camundaClient).updateProcessVariables(eq(processInstanceId), eq(variables));
     }
 
 }


### PR DESCRIPTION
- Query variables in all processes associated with a case
- Query variables for a specific process
- Update variables for a specific process
- Adds `com.fasterxml.jackson.datatype:jackson-datatype-jdk` for handling (de)serialization of Optional

- - - -

The intent for this PR is to provide some http endpoints that can be used via hocs-toolbox to inspect and correct variables for a case. The usecase is to allow TO cases that have lost their teamUUID in [HOCS-6963](https://collaboration.homeoffice.gov.uk/jira/browse/HOCS-6963) to be investigated and corrected.

In my local environment I have been able to use this to break a case in a similar manner as the TO cases with the issue, see the same error, and update the ID to the expected value and see that allow the case to be progressed normally again. 

https://collaboration.homeoffice.gov.uk/jira/browse/HOCS-6963