### PR TITLE
end-to-end-target-on-home-sec-cases-from-10-to-20

### DIFF
--- a/src/main/resources/processes/DCU/DCU_MIN_MARKUP.bpmn
+++ b/src/main/resources/processes/DCU/DCU_MIN_MARKUP.bpmn
@@ -331,7 +331,7 @@
       <bpmn:outgoing>SequenceFlow_1tvrupz</bpmn:outgoing>
       <bpmn:outgoing>SequenceFlow_0h5w2hd</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="UPDATE_HOME_SEC_DEADLINE" name="Update Home Sec Deadline" camunda:expression="${bpmnService.updateDeadlineDays(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,10)}">
+    <bpmn:serviceTask id="UPDATE_HOME_SEC_DEADLINE" name="Update Home Sec Deadline" camunda:expression="${bpmnService.updateDeadlineDays(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,20)}">
       <bpmn:incoming>SequenceFlow_1tvrupz</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_19y51wn</bpmn:outgoing>
     </bpmn:serviceTask>
@@ -348,7 +348,7 @@
     </bpmn:serviceTask>
     <bpmn:sequenceFlow id="SequenceFlow_0qwnolp" sourceRef="UPDATE_VALUE" targetRef="ExclusiveGateway_16e8bat" />
     <bpmn:sequenceFlow id="SequenceFlow_10xa109" sourceRef="UPDATE_HOME_SEC_STAGES_DEADLINES" targetRef="DCU_MIN_MARKUP_END" />
-    <bpmn:serviceTask id="UPDATE_HOME_SEC_STAGES_DEADLINES" name="Update Stage Deadlines for Home Secretary Teams" camunda:expression="${bpmnService.updateDeadlineForStages(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;DCU_MIN_INITIAL_DRAFT&#34;,7,&#34;DCU_MIN_QA_RESPONSE&#34;,7,&#34;DCU_MIN_PRIVATE_OFFICE&#34;,9,&#34;DCU_MIN_MINISTER_SIGN_OFF&#34;,9,&#34;DCU_MIN_TRANSFER_CONFIRMATION&#34;,10,&#34;DCU_MIN_NO_REPLY_NEEDED_CONFIRMATION&#34;,10,&#34;DCU_MIN_DISPATCH&#34;,10,&#34;DCU_MIN_COPY_NUMBER_TEN&#34;,10)}">
+    <bpmn:serviceTask id="UPDATE_HOME_SEC_STAGES_DEADLINES" name="Update Stage Deadlines for Home Secretary Teams" camunda:expression="${bpmnService.updateDeadlineForStages(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;DCU_MIN_INITIAL_DRAFT&#34;,10,&#34;DCU_MIN_QA_RESPONSE&#34;,10,&#34;DCU_MIN_PRIVATE_OFFICE&#34;,19,&#34;DCU_MIN_MINISTER_SIGN_OFF&#34;,19,&#34;DCU_MIN_TRANSFER_CONFIRMATION&#34;,20,&#34;DCU_MIN_NO_REPLY_NEEDED_CONFIRMATION&#34;,20,&#34;DCU_MIN_DISPATCH&#34;,20,&#34;DCU_MIN_COPY_NUMBER_TEN&#34;,20)}">
       <bpmn:incoming>SequenceFlow_19y51wn</bpmn:incoming>
       <bpmn:outgoing>SequenceFlow_10xa109</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/src/main/resources/processes/DCU/DCU_MIN_PRIVATE_OFFICE.bpmn
+++ b/src/main/resources/processes/DCU/DCU_MIN_PRIVATE_OFFICE.bpmn
@@ -139,11 +139,11 @@
       <bpmn:outgoing>Flow_089ofpi</bpmn:outgoing>
       <bpmn:outgoing>Flow_1p3dy02</bpmn:outgoing>
     </bpmn:exclusiveGateway>
-    <bpmn:serviceTask id="UPDATE_HOME_SEC_DEADLINE" name="Update Home Sec Deadline" camunda:expression="${bpmnService.updateDeadlineDays(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,10)}">
+    <bpmn:serviceTask id="UPDATE_HOME_SEC_DEADLINE" name="Update Home Sec Deadline" camunda:expression="${bpmnService.updateDeadlineDays(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,20)}">
       <bpmn:incoming>Flow_089ofpi</bpmn:incoming>
       <bpmn:outgoing>Flow_1lu0iiz</bpmn:outgoing>
     </bpmn:serviceTask>
-    <bpmn:serviceTask id="UPDATE_HOME_SEC_STAGES_DEADLINES" name="Update Stage Deadlines for Home Secretary Teams" camunda:expression="${bpmnService.updateDeadlineForStages(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;DCU_MIN_INITIAL_DRAFT&#34;,7,&#34;DCU_MIN_QA_RESPONSE&#34;,7,&#34;DCU_MIN_PRIVATE_OFFICE&#34;,9,&#34;DCU_MIN_MINISTER_SIGN_OFF&#34;,9,&#34;DCU_MIN_TRANSFER_CONFIRMATION&#34;,10,&#34;DCU_MIN_NO_REPLY_NEEDED_CONFIRMATION&#34;,10,&#34;DCU_MIN_DISPATCH&#34;,10,&#34;DCU_MIN_COPY_NUMBER_TEN&#34;,10)}">
+    <bpmn:serviceTask id="UPDATE_HOME_SEC_STAGES_DEADLINES" name="Update Stage Deadlines for Home Secretary Teams" camunda:expression="${bpmnService.updateDeadlineForStages(execution.getVariable(&#34;CaseUUID&#34;),execution.processBusinessKey,&#34;DCU_MIN_INITIAL_DRAFT&#34;,10,&#34;DCU_MIN_QA_RESPONSE&#34;,10,&#34;DCU_MIN_PRIVATE_OFFICE&#34;,19,&#34;DCU_MIN_MINISTER_SIGN_OFF&#34;,19,&#34;DCU_MIN_TRANSFER_CONFIRMATION&#34;,20,&#34;DCU_MIN_NO_REPLY_NEEDED_CONFIRMATION&#34;,20,&#34;DCU_MIN_DISPATCH&#34;,20,&#34;DCU_MIN_COPY_NUMBER_TEN&#34;,20)}">
       <bpmn:incoming>Flow_1lu0iiz</bpmn:incoming>
       <bpmn:outgoing>Flow_1fugzjx</bpmn:outgoing>
     </bpmn:serviceTask>

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/dcu/DCU_MIN_Markup.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/dcu/DCU_MIN_Markup.java
@@ -347,15 +347,15 @@ public class DCU_MIN_Markup extends DCU_MIN_DTEN_Markup_Common {
     private void verifyHomeSecOfficeDeadlinesSet() {
         verify(dcuMinMarkup).hasCompleted(UPDATE_HOME_SEC_DEADLINE);
 
-        // Case deadline of 10 days
-        verify(bpmnService).updateDeadlineDays(eq(CASE_UUID), any(), eq("10"));
+        // Case deadline of 20 days
+        verify(bpmnService).updateDeadlineDays(eq(CASE_UUID), any(), eq("20"));
         verify(dcuMinMarkup).hasCompleted(UPDATE_HOME_SEC_STAGES_DEADLINES);
 
         // Case stage deadlines
-        verify(bpmnService).updateDeadlineForStages(eq(CASE_UUID), any(), eq("DCU_MIN_INITIAL_DRAFT"), eq("7"),
-            eq("DCU_MIN_QA_RESPONSE"), eq("7"), eq("DCU_MIN_PRIVATE_OFFICE"), eq("9"), eq("DCU_MIN_MINISTER_SIGN_OFF"),
-            eq("9"), eq("DCU_MIN_TRANSFER_CONFIRMATION"), eq("10"), eq("DCU_MIN_NO_REPLY_NEEDED_CONFIRMATION"),
-            eq("10"), eq("DCU_MIN_DISPATCH"), eq("10"), eq("DCU_MIN_COPY_NUMBER_TEN"), eq("10"));
+        verify(bpmnService).updateDeadlineForStages(eq(CASE_UUID), any(), eq("DCU_MIN_INITIAL_DRAFT"), eq("10"),
+            eq("DCU_MIN_QA_RESPONSE"), eq("10"), eq("DCU_MIN_PRIVATE_OFFICE"), eq("19"), eq("DCU_MIN_MINISTER_SIGN_OFF"),
+            eq("19"), eq("DCU_MIN_TRANSFER_CONFIRMATION"), eq("20"), eq("DCU_MIN_NO_REPLY_NEEDED_CONFIRMATION"),
+            eq("20"), eq("DCU_MIN_DISPATCH"), eq("20"), eq("DCU_MIN_COPY_NUMBER_TEN"), eq("20"));
     }
 
     private void verifyMinisterOrDirectorOfficeDeadlinesSet() {

--- a/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/dcu/DCU_MIN_PRIVATE_OFFICE.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/workflow/processes/dcu/DCU_MIN_PRIVATE_OFFICE.java
@@ -185,15 +185,15 @@ public class DCU_MIN_PRIVATE_OFFICE {
     private void verifyHomeSecOfficeDeadlinesSet() {
         verify(processScenario).hasCompleted(UPDATE_HOME_SEC_DEADLINE);
 
-        // Case deadline of 10 days
-        verify(bpmnService).updateDeadlineDays(eq(CASE_UUID), any(), eq("10"));
+        // Case deadline of 20 days
+        verify(bpmnService).updateDeadlineDays(eq(CASE_UUID), any(), eq("20"));
         verify(processScenario).hasCompleted(UPDATE_HOME_SEC_STAGES_DEADLINES);
 
         // Case stage deadlines
-        verify(bpmnService).updateDeadlineForStages(eq(CASE_UUID), any(), eq("DCU_MIN_INITIAL_DRAFT"), eq("7"),
-            eq("DCU_MIN_QA_RESPONSE"), eq("7"), eq("DCU_MIN_PRIVATE_OFFICE"), eq("9"), eq("DCU_MIN_MINISTER_SIGN_OFF"),
-            eq("9"), eq("DCU_MIN_TRANSFER_CONFIRMATION"), eq("10"), eq("DCU_MIN_NO_REPLY_NEEDED_CONFIRMATION"),
-            eq("10"), eq("DCU_MIN_DISPATCH"), eq("10"), eq("DCU_MIN_COPY_NUMBER_TEN"), eq("10"));
+        verify(bpmnService).updateDeadlineForStages(eq(CASE_UUID), any(), eq("DCU_MIN_INITIAL_DRAFT"), eq("10"),
+            eq("DCU_MIN_QA_RESPONSE"), eq("10"), eq("DCU_MIN_PRIVATE_OFFICE"), eq("19"), eq("DCU_MIN_MINISTER_SIGN_OFF"),
+            eq("19"), eq("DCU_MIN_TRANSFER_CONFIRMATION"), eq("20"), eq("DCU_MIN_NO_REPLY_NEEDED_CONFIRMATION"),
+            eq("20"), eq("DCU_MIN_DISPATCH"), eq("20"), eq("DCU_MIN_COPY_NUMBER_TEN"), eq("20"));
     }
 
     private void verifyMinisterOrDirectorOfficeDeadlinesSet() {


### PR DESCRIPTION
That BPMN task is not just metadata; it actively **overrides stage deadlines** in casework via `bpmnService.updateDeadlineForStages(...)`.  
So after switching Home Sec case deadline to 20 days (`updateDeadlineDays(...,20)`), keeping old stage values (`7/9/10`) would cause mismatches.

Why the change was needed:
- If case deadline = 20 but stage deadlines still end at 10, users would see stage targets inconsistent with the new E2E policy.
- Workflow behavior/tests in `DCU_MIN_Markup` and `DCU_MIN_PRIVATE_OFFICE` assert both case and stage deadline updates, so they must align.
- Existing “other Private Office” path already used a 20-day profile with stage milestones `10,10,19,19,20,20,20,20`; reusing that keeps behavior consistent across PO types.

Why those exact values:
- `DCU_MIN_INITIAL_DRAFT`, `DCU_MIN_QA_RESPONSE` → `10` (midpoint milestones)
- `DCU_MIN_PRIVATE_OFFICE`, `DCU_MIN_MINISTER_SIGN_OFF` → `19` (warning/near-deadline stages)
- final stages (`TRANSFER_CONFIRMATION`, `NO_REPLY_NEEDED_CONFIRMATION`, `DISPATCH`, `COPY_NUMBER_TEN`) → `20` (full E2E target)

So in short: this edit was required because changing only the top-level case SLA would have left Home Sec stage SLAs on the old 10-day schedule, creating contradictory deadlines.